### PR TITLE
Fix intermittent bugs in test code 

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -47,7 +47,7 @@ var (
 	emptyBlake3Hash [4]uint64
 )
 
-func NewBasicDigesterBuilder(key [16]byte) *basicDigesterBuilder {
+func newBasicDigesterBuilder(key [16]byte) *basicDigesterBuilder {
 	return &basicDigesterBuilder{secretKey: key}
 }
 
@@ -106,6 +106,6 @@ func (bd *basicDigester) Digest(level int) (Digest, error) {
 	}
 }
 
-func (d *basicDigester) Levels() int {
+func (bd *basicDigester) Levels() int {
 	return 4
 }

--- a/map_debug.go
+++ b/map_debug.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 )
 
-type mapStats struct {
+type MapStats struct {
 	Levels                 uint64
 	ElementCount           uint64
 	MetaDataSlabCount      uint64
@@ -20,7 +20,7 @@ type mapStats struct {
 }
 
 // Stats returns stats about the map slabs.
-func (m *OrderedMap) Stats() (mapStats, error) {
+func (m *OrderedMap) Stats() (MapStats, error) {
 	level := uint64(0)
 	metaDataSlabCount := uint64(0)
 	metaDataSlabSize := uint64(0)
@@ -42,7 +42,7 @@ func (m *OrderedMap) Stats() (mapStats, error) {
 
 			slab, err := getMapSlab(m.storage, id)
 			if err != nil {
-				return mapStats{}, err
+				return MapStats{}, err
 			}
 
 			if slab.IsData() {
@@ -53,7 +53,7 @@ func (m *OrderedMap) Stats() (mapStats, error) {
 				for i := 0; i < int(leaf.elements.Count()); i++ {
 					elem, err := leaf.elements.Element(i)
 					if err != nil {
-						return mapStats{}, err
+						return MapStats{}, err
 					}
 					if group, ok := elem.(elementGroup); ok {
 						if !group.Inline() {
@@ -75,7 +75,7 @@ func (m *OrderedMap) Stats() (mapStats, error) {
 		level++
 	}
 
-	return mapStats{
+	return MapStats{
 		Levels:                 level,
 		MetaDataSlabCount:      metaDataSlabCount,
 		DataSlabCount:          dataSlabCount,

--- a/map_test.go
+++ b/map_test.go
@@ -94,7 +94,7 @@ func TestMapSetAndGet(t *testing.T) {
 			}
 		}
 
-		m, err := NewMap(storage, address, NewBasicDigesterBuilder(secretkey), typeInfo)
+		m, err := NewMap(storage, address, newBasicDigesterBuilder(secretkey), typeInfo)
 		require.NoError(t, err)
 
 		for k, v := range uniqueKeyValues {
@@ -150,7 +150,7 @@ func TestMapSetAndGet(t *testing.T) {
 			}
 		}
 
-		m, err := NewMap(storage, address, NewBasicDigesterBuilder(secretkey), typeInfo)
+		m, err := NewMap(storage, address, newBasicDigesterBuilder(secretkey), typeInfo)
 		require.NoError(t, err)
 
 		for k, v := range uniqueKeyValues {
@@ -217,7 +217,7 @@ func TestMapSetAndGet(t *testing.T) {
 
 		storage := newTestInMemoryStorage(t)
 
-		m, err := NewMap(storage, address, NewBasicDigesterBuilder(secretkey), typeInfo)
+		m, err := NewMap(storage, address, newBasicDigesterBuilder(secretkey), typeInfo)
 		require.NoError(t, err)
 
 		for k, v := range uniqueKeyValues {
@@ -276,7 +276,7 @@ func TestMapHas(t *testing.T) {
 		}
 	}
 
-	m, err := NewMap(storage, address, NewBasicDigesterBuilder(secretkey), typeInfo)
+	m, err := NewMap(storage, address, newBasicDigesterBuilder(secretkey), typeInfo)
 	require.NoError(t, err)
 
 	for i, k := range keysToInsert {
@@ -317,7 +317,7 @@ func TestMapIterate(t *testing.T) {
 
 		storage := newTestInMemoryStorage(t)
 
-		digesterBuilder := NewBasicDigesterBuilder(secretkey)
+		digesterBuilder := newBasicDigesterBuilder(secretkey)
 
 		uniqueKeyValues := make(map[string]uint64, mapSize)
 
@@ -675,7 +675,7 @@ func TestMapLargeElement(t *testing.T) {
 
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
-	m, err := NewMap(storage, address, NewBasicDigesterBuilder(secretkey), typeInfo)
+	m, err := NewMap(storage, address, newBasicDigesterBuilder(secretkey), typeInfo)
 	require.NoError(t, err)
 
 	for k, v := range strs {


### PR DESCRIPTION
This PR fixes intermittent bugs found in test code while investigating issue #70.  

- Fixed test bug that generates non-unique digests

- Fixed test bug that generates non-unique map keys

- Improved `TestMapHashCollision` to test max hash levels from 1 to 4 for both deterministic and random hash collision.

Updates issue #70.