### PR TITLE
Add NewMapFromBatchData() to copy a map faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20210510192846-c3f3c69e7bc8
 	github.com/stretchr/testify v1.7.0
 	github.com/zeebo/blake3 v0.2.0
-	github.com/zeebo/xxh3 v0.12.0 // indirect
+	github.com/zeebo/xxh3 v0.12.0
 )


### PR DESCRIPTION
Closes #126 

```
Benchstat -geomean:
name                       old time/op    new time/op    delta
BatchSetMap10Elems/loop-4    8.70µs ± 2%    6.35µs ± 4%  -27.09% (p=0.000 n=9+10)

name                       old alloc/op   new alloc/op   delta
BatchSetMap10Elems/loop-4    1.76kB ± 0%    1.74kB ± 0%   -0.84% (p=0.000 n=10+10)

name                       old allocs/op  new allocs/op  delta
BatchSetMap10Elems/loop-4      28.0 ± 0%      20.0 ± 0%  -28.57% (p=0.000 n=10+10)
```
```
Benchstat -geomean:
name                        old time/op    new time/op    delta
BatchSetMap100Elems/loop-4    77.2µs ± 4%    42.9µs ± 4%  -44.50% (p=0.000 n=10+10)

name                        old alloc/op   new alloc/op   delta
BatchSetMap100Elems/loop-4    15.4kB ± 0%    10.5kB ± 0%  -31.71% (p=0.000 n=9+10)

name                        old allocs/op  new allocs/op  delta
BatchSetMap100Elems/loop-4       133 ± 0%       122 ± 0%   -8.27% (p=0.000 n=10+10)
```
```
Benchstat -geomean:
name                         old time/op    new time/op    delta
BatchSetMap1000Elems/loop-4    1.01ms ± 2%    0.49ms ± 7%  -51.72% (p=0.000 n=9+10)

name                         old alloc/op   new alloc/op   delta
BatchSetMap1000Elems/loop-4     148kB ± 0%     124kB ± 0%  -16.24% (p=0.000 n=10+10)

name                         old allocs/op  new allocs/op  delta
BatchSetMap1000Elems/loop-4     4.13k ± 0%     4.12k ± 0%   -0.17% (p=0.002 n=8+10)
```