### PR TITLE
Externalize storable decoding 

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -33,6 +33,7 @@ func TestAppendAndGet(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -72,6 +73,7 @@ func TestSetAndGet(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -119,6 +121,7 @@ func TestInsertAndGet(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -155,6 +158,7 @@ func TestInsertAndGet(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -191,6 +195,7 @@ func TestInsertAndGet(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -238,6 +243,7 @@ func TestRemove(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -282,6 +288,7 @@ func TestRemove(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -326,6 +333,7 @@ func TestRemove(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -378,6 +386,7 @@ func TestSplit(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -409,6 +418,7 @@ func TestSplit(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -453,6 +463,7 @@ func TestIterate(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -485,6 +496,7 @@ func TestIterate(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -522,6 +534,7 @@ func TestIterate(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -559,6 +572,7 @@ func TestIterate(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -592,6 +606,7 @@ func TestIterate(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -625,6 +640,7 @@ func TestIterate(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -669,6 +685,7 @@ func TestDeepCopy(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -715,6 +732,7 @@ func TestConstRootStorageID(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -755,6 +773,7 @@ func TestSetRandomValue(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -816,6 +835,7 @@ func TestInsertRandomValue(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -857,6 +877,7 @@ func TestInsertRandomValue(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -898,6 +919,7 @@ func TestInsertRandomValue(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		array, err := NewArray(storage)
 		require.NoError(t, err)
@@ -948,6 +970,7 @@ func TestRemoveRandomElement(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -1014,6 +1037,7 @@ func TestRandomAppendSetInsertRemove(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -1131,6 +1155,7 @@ func TestRandomAppendSetInsertRemoveUint8(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -1256,6 +1281,7 @@ func TestRandomAppendSetInsertRemoveMixedTypes(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 
 	storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)
@@ -1372,6 +1398,7 @@ func TestNestedArray(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		nestedArrays := make([]*Array, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
@@ -1414,6 +1441,7 @@ func TestNestedArray(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 
 		storage := NewPersistentSlabStorage(baseStorage, WithNoAutoCommit())
+		storage.DecodeStorable = decodeStorable
 
 		nestedArrays := make([]*Array, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
@@ -1457,6 +1485,8 @@ func TestEncode(t *testing.T) {
 
 	// Create and populate array in memory
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
+
 	array, err := NewArray(storage)
 	require.NoError(t, err)
 
@@ -1580,6 +1610,8 @@ func TestDecodeEncode(t *testing.T) {
 
 	// Decode serialized slabs and store them in storage
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
+
 	err := storage.Load(data)
 	require.NoError(t, err)
 
@@ -1634,6 +1666,8 @@ func TestDecodeEncodeRandomData(t *testing.T) {
 	}()
 
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
+
 	array, err := NewArray(storage)
 	require.NoError(t, err)
 
@@ -1674,6 +1708,8 @@ func TestDecodeEncodeRandomData(t *testing.T) {
 
 	// Decode data to new storage
 	storage2 := NewBasicSlabStorage()
+	storage2.DecodeStorable = decodeStorable
+
 	err = storage2.Load(m1)
 	require.NoError(t, err)
 
@@ -1694,6 +1730,7 @@ func TestEmptyArray(t *testing.T) {
 	t.Parallel()
 
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
 
 	array, err := NewArray(storage)
 	require.NoError(t, err)

--- a/basicarray.go
+++ b/basicarray.go
@@ -70,7 +70,7 @@ func NewBasicArrayDataSlab(storage SlabStorage) *BasicArrayDataSlab {
 	}
 }
 
-func newBasicArrayDataSlabFromData(id StorageID, data []byte) (*BasicArrayDataSlab, error) {
+func newBasicArrayDataSlabFromData(id StorageID, data []byte, decodeStorable StorableDecoder) (*BasicArrayDataSlab, error) {
 	if len(data) == 0 {
 		return nil, errors.New("data is too short for basic array")
 	}
@@ -121,10 +121,10 @@ func (a *BasicArrayDataSlab) Encode(enc *Encoder) error {
 	}
 
 	// Encode CBOR array size for 9 bytes
-	enc.scratch[0] = 0x80 | 27
-	binary.BigEndian.PutUint64(enc.scratch[1:], uint64(len(a.elements)))
+	enc.Scratch[0] = 0x80 | 27
+	binary.BigEndian.PutUint64(enc.Scratch[1:], uint64(len(a.elements)))
 
-	_, err = enc.Write(enc.scratch[:9])
+	_, err = enc.Write(enc.Scratch[:9])
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (a *BasicArrayDataSlab) Encode(enc *Encoder) error {
 			return err
 		}
 	}
-	err = enc.cbor.Flush()
+	err = enc.CBOR.Flush()
 	if err != nil {
 		return err
 	}

--- a/basicarray_test.go
+++ b/basicarray_test.go
@@ -21,6 +21,7 @@ func TestBasicArrayAppendAndGet(t *testing.T) {
 	//storage := NewPersistentSlabStorage(baseStorage)
 
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
 
 	array := NewBasicArray(storage)
 
@@ -48,6 +49,7 @@ func TestBasicArraySetAndGet(t *testing.T) {
 	//storage := NewPersistentSlabStorage(baseStorage)
 
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
 
 	array := NewBasicArray(storage)
 
@@ -81,6 +83,7 @@ func TestBasicArrayInsertAndGet(t *testing.T) {
 		//storage := NewPersistentSlabStorage(baseStorage)
 
 		storage := NewBasicSlabStorage()
+		storage.DecodeStorable = decodeStorable
 
 		array := NewBasicArray(storage)
 
@@ -108,6 +111,7 @@ func TestBasicArrayInsertAndGet(t *testing.T) {
 		//storage := NewPersistentSlabStorage(baseStorage)
 
 		storage := NewBasicSlabStorage()
+		storage.DecodeStorable = decodeStorable
 
 		array := NewBasicArray(storage)
 
@@ -135,6 +139,7 @@ func TestBasicArrayInsertAndGet(t *testing.T) {
 		//storage := NewPersistentSlabStorage(baseStorage)
 
 		storage := NewBasicSlabStorage()
+		storage.DecodeStorable = decodeStorable
 
 		array := NewBasicArray(storage)
 
@@ -170,6 +175,7 @@ func TestBasicArrayRemove(t *testing.T) {
 		//storage := NewPersistentSlabStorage(baseStorage)
 
 		storage := NewBasicSlabStorage()
+		storage.DecodeStorable = decodeStorable
 
 		array := NewBasicArray(storage)
 
@@ -203,6 +209,7 @@ func TestBasicArrayRemove(t *testing.T) {
 		//storage := NewPersistentSlabStorage(baseStorage)
 
 		storage := NewBasicSlabStorage()
+		storage.DecodeStorable = decodeStorable
 
 		array := NewBasicArray(storage)
 
@@ -236,6 +243,7 @@ func TestBasicArrayRemove(t *testing.T) {
 		//storage := NewPersistentSlabStorage(baseStorage)
 
 		storage := NewBasicSlabStorage()
+		storage.DecodeStorable = decodeStorable
 
 		array := NewBasicArray(storage)
 
@@ -293,6 +301,7 @@ func TestBasicArrayRandomAppendSetInsertRemoveMixedTypes(t *testing.T) {
 	//storage := NewPersistentSlabStorage(baseStorage)
 
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
 
 	array := NewBasicArray(storage)
 
@@ -381,6 +390,8 @@ func TestBasicArrayDecodeEncodeRandomData(t *testing.T) {
 	)
 
 	storage := NewBasicSlabStorage()
+	storage.DecodeStorable = decodeStorable
+
 	array := NewBasicArray(storage)
 
 	const arraySize = 256 * 256
@@ -416,6 +427,8 @@ func TestBasicArrayDecodeEncodeRandomData(t *testing.T) {
 
 	// Decode data to new storage
 	storage2 := NewBasicSlabStorage()
+	storage2.DecodeStorable = decodeStorable
+
 	err = storage2.Load(m1)
 	require.NoError(t, err)
 

--- a/cbor_bench_test.go
+++ b/cbor_bench_test.go
@@ -59,14 +59,14 @@ func benchmarkEncodeCBORArray(b *testing.B, values []Storable) {
 		var buf bytes.Buffer
 		enc := newEncoder(&buf)
 
-		enc.scratch[0] = 0x80 | 27
-		binary.BigEndian.PutUint64(enc.scratch[1:], uint64(len(values)))
-		enc.Write(enc.scratch[:9])
+		enc.Scratch[0] = 0x80 | 27
+		binary.BigEndian.PutUint64(enc.Scratch[1:], uint64(len(values)))
+		enc.Write(enc.Scratch[:9])
 
 		for _, v := range values {
 			v.Encode(enc)
 		}
-		enc.cbor.Flush()
+		enc.CBOR.Flush()
 	}
 }
 
@@ -145,13 +145,13 @@ func encode(values []Storable) []byte {
 	var buf bytes.Buffer
 	enc := newEncoder(&buf)
 
-	enc.scratch[0] = 0x80 | 27
-	binary.BigEndian.PutUint64(enc.scratch[1:], uint64(len(values)))
-	enc.Write(enc.scratch[:9])
+	enc.Scratch[0] = 0x80 | 27
+	binary.BigEndian.PutUint64(enc.Scratch[1:], uint64(len(values)))
+	enc.Write(enc.Scratch[:9])
 
 	for _, v := range values {
 		v.Encode(enc)
 	}
-	enc.cbor.Flush()
+	enc.CBOR.Flush()
 	return buf.Bytes()
 }

--- a/encode.go
+++ b/encode.go
@@ -16,18 +16,20 @@ import (
 // Encoder writes atree slabs to io.Writer.
 type Encoder struct {
 	io.Writer
-	cbor    *cbor.StreamEncoder
-	scratch [32]byte
+	CBOR    *cbor.StreamEncoder
+	Scratch [32]byte
 }
 
 func newEncoder(w io.Writer) *Encoder {
 	return &Encoder{
 		Writer: w,
-		cbor:   cbor.NewStreamEncoder(w),
+		CBOR:   cbor.NewStreamEncoder(w),
 	}
 }
 
-func decodeSlab(id StorageID, data []byte) (Slab, error) {
+type StorableDecoder func (*cbor.StreamDecoder) (Storable, error)
+
+func decodeSlab(id StorageID, data []byte, decodeStorable StorableDecoder) (Slab, error) {
 	if len(data) < 2 {
 		return nil, errors.New("data is too short")
 	}
@@ -35,12 +37,12 @@ func decodeSlab(id StorageID, data []byte) (Slab, error) {
 	if flag&flagArray != 0 {
 
 		if flag&flagMetaDataSlab != 0 {
-			return newArrayMetaDataSlabFromData(id, data)
+			return newArrayMetaDataSlabFromData(id, data, decodeStorable)
 		}
-		return newArrayDataSlabFromData(id, data)
+		return newArrayDataSlabFromData(id, data, decodeStorable)
 
 	} else if flag&flagBasicArray != 0 {
-		return newBasicArrayDataSlabFromData(id, data)
+		return newBasicArrayDataSlabFromData(id, data, decodeStorable)
 	} else if flag&flagStorable != 0 {
 		const versionAndFlagSize = 2
 		cborDec := NewByteStreamDecoder(data[versionAndFlagSize:])
@@ -53,64 +55,9 @@ func decodeSlab(id StorageID, data []byte) (Slab, error) {
 	return nil, fmt.Errorf("data has invalid flag %x", flag)
 }
 
-func decodeStorable(dec *cbor.StreamDecoder) (Storable, error) {
-	tagNumber, err := dec.DecodeTagNumber()
-	if err != nil {
-		return nil, err
-	}
-
-	switch tagNumber {
-	case cborTagStorageID:
-		n, err := dec.DecodeUint64()
-		if err != nil {
-			return nil, err
-		}
-		return StorageIDStorable(n), nil
-
-	case cborTagUInt8Value:
-		n, err := dec.DecodeUint64()
-		if err != nil {
-			return nil, err
-		}
-		if n > math.MaxUint8 {
-			return nil, fmt.Errorf("invalid data, got %d, expected max %d", n, math.MaxUint8)
-		}
-		return Uint8Value(n), nil
-
-	case cborTagUInt16Value:
-		n, err := dec.DecodeUint64()
-		if err != nil {
-			return nil, err
-		}
-		if n > math.MaxUint16 {
-			return nil, fmt.Errorf("invalid data, got %d, expected max %d", n, math.MaxUint16)
-		}
-		return Uint16Value(n), nil
-
-	case cborTagUInt32Value:
-		n, err := dec.DecodeUint64()
-		if err != nil {
-			return nil, err
-		}
-		if n > math.MaxUint32 {
-			return nil, fmt.Errorf("invalid data, got %d, expected max %d", n, math.MaxUint32)
-		}
-		return Uint32Value(n), nil
-
-	case cborTagUInt64Value:
-		n, err := dec.DecodeUint64()
-		if err != nil {
-			return nil, err
-		}
-		return Uint64Value(n), nil
-
-	default:
-		return nil, fmt.Errorf("invalid tag number %d", tagNumber)
-	}
-}
 
 // TODO: make it inline
-func getUintCBORSize(n uint64) uint32 {
+func GetUintCBORSize(n uint64) uint32 {
 	if n <= 23 {
 		return 1
 	}

--- a/storable.go
+++ b/storable.go
@@ -7,6 +7,8 @@ package atree
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/fxamacker/cbor/v2"
 )
 
 type Storable interface {
@@ -29,213 +31,7 @@ const (
 	flagStorable     byte = 0b00001000
 )
 
-const (
-	cborTagStorageID = 255
-
-	cborTagUInt8Value  = 161
-	cborTagUInt16Value = 162
-	cborTagUInt32Value = 163
-	cborTagUInt64Value = 164
-)
-
-type Uint8Value uint8
-
-var _ Value = Uint8Value(0)
-var _ Storable = Uint8Value(0)
-
-func (v Uint8Value) DeepCopy(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint8Value) Value(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint8Value) Storable() Storable {
-	return v
-}
-
-// Encode encodes UInt8Value as
-// cbor.Tag{
-//		Number:  cborTagUInt8Value,
-//		Content: uint8(v),
-// }
-func (v Uint8Value) Encode(enc *Encoder) error {
-	err := enc.cbor.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, cborTagUInt8Value,
-	})
-	if err != nil {
-		return err
-	}
-	return enc.cbor.EncodeUint8(uint8(v))
-}
-
-// TODO: cache size
-func (v Uint8Value) ByteSize() uint32 {
-	// tag number (2 bytes) + encoded content
-	return 2 + getUintCBORSize(uint64(v))
-}
-
-func (v Uint8Value) Mutable() bool {
-	return false
-}
-
-func (v Uint8Value) ID() StorageID {
-	return StorageIDUndefined
-}
-
-func (v Uint8Value) String() string {
-	return fmt.Sprintf("%d", uint8(v))
-}
-
-type Uint16Value uint16
-
-var _ Value = Uint16Value(0)
-var _ Storable = Uint16Value(0)
-
-func (v Uint16Value) DeepCopy(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint16Value) Value(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint16Value) Storable() Storable {
-	return v
-}
-
-func (v Uint16Value) Encode(enc *Encoder) error {
-	err := enc.cbor.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, cborTagUInt16Value,
-	})
-	if err != nil {
-		return err
-	}
-	return enc.cbor.EncodeUint16(uint16(v))
-}
-
-// TODO: cache size
-func (v Uint16Value) ByteSize() uint32 {
-	// tag number (2 bytes) + encoded content
-	return 2 + getUintCBORSize(uint64(v))
-}
-
-func (v Uint16Value) Mutable() bool {
-	return false
-}
-
-func (v Uint16Value) ID() StorageID {
-	return StorageIDUndefined
-}
-
-func (v Uint16Value) String() string {
-	return fmt.Sprintf("%d", uint16(v))
-}
-
-type Uint32Value uint32
-
-var _ Value = Uint32Value(0)
-var _ Storable = Uint32Value(0)
-
-func (v Uint32Value) DeepCopy(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint32Value) Value(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint32Value) Storable() Storable {
-	return v
-}
-
-// Encode encodes UInt32Value as
-// cbor.Tag{
-//		Number:  cborTagUInt32Value,
-//		Content: uint32(v),
-// }
-func (v Uint32Value) Encode(enc *Encoder) error {
-	err := enc.cbor.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, cborTagUInt32Value,
-	})
-	if err != nil {
-		return err
-	}
-	return enc.cbor.EncodeUint32(uint32(v))
-}
-
-// TODO: cache size
-func (v Uint32Value) ByteSize() uint32 {
-	// tag number (2 bytes) + encoded content
-	return 2 + getUintCBORSize(uint64(v))
-}
-
-func (v Uint32Value) Mutable() bool {
-	return false
-}
-
-func (v Uint32Value) ID() StorageID {
-	return StorageIDUndefined
-}
-
-func (v Uint32Value) String() string {
-	return fmt.Sprintf("%d", uint32(v))
-}
-
-type Uint64Value uint64
-
-var _ Value = Uint64Value(0)
-var _ Storable = Uint64Value(0)
-
-func (v Uint64Value) DeepCopy(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint64Value) Value(_ SlabStorage) (Value, error) {
-	return v, nil
-}
-
-func (v Uint64Value) Storable() Storable {
-	return v
-}
-
-// Encode encodes UInt64Value as
-// cbor.Tag{
-//		Number:  cborTagUInt64Value,
-//		Content: uint64(v),
-// }
-func (v Uint64Value) Encode(enc *Encoder) error {
-	err := enc.cbor.EncodeRawBytes([]byte{
-		// tag number
-		0xd8, cborTagUInt64Value,
-	})
-	if err != nil {
-		return err
-	}
-	return enc.cbor.EncodeUint64(uint64(v))
-}
-
-// TODO: cache size
-func (v Uint64Value) ByteSize() uint32 {
-	// tag number (2 bytes) + encoded content
-	return 2 + getUintCBORSize(uint64(v))
-}
-
-func (v Uint64Value) Mutable() bool {
-	return false
-}
-
-func (v Uint64Value) ID() StorageID {
-	return StorageIDUndefined
-}
-
-func (v Uint64Value) String() string {
-	return fmt.Sprintf("%d", uint64(v))
-}
+const CBORTagStorageID = 255
 
 type StorageIDStorable StorageID
 
@@ -262,20 +58,20 @@ func (v StorageIDStorable) Value(storage SlabStorage) (Value, error) {
 //		Content: uint64(v),
 // }
 func (v StorageIDStorable) Encode(enc *Encoder) error {
-	err := enc.cbor.EncodeRawBytes([]byte{
+	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, cborTagStorageID,
+		0xd8, CBORTagStorageID,
 	})
 	if err != nil {
 		return err
 	}
-	return enc.cbor.EncodeUint64(uint64(v))
+	return enc.CBOR.EncodeUint64(uint64(v))
 }
 
 // TODO: cache size
 func (v StorageIDStorable) ByteSize() uint32 {
 	// tag number (2 bytes) + encoded content
-	return 2 + getUintCBORSize(uint64(v))
+	return 2 + GetUintCBORSize(uint64(v))
 }
 
 func (v StorageIDStorable) Mutable() bool {
@@ -300,4 +96,12 @@ func Encode(storable Storable) ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func DecodeStorageIDStorable(dec *cbor.StreamDecoder) (Storable, error) {
+	n, err := dec.DecodeUint64()
+	if err != nil {
+		return nil, err
+	}
+	return StorageIDStorable(n), nil
 }

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -19,13 +19,13 @@ var _ Slab = StorableSlab{}
 
 func (s StorableSlab) Encode(enc *Encoder) error {
 	// Encode version
-	enc.scratch[0] = 0
+	enc.Scratch[0] = 0
 
 	// Encode flag
-	enc.scratch[1] = flagStorable
+	enc.Scratch[1] = flagStorable
 
 	const versionAndFlagSize = 2
-	_, err := enc.Write(enc.scratch[:versionAndFlagSize])
+	_, err := enc.Write(enc.Scratch[:versionAndFlagSize])
 	if err != nil {
 		return err
 	}

--- a/storable_test.go
+++ b/storable_test.go
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2021 Dapper Labs, Inc.  All rights reserved.
+ */
+
+package atree
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+
+// This file contains value implementations for testing purposes
+
+const (
+	cborTagUInt8Value  = 161
+	cborTagUInt16Value = 162
+	cborTagUInt32Value = 163
+	cborTagUInt64Value = 164
+)
+
+type Uint8Value uint8
+
+var _ Value = Uint8Value(0)
+var _ Storable = Uint8Value(0)
+
+func (v Uint8Value) DeepCopy(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint8Value) Value(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint8Value) Storable() Storable {
+	return v
+}
+
+// Encode encodes UInt8Value as
+// cbor.Tag{
+//		Number:  cborTagUInt8Value,
+//		Content: uint8(v),
+// }
+func (v Uint8Value) Encode(enc *Encoder) error {
+	err := enc.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt8Value,
+	})
+	if err != nil {
+		return err
+	}
+	return enc.CBOR.EncodeUint8(uint8(v))
+}
+
+// TODO: cache size
+func (v Uint8Value) ByteSize() uint32 {
+	// tag number (2 bytes) + encoded content
+	return 2 + GetUintCBORSize(uint64(v))
+}
+
+func (v Uint8Value) Mutable() bool {
+	return false
+}
+
+func (v Uint8Value) ID() StorageID {
+	return StorageIDUndefined
+}
+
+func (v Uint8Value) String() string {
+	return fmt.Sprintf("%d", uint8(v))
+}
+
+type Uint16Value uint16
+
+var _ Value = Uint16Value(0)
+var _ Storable = Uint16Value(0)
+
+func (v Uint16Value) DeepCopy(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint16Value) Value(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint16Value) Storable() Storable {
+	return v
+}
+
+func (v Uint16Value) Encode(enc *Encoder) error {
+	err := enc.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt16Value,
+	})
+	if err != nil {
+		return err
+	}
+	return enc.CBOR.EncodeUint16(uint16(v))
+}
+
+// TODO: cache size
+func (v Uint16Value) ByteSize() uint32 {
+	// tag number (2 bytes) + encoded content
+	return 2 + GetUintCBORSize(uint64(v))
+}
+
+func (v Uint16Value) Mutable() bool {
+	return false
+}
+
+func (v Uint16Value) ID() StorageID {
+	return StorageIDUndefined
+}
+
+func (v Uint16Value) String() string {
+	return fmt.Sprintf("%d", uint16(v))
+}
+
+type Uint32Value uint32
+
+var _ Value = Uint32Value(0)
+var _ Storable = Uint32Value(0)
+
+func (v Uint32Value) DeepCopy(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint32Value) Value(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint32Value) Storable() Storable {
+	return v
+}
+
+// Encode encodes UInt32Value as
+// cbor.Tag{
+//		Number:  cborTagUInt32Value,
+//		Content: uint32(v),
+// }
+func (v Uint32Value) Encode(enc *Encoder) error {
+	err := enc.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt32Value,
+	})
+	if err != nil {
+		return err
+	}
+	return enc.CBOR.EncodeUint32(uint32(v))
+}
+
+// TODO: cache size
+func (v Uint32Value) ByteSize() uint32 {
+	// tag number (2 bytes) + encoded content
+	return 2 + GetUintCBORSize(uint64(v))
+}
+
+func (v Uint32Value) Mutable() bool {
+	return false
+}
+
+func (v Uint32Value) ID() StorageID {
+	return StorageIDUndefined
+}
+
+func (v Uint32Value) String() string {
+	return fmt.Sprintf("%d", uint32(v))
+}
+
+type Uint64Value uint64
+
+var _ Value = Uint64Value(0)
+var _ Storable = Uint64Value(0)
+
+func (v Uint64Value) DeepCopy(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint64Value) Value(_ SlabStorage) (Value, error) {
+	return v, nil
+}
+
+func (v Uint64Value) Storable() Storable {
+	return v
+}
+
+// Encode encodes UInt64Value as
+// cbor.Tag{
+//		Number:  cborTagUInt64Value,
+//		Content: uint64(v),
+// }
+func (v Uint64Value) Encode(enc *Encoder) error {
+	err := enc.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagUInt64Value,
+	})
+	if err != nil {
+		return err
+	}
+	return enc.CBOR.EncodeUint64(uint64(v))
+}
+
+// TODO: cache size
+func (v Uint64Value) ByteSize() uint32 {
+	// tag number (2 bytes) + encoded content
+	return 2 + GetUintCBORSize(uint64(v))
+}
+
+func (v Uint64Value) Mutable() bool {
+	return false
+}
+
+func (v Uint64Value) ID() StorageID {
+	return StorageIDUndefined
+}
+
+func (v Uint64Value) String() string {
+	return fmt.Sprintf("%d", uint64(v))
+}
+
+func decodeStorable(dec *cbor.StreamDecoder) (Storable, error) {
+	tagNumber, err := dec.DecodeTagNumber()
+	if err != nil {
+		return nil, err
+	}
+
+	switch tagNumber {
+	case CBORTagStorageID:
+		return DecodeStorageIDStorable(dec)
+
+	case cborTagUInt8Value:
+		n, err := dec.DecodeUint64()
+		if err != nil {
+			return nil, err
+		}
+		if n > math.MaxUint8 {
+			return nil, fmt.Errorf("invalid data, got %d, expected max %d", n, math.MaxUint8)
+		}
+		return Uint8Value(n), nil
+
+	case cborTagUInt16Value:
+		n, err := dec.DecodeUint64()
+		if err != nil {
+			return nil, err
+		}
+		if n > math.MaxUint16 {
+			return nil, fmt.Errorf("invalid data, got %d, expected max %d", n, math.MaxUint16)
+		}
+		return Uint16Value(n), nil
+
+	case cborTagUInt32Value:
+		n, err := dec.DecodeUint64()
+		if err != nil {
+			return nil, err
+		}
+		if n > math.MaxUint32 {
+			return nil, fmt.Errorf("invalid data, got %d, expected max %d", n, math.MaxUint32)
+		}
+		return Uint32Value(n), nil
+
+	case cborTagUInt64Value:
+		n, err := dec.DecodeUint64()
+		if err != nil {
+			return nil, err
+		}
+		return Uint64Value(n), nil
+
+	default:
+		return nil, fmt.Errorf("invalid tag number %d", tagNumber)
+	}
+}


### PR DESCRIPTION
:warning: Depends on #42 

Instead of having the storable decoding, and thus the kinds of values that are supported, hard-coded, make it a field of storage, and thus allow users of the library to inject a custom storable decoding function.

This currently requires the external decoding function to always handle the built-in storable `StorageIDStorable`, which the array implementation relies on. I tried to handle this in the library itself first, and only delegating to the external storable decoding function, but I couldn't quite figure this out. Feedback welcome!
