### PR TITLE
Replace Value.Equal with Comparator

### DIFF
--- a/map_debug.go
+++ b/map_debug.go
@@ -237,9 +237,9 @@ func (m *OrderedMap) _validHkeyElements(id StorageID, db DigesterBuilder, elemen
 				return 0, err
 			}
 
-			ck, ok := ks.(ComparableValue)
+			ck, ok := ks.(HashableValue)
 			if !ok {
-				return 0, fmt.Errorf("key %s doesn't implement ComparableValue", ks)
+				return 0, fmt.Errorf("key %s doesn't implement HashableValue", ks)
 			}
 
 			// Verify single element size
@@ -300,9 +300,9 @@ func (m *OrderedMap) _validSingleElements(id StorageID, db DigesterBuilder, elem
 			return 0, err
 		}
 
-		ck, ok := ks.(ComparableValue)
+		ck, ok := ks.(HashableValue)
 		if !ok {
-			return 0, fmt.Errorf("key %s doesn't implement ComparableValue", ks)
+			return 0, fmt.Errorf("key %s doesn't implement HashableValue", ks)
 		}
 
 		// Verify single element size

--- a/map_test.go
+++ b/map_test.go
@@ -78,7 +78,7 @@ func TestMapSetAndGet(t *testing.T) {
 		storage := newTestInMemoryStorage(t)
 
 		uniqueKeys := make(map[string]bool, mapSize)
-		uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+		uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 		for i := uint64(0); i < mapSize; i++ {
 			for {
 				s := randStr(16)
@@ -139,7 +139,7 @@ func TestMapSetAndGet(t *testing.T) {
 		storage := newTestInMemoryStorage(t)
 
 		uniqueKeys := make(map[string]bool, mapSize)
-		uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+		uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 		for i := uint64(0); i < mapSize; i++ {
 			for {
 				s := randStr(16)
@@ -215,7 +215,7 @@ func TestMapSetAndGet(t *testing.T) {
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 		uniqueKeys := make(map[string]bool, mapSize)
-		uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+		uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 		for i := uint64(0); i < mapSize; i++ {
 			for {
 				slen := rand.Intn(maxKeyLength + 1)
@@ -355,7 +355,7 @@ func TestMapRemove(t *testing.T) {
 		storage := newTestInMemoryStorage(t)
 
 		uniqueKeys := make(map[string]bool, mapSize)
-		uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+		uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 		for i := uint64(0); i < mapSize; i++ {
 			for {
 				s := randStr(keyStringMaxSize)
@@ -452,7 +452,7 @@ func TestMapRemove(t *testing.T) {
 		storage := newTestInMemoryStorage(t)
 
 		uniqueKeys := make(map[string]bool, mapSize)
-		uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+		uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 		for i := uint64(0); i < mapSize; i++ {
 			for {
 				s := randStr(keyStringMaxSize)
@@ -624,13 +624,13 @@ func TestMapIterate(t *testing.T) {
 
 		storage := newTestInMemoryStorage(t)
 
-		uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+		uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 
 		uniqueKeys := make(map[string]bool, mapSize)
 
-		sortedKeys := make([]ComparableValue, mapSize)
+		sortedKeys := make([]HashableValue, mapSize)
 
-		keys := make([]ComparableValue, mapSize)
+		keys := make([]HashableValue, mapSize)
 
 		for i := uint64(0); i < mapSize; i++ {
 			for {
@@ -698,7 +698,7 @@ func TestMapIterate(t *testing.T) {
 		err = m.Iterate(func(k Value, v Value) (resume bool, err error) {
 			require.Equal(t, sortedKeys[i], k)
 
-			mk, ok := k.(ComparableValue)
+			mk, ok := k.(HashableValue)
 			require.True(t, ok)
 			require.Equal(t, uniqueKeyValues[mk], v)
 
@@ -740,7 +740,7 @@ func testMapDeterministicHashCollision(t *testing.T, maxDigestLevel int) {
 
 	storage := newTestInMemoryStorage(t)
 
-	uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+	uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 	uniqueKeys := make(map[string]bool)
 	for i := uint64(0); i < mapSize; i++ {
 		for {
@@ -839,7 +839,7 @@ func testMapRandomHashCollision(t *testing.T, maxDigestLevel int) {
 
 	storage := newTestInMemoryStorage(t)
 
-	uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+	uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 	uniqueKeys := make(map[string]bool)
 	for i := uint64(0); i < mapSize; i++ {
 		for {
@@ -1051,8 +1051,8 @@ func TestMapRandomSetRemoveMixedTypes(t *testing.T) {
 	m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 	require.NoError(t, err)
 
-	keyValues := make(map[ComparableValue]Value)
-	var keys []ComparableValue
+	keyValues := make(map[HashableValue]Value)
+	var keys []HashableValue
 
 	for i := uint64(0); i < actionCount; i++ {
 
@@ -1060,7 +1060,7 @@ func TestMapRandomSetRemoveMixedTypes(t *testing.T) {
 
 		case SetAction:
 
-			var k ComparableValue
+			var k HashableValue
 
 			switch rand.Intn(MaxType) {
 			case Uint8Type:
@@ -2726,8 +2726,8 @@ func TestMapEncodeDecodeRandomData(t *testing.T) {
 	m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 	require.NoError(t, err)
 
-	keyValues := make(map[ComparableValue]Value)
-	var keys []ComparableValue
+	keyValues := make(map[HashableValue]Value)
+	var keys []HashableValue
 
 	for i := uint64(0); i < actionCount; i++ {
 
@@ -2741,7 +2741,7 @@ func TestMapEncodeDecodeRandomData(t *testing.T) {
 
 		case SetAction:
 
-			var k ComparableValue
+			var k HashableValue
 
 			switch rand.Intn(MaxType) {
 			case Uint8Type:
@@ -2856,7 +2856,7 @@ func TestMapStoredValue(t *testing.T) {
 	storage := newTestInMemoryStorage(t)
 
 	uniqueKeys := make(map[string]bool, mapSize)
-	uniqueKeyValues := make(map[ComparableValue]Value, mapSize)
+	uniqueKeyValues := make(map[HashableValue]Value, mapSize)
 	for i := uint64(0); i < mapSize; i++ {
 		for {
 			s := randStr(16)

--- a/storable_test.go
+++ b/storable_test.go
@@ -26,7 +26,7 @@ type Uint8Value uint8
 
 var _ Value = Uint8Value(0)
 var _ Storable = Uint8Value(0)
-var _ ComparableValue = Uint8Value(0)
+var _ HashableValue = Uint8Value(0)
 
 func (v Uint8Value) StoredValue(_ SlabStorage) (Value, error) {
 	return v, nil
@@ -89,7 +89,7 @@ type Uint16Value uint16
 
 var _ Value = Uint16Value(0)
 var _ Storable = Uint16Value(0)
-var _ ComparableValue = Uint16Value(0)
+var _ HashableValue = Uint16Value(0)
 
 func (v Uint16Value) StoredValue(_ SlabStorage) (Value, error) {
 	return v, nil
@@ -146,7 +146,7 @@ type Uint32Value uint32
 
 var _ Value = Uint32Value(0)
 var _ Storable = Uint32Value(0)
-var _ ComparableValue = Uint32Value(0)
+var _ HashableValue = Uint32Value(0)
 
 func (v Uint32Value) DeepCopy(_ SlabStorage, _ Address) (Value, error) {
 	return v, nil
@@ -212,7 +212,7 @@ type Uint64Value uint64
 
 var _ Value = Uint64Value(0)
 var _ Storable = Uint64Value(0)
-var _ ComparableValue = Uint64Value(0)
+var _ HashableValue = Uint64Value(0)
 
 func (v Uint64Value) StoredValue(_ SlabStorage) (Value, error) {
 	return v, nil
@@ -277,7 +277,7 @@ type StringValue struct {
 
 var _ Value = &StringValue{}
 var _ Storable = &StringValue{}
-var _ ComparableValue = &StringValue{}
+var _ HashableValue = &StringValue{}
 
 func NewStringValue(s string) StringValue {
 	size := GetUintCBORSize(uint64(len(s))) + uint32(len(s))

--- a/value.go
+++ b/value.go
@@ -8,7 +8,7 @@ type Value interface {
 	Storable(SlabStorage, Address, uint64) (Storable, error)
 }
 
-type ComparableValue interface {
+type HashableValue interface {
 	Value
 	Hashable
 }


### PR DESCRIPTION
`Value` objects in Cadence already implement `Equal` with a different API.

Resolve this by replacing `Value.Equal` in atree with `Comparator` as suggested by @turbolent .

Also, optimize speed by removing unnecessary calls to `StoredValue`. 

`Comparator(SlabStorage, Value, Storable)` can compare storable with value using type assertion because some value objects implement `Storable` interface.

Closes #107 