### PR TITLE
Add isCopy result to DeepCopy function

### DIFF
--- a/array.go
+++ b/array.go
@@ -1908,16 +1908,16 @@ func (a *Array) Iterate(fn ArrayIterationFunc) error {
 	}
 }
 
-func (a *Array) DeepCopy(storage SlabStorage, address Address) (Value, error) {
+func (a *Array) DeepCopy(storage SlabStorage, address Address) (Value, bool, error) {
 	result, err := NewArray(storage, address, a.Type())
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	var index uint64
 	err = a.Iterate(func(element Value) (resume bool, err error) {
 
-		elementCopy, err := element.DeepCopy(storage, address)
+		elementCopy, _, err := element.DeepCopy(storage, address)
 		if err != nil {
 			return false, err
 		}
@@ -1932,10 +1932,10 @@ func (a *Array) DeepCopy(storage SlabStorage, address Address) (Value, error) {
 		return true, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return result, nil
+	return result, true, nil
 }
 
 func (a *Array) DeepRemove(storage SlabStorage) error {

--- a/array_test.go
+++ b/array_test.go
@@ -787,7 +787,7 @@ func TestDeepCopy(t *testing.T) {
 
 	address2 := Address{11, 12, 13, 14, 15, 16, 17, 18}
 
-	copied, err := array.DeepCopy(storage, address2)
+	copied, _, err := array.DeepCopy(storage, address2)
 	require.NoError(t, err)
 	require.IsType(t, &Array{}, copied)
 

--- a/basicarray.go
+++ b/basicarray.go
@@ -36,27 +36,27 @@ type BasicArray struct {
 
 var _ Value = &BasicArray{}
 
-func (a *BasicArray) DeepCopy(storage SlabStorage, address Address) (Value, error) {
+func (a *BasicArray) DeepCopy(storage SlabStorage, address Address) (Value, bool, error) {
 	result := NewBasicArray(storage, address)
 
 	for i, element := range a.root.elements {
 		value, err := element.StoredValue(storage)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
-		valueCopy, err := value.DeepCopy(storage, address)
+		valueCopy, _, err := value.DeepCopy(storage, address)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		err = result.Insert(uint64(i), valueCopy)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
-	return result, nil
+	return result, true, nil
 }
 
 func (a *BasicArray) DeepRemove(storage SlabStorage) error {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,8 +19,8 @@ type Uint64Value uint64
 var _ atree.Value = Uint64Value(0)
 var _ atree.Storable = Uint64Value(0)
 
-func (v Uint64Value) DeepCopy(_ atree.SlabStorage, _ atree.Address) (atree.Value, error) {
-	return v, nil
+func (v Uint64Value) DeepCopy(_ atree.SlabStorage, _ atree.Address) (atree.Value, bool, error) {
+	return v, false, nil
 }
 
 func (v Uint64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/map.go
+++ b/map.go
@@ -2381,9 +2381,9 @@ func (m *OrderedMap) StorageID() StorageID {
 	return m.root.Header().id
 }
 
-func (m *OrderedMap) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
+func (m *OrderedMap) DeepCopy(_ SlabStorage, _ Address) (Value, bool, error) {
 	// TODO: implement me
-	return nil, NewNotImplementedError("OrderedMap's DeepCopy")
+	return nil, false, NewNotImplementedError("OrderedMap's DeepCopy")
 }
 
 func (m *OrderedMap) DeepRemove(storage SlabStorage) error {

--- a/storable_test.go
+++ b/storable_test.go
@@ -27,8 +27,8 @@ var _ Value = Uint8Value(0)
 var _ Storable = Uint8Value(0)
 var _ ComparableValue = Uint8Value(0)
 
-func (v Uint8Value) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
-	return v, nil
+func (v Uint8Value) DeepCopy(_ SlabStorage, _ Address) (Value, bool, error) {
+	return v, false, nil
 }
 
 func (v Uint8Value) StoredValue(_ SlabStorage) (Value, error) {
@@ -103,8 +103,8 @@ var _ Value = Uint16Value(0)
 var _ Storable = Uint16Value(0)
 var _ ComparableValue = Uint16Value(0)
 
-func (v Uint16Value) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
-	return v, nil
+func (v Uint16Value) DeepCopy(_ SlabStorage, _ Address) (Value, bool, error) {
+	return v, false, nil
 }
 
 func (v Uint16Value) StoredValue(_ SlabStorage) (Value, error) {
@@ -173,8 +173,8 @@ var _ Value = Uint32Value(0)
 var _ Storable = Uint32Value(0)
 var _ ComparableValue = Uint32Value(0)
 
-func (v Uint32Value) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
-	return v, nil
+func (v Uint32Value) DeepCopy(_ SlabStorage, _ Address) (Value, bool, error) {
+	return v, false, nil
 }
 
 func (v Uint32Value) StoredValue(_ SlabStorage) (Value, error) {
@@ -253,8 +253,8 @@ var _ Value = Uint64Value(0)
 var _ Storable = Uint64Value(0)
 var _ ComparableValue = Uint64Value(0)
 
-func (v Uint64Value) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
-	return v, nil
+func (v Uint64Value) DeepCopy(_ SlabStorage, _ Address) (Value, bool, error) {
+	return v, false, nil
 }
 
 func (v Uint64Value) StoredValue(_ SlabStorage) (Value, error) {
@@ -331,8 +331,8 @@ func NewStringValue(s string) *StringValue {
 	return &StringValue{str: s, size: size}
 }
 
-func (v *StringValue) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
-	return v, nil
+func (v *StringValue) DeepCopy(_ SlabStorage, _ Address) (Value, bool, error) {
+	return v, false, nil
 }
 
 func (v *StringValue) StoredValue(_ SlabStorage) (Value, error) {

--- a/value.go
+++ b/value.go
@@ -6,7 +6,7 @@ package atree
 
 type Value interface {
 	Storable(SlabStorage, Address, uint64) (Storable, error)
-	DeepCopy(SlabStorage, Address) (Value, error)
+	DeepCopy(SlabStorage, Address) (result Value, isCopy bool, err error)
 	DeepRemove(storage SlabStorage) error
 }
 


### PR DESCRIPTION
The additional result value lets the copy function indicate if the result was actually copied, or if the returned value is actually the same value.

This allows the caller to know if the original value can be removed or should not be removed.

The use-case for this functionality are resources: A resource can be safely returned as-is from its DeepCopy function if it already exists in the target account. The caller of DeepCopy may then not DeepRemove the original.