### PR TITLE
Improve errors

### DIFF
--- a/array_debug.go
+++ b/array_debug.go
@@ -293,13 +293,17 @@ func validArraySlab(
 		for _, e := range dataSlab.elements {
 			v, err := e.StoredValue(storage)
 			if err != nil {
-				return 0, nil, nil, fmt.Errorf("data slab %d element %s can't be converted to value, %s",
-					id, e, err)
+				return 0, nil, nil, fmt.Errorf(
+					"data slab %d element %s can't be converted to value: %w",
+					id, e, err,
+				)
 			}
 			err = ValidValue(v, nil, tic, hip)
 			if err != nil {
-				return 0, nil, nil, fmt.Errorf("data slab %d element %s isn't valid, %s",
-					id, e, err)
+				return 0, nil, nil, fmt.Errorf(
+					"data slab %d element %s isn't valid: %w",
+					id, e, err,
+				)
 			}
 		}
 
@@ -446,7 +450,7 @@ func validArraySlabSerialization(
 		// Compare slabs
 		err = arrayDataSlabEqual(dataSlab, decodedDataSlab, storage, cborDecMode, cborEncMode, decodeStorable, decodeTypeInfo)
 		if err != nil {
-			return fmt.Errorf("data slab %d round-trip serialization failed: %s", id, err)
+			return fmt.Errorf("data slab %d round-trip serialization failed: %w", id, err)
 		}
 
 		return nil
@@ -465,7 +469,7 @@ func validArraySlabSerialization(
 	// Compare slabs
 	err = arrayMetaDataSlabEqual(metaSlab, decodedMetaSlab)
 	if err != nil {
-		return fmt.Errorf("metadata slab %d round-trip serialization failed: %s", id, err)
+		return fmt.Errorf("metadata slab %d round-trip serialization failed: %w", id, err)
 	}
 
 	for _, h := range metaSlab.childrenHeaders {

--- a/cmd/stress/array.go
+++ b/cmd/stress/array.go
@@ -277,11 +277,11 @@ func checkArrayDataLoss(array *atree.Array, values []atree.Value) error {
 	for i, v := range values {
 		storable, err := array.Get(uint64(i))
 		if err != nil {
-			return fmt.Errorf("failed to get element at %d: %s", i, err)
+			return fmt.Errorf("failed to get element at %d: %w", i, err)
 		}
 		equal, err := compare(array.Storage, v, storable)
 		if err != nil {
-			return fmt.Errorf("failed to compare %s and %s: %s", v, storable, err)
+			return fmt.Errorf("failed to compare %s and %s: %w", v, storable, err)
 		}
 		if !equal {
 			return fmt.Errorf("Get(%d) returns %s, want %s", i, storable, v)

--- a/cmd/stress/map.go
+++ b/cmd/stress/map.go
@@ -260,11 +260,11 @@ func checkMapDataLoss(m *atree.OrderedMap, elements map[atree.Value]atree.Value)
 	for k, v := range elements {
 		storable, err := m.Get(compare, hashInputProvider, k)
 		if err != nil {
-			return fmt.Errorf("failed to get element with key %s: %s", k, err)
+			return fmt.Errorf("failed to get element with key %s: %w", k, err)
 		}
 		equal, err := compare(m.Storage, v, storable)
 		if err != nil {
-			return fmt.Errorf("failed to compare %s and %s: %s", v, storable, err)
+			return fmt.Errorf("failed to compare %s and %s: %w", v, storable, err)
 		}
 		if !equal {
 			return fmt.Errorf("Get(%s) returns %s, want %s", k, storable, v)

--- a/map_debug.go
+++ b/map_debug.go
@@ -536,12 +536,12 @@ func validMapHkeyElements(
 			// Verify element
 			computedSize, maxDigestLevel, err := validSingleElement(storage, db, tic, hip, se, hkeys)
 			if err != nil {
-				return 0, 0, fmt.Errorf("data slab %d %s", id, err)
+				return 0, 0, fmt.Errorf("data slab %d: %w", id, err)
 			}
 
 			// Verify digest level
 			if digestLevel >= maxDigestLevel {
-				return 0, 0, fmt.Errorf("data slab %d hkey elements %s digest level %d is wrong, want < %d",
+				return 0, 0, fmt.Errorf("data slab %d, hkey elements %s: digest level %d is wrong, want < %d",
 					id, elements, digestLevel, maxDigestLevel)
 			}
 
@@ -587,7 +587,7 @@ func validMapSingleElements(
 		// Verify element
 		computedSize, maxDigestLevel, err := validSingleElement(storage, db, tic, hip, e, hkeyPrefixes)
 		if err != nil {
-			return 0, 0, fmt.Errorf("data slab %d %s", id, err)
+			return 0, 0, fmt.Errorf("data slab %d: %w", id, err)
 		}
 
 		// Verify element size is <= inline size
@@ -634,12 +634,12 @@ func validSingleElement(
 	// Verify key
 	kv, err := e.key.StoredValue(storage)
 	if err != nil {
-		return 0, 0, fmt.Errorf("element %s key can't be converted to value, %s", e, err)
+		return 0, 0, fmt.Errorf("element %s key can't be converted to value: %w", e, err)
 	}
 
 	err = ValidValue(kv, nil, tic, hip)
 	if err != nil {
-		return 0, 0, fmt.Errorf("element %s key isn't valid, %s", e, err)
+		return 0, 0, fmt.Errorf("element %s key isn't valid: %w", e, err)
 	}
 
 	// Verify value pointer
@@ -650,12 +650,12 @@ func validSingleElement(
 	// Verify value
 	vv, err := e.value.StoredValue(storage)
 	if err != nil {
-		return 0, 0, fmt.Errorf("element %s value can't be converted to value, %s", e, err)
+		return 0, 0, fmt.Errorf("element %s value can't be converted to value: %w", e, err)
 	}
 
 	err = ValidValue(vv, nil, tic, hip)
 	if err != nil {
-		return 0, 0, fmt.Errorf("element %s value isn't valid, %s", e, err)
+		return 0, 0, fmt.Errorf("element %s value isn't valid: %w", e, err)
 	}
 
 	// Verify size
@@ -778,7 +778,7 @@ func validMapSlabSerialization(
 		// Compare slabs
 		err = mapDataSlabEqual(dataSlab, decodedDataSlab, storage, cborDecMode, cborEncMode, decodeStorable, decodeTypeInfo)
 		if err != nil {
-			return fmt.Errorf("data slab %d round-trip serialization failed: %s", id, err)
+			return fmt.Errorf("data slab %d round-trip serialization failed: %w", id, err)
 		}
 
 		return nil
@@ -797,7 +797,7 @@ func validMapSlabSerialization(
 	// Compare slabs
 	err = mapMetaDataSlabEqual(metaSlab, decodedMetaSlab)
 	if err != nil {
-		return fmt.Errorf("metadata slab %d round-trip serialization failed: %s", id, err)
+		return fmt.Errorf("metadata slab %d round-trip serialization failed: %w", id, err)
 	}
 
 	for _, h := range metaSlab.childrenHeaders {


### PR DESCRIPTION
## Description

The wrapping-formatting using `%w` allows the caller of the validation functions to use `errors.As`.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
