### PR TITLE
deterministic commit

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -447,10 +447,12 @@ func (s *PersistentSlabStorage) Commit() error {
 	}
 
 	sort.Slice(keysWithOwners, func(i, j int) bool {
-		if keysWithOwners[i].Address == keysWithOwners[j].Address {
-			return keysWithOwners[i].IndexAsUint64() < keysWithOwners[j].IndexAsUint64()
+		a := keysWithOwners[i]
+		b := keysWithOwners[j]
+		if a.Address == b.Address {
+			return a.IndexAsUint64() < b.IndexAsUint64()
 		}
-		return keysWithOwners[i].AddressAsUint64() < keysWithOwners[j].AddressAsUint64()
+		return a.AddressAsUint64() < b.AddressAsUint64()
 	})
 
 	for _, id := range keysWithOwners {


### PR DESCRIPTION
This PR: 
 - sorts keys before committing them (to make sure it is deterministic) 
 - before sorting we would exclude the keys that are owned by AddressUndefined (this saves us time from sorting unnecessary data) 
 - for sorting, we consider the address part first and if they are equal we fall back to indices