### PR TITLE
Change Value.Storable to return error and add tests

### DIFF
--- a/array.go
+++ b/array.go
@@ -126,8 +126,8 @@ func (a *Array) Value(_ SlabStorage) (Value, error) {
 	return a, nil
 }
 
-func (a *Array) Storable(_ SlabStorage, _ Address) Storable {
-	return StorageIDStorable(a.StorageID())
+func (a *Array) Storable(_ SlabStorage, _ Address) (Storable, error) {
+	return StorageIDStorable(a.StorageID()), nil
 }
 
 type IndexOutOfRangeError struct {
@@ -1683,7 +1683,10 @@ func (a *Array) Get(i uint64) (Value, error) {
 }
 
 func (a *Array) Set(index uint64, value Value) error {
-	storable := value.Storable(a.storage, a.Address())
+	storable, err := value.Storable(a.storage, a.Address())
+	if err != nil {
+		return err
+	}
 	return a.root.Set(a.storage, index, storable)
 }
 
@@ -1692,9 +1695,12 @@ func (a *Array) Append(value Value) error {
 }
 
 func (a *Array) Insert(index uint64, value Value) error {
-	storable := value.Storable(a.storage, a.Address())
+	storable, err := value.Storable(a.storage, a.Address())
+	if err != nil {
+		return err
+	}
 
-	err := a.root.Insert(a.storage, index, storable)
+	err = a.root.Insert(a.storage, index, storable)
 	if err != nil {
 		return err
 	}

--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -132,7 +132,7 @@ func benchmarkGet(b *testing.B, initialArraySize, numberOfElements int) {
 		for i := 0; i < numberOfElements; i++ {
 			index := rand.Intn(int(array.Count()))
 			v, _ := array.Get(uint64(index))
-			storable = v.Storable(storage, array.Address())
+			storable, _ = v.Storable(storage, array.Address())
 		}
 	}
 

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -76,8 +76,10 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	// setup
 	for i := 0; i < initialArraySize; i++ {
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Append(v)
+		storable, err := v.Storable(storage, array.Address())
+		require.NoError(b, err)
+		totalRawDataSize += storable.ByteSize()
+		err = array.Append(v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -93,8 +95,9 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	require.NoError(b, err)
 	for i := 0; i < numberOfElements; i++ {
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Append(v)
+		storable, err := v.Storable(storage, array.Address())
+		totalRawDataSize += storable.ByteSize()
+		err = array.Append(v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -111,7 +114,9 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		ind := rand.Intn(int(array.Count()))
 		s, err := array.Remove(uint64(ind))
 		require.NoError(b, err)
-		totalRawDataSize -= s.Storable(storage, array.Address()).ByteSize()
+		storable, err := s.Storable(storage, array.Address())
+		require.NoError(b, err)
+		totalRawDataSize -= storable.ByteSize()
 	}
 	require.NoError(b, storage.Commit())
 	totalRemoveTime = time.Since(start)
@@ -126,8 +131,9 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	for i := 0; i < numberOfElements; i++ {
 		ind := rand.Intn(int(array.Count()))
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Insert(uint64(ind), v)
+		storable, err := v.Storable(storage, array.Address())
+		totalRawDataSize += storable.ByteSize()
+		err = array.Insert(uint64(ind), v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -194,8 +200,9 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 	// setup
 	for i := 0; i < initialArraySize; i++ {
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Append(v)
+		storable, err := v.Storable(storage, array.Address())
+		totalRawDataSize += storable.ByteSize()
+		err = array.Append(v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -208,11 +215,14 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 		case 0: // remove
 			v, err := array.Remove(uint64(ind))
 			require.NoError(b, err)
-			totalRawDataSize -= v.Storable(storage, array.Address()).ByteSize()
+			storable, err := v.Storable(storage, array.Address())
+			require.NoError(b, err)
+			totalRawDataSize -= storable.ByteSize()
 		case 1: // insert
 			v := RandomValue()
-			totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-			err := array.Insert(uint64(ind), v)
+			storable, err := v.Storable(storage, array.Address())
+			totalRawDataSize += storable.ByteSize()
+			err = array.Insert(uint64(ind), v)
 			require.NoError(b, err)
 		}
 	}

--- a/basicarray.go
+++ b/basicarray.go
@@ -57,8 +57,8 @@ func (a *BasicArray) DeepCopy(storage SlabStorage, address Address) (Value, erro
 	return result, nil
 }
 
-func (a *BasicArray) Storable(_ SlabStorage, _ Address) Storable {
-	return a.root
+func (a *BasicArray) Storable(_ SlabStorage, _ Address) (Storable, error) {
+	return a.root, nil
 }
 
 func NewBasicArrayDataSlab(storage SlabStorage, address Address) *BasicArrayDataSlab {
@@ -299,10 +299,12 @@ func (a *BasicArray) Get(index uint64) (Value, error) {
 }
 
 func (a *BasicArray) Set(index uint64, v Value) error {
-	storable := v.Storable(a.storage, a.Address())
+	storable, err := v.Storable(a.storage, a.Address())
+	if err != nil {
+		return err
+	}
 	return a.root.Set(a.storage, index, storable)
 }
-
 
 func (a *BasicArray) Append(v Value) error {
 	index := uint64(a.root.header.count)
@@ -310,7 +312,10 @@ func (a *BasicArray) Append(v Value) error {
 }
 
 func (a *BasicArray) Insert(index uint64, v Value) error {
-	storable := v.Storable(a.storage, a.Address())
+	storable, err := v.Storable(a.storage, a.Address())
+	if err != nil {
+		return err
+	}
 	return a.root.Insert(a.storage, index, storable)
 }
 

--- a/basicarray_benchmark_test.go
+++ b/basicarray_benchmark_test.go
@@ -65,8 +65,10 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	// setup
 	for i := 0; i < initialArraySize; i++ {
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Append(v)
+		storable, err := v.Storable(storage, array.Address())
+		require.NoError(b, err)
+		totalRawDataSize += storable.ByteSize()
+		err = array.Append(v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -82,8 +84,10 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	start = time.Now()
 	for i := 0; i < numberOfElements; i++ {
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Append(v)
+		storable, err := v.Storable(storage, array.Address())
+		require.NoError(b, err)
+		totalRawDataSize += storable.ByteSize()
+		err = array.Append(v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -99,7 +103,9 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		ind := rand.Intn(int(array.Count()))
 		s, err := array.Remove(uint64(ind))
 		require.NoError(b, err)
-		totalRawDataSize -= s.Storable(storage, array.Address()).ByteSize()
+		storable, err := s.Storable(storage, array.Address())
+		require.NoError(b, err)
+		totalRawDataSize -= storable.ByteSize()
 	}
 	require.NoError(b, storage.Commit())
 	totalRemoveTime = time.Since(start)
@@ -113,8 +119,10 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	for i := 0; i < numberOfElements; i++ {
 		ind := rand.Intn(int(array.Count()))
 		v := RandomValue()
-		totalRawDataSize += v.Storable(storage, array.Address()).ByteSize()
-		err := array.Insert(uint64(ind), v)
+		storable, err := v.Storable(storage, array.Address())
+		require.NoError(b, err)
+		totalRawDataSize += storable.ByteSize()
+		err = array.Insert(uint64(ind), v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,8 +27,8 @@ func (v Uint64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (v Uint64Value) Storable(_ atree.SlabStorage, _ atree.Address) atree.Storable {
-	return v
+func (v Uint64Value) Storable(_ atree.SlabStorage, _ atree.Address) (atree.Storable, error) {
+	return v, nil
 }
 
 // Encode encodes UInt64Value as

--- a/value.go
+++ b/value.go
@@ -5,6 +5,6 @@
 package atree
 
 type Value interface {
-	Storable(SlabStorage, Address) Storable
+	Storable(SlabStorage, Address) (Storable, error)
 	DeepCopy(SlabStorage, Address) (Value, error)
 }


### PR DESCRIPTION
Changes include:
 - add error to `Value.Storable` return values
 - add `StringValue` type
 - add tests to insert small strings (inlined) and large strings (stored in separate slabs) 