### PR TITLE
Use custom comparator when comparing values, don't assume deep equality

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"reflect"
 	"testing"
 	"time"
 
@@ -3104,5 +3105,8 @@ func validArraySerialization(array *Array, storage *PersistentSlabStorage) error
 		storage.cborEncMode,
 		storage.DecodeStorable,
 		storage.DecodeTypeInfo,
+		func(a, b Storable) bool {
+			return reflect.DeepEqual(a, b)
+		},
 	)
 }

--- a/map_test.go
+++ b/map_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -2929,7 +2930,7 @@ func TestMapEncodeDecodeRandomData(t *testing.T) {
 	}
 	require.NoError(t, err)
 
-	err = ValidMapSerialization(m, storage.cborDecMode, storage.cborEncMode, storage.DecodeStorable, storage.DecodeTypeInfo)
+	err = validMapSerialization(m, storage)
 	if err != nil {
 		PrintMap(m)
 	}
@@ -3766,7 +3767,7 @@ func testPopulatedMapFromStorage(
 	rootID StorageID,
 	typeInfo TypeInfo,
 	digesterBuilder DigesterBuilder,
-	comparator Comparator,
+	comparator ValueComparator,
 	hip HashInputProvider,
 	sortedKeys []Value,
 	keyValues map[Value]Value,
@@ -3817,5 +3818,8 @@ func validMapSerialization(m *OrderedMap, storage *PersistentSlabStorage) error 
 		storage.cborEncMode,
 		storage.DecodeStorable,
 		storage.DecodeTypeInfo,
+		func(a, b Storable) bool {
+			return reflect.DeepEqual(a, b)
+		},
 	)
 }

--- a/value.go
+++ b/value.go
@@ -22,4 +22,6 @@ type Value interface {
 	Storable(SlabStorage, Address, uint64) (Storable, error)
 }
 
-type Comparator func(SlabStorage, Value, Storable) (bool, error)
+type ValueComparator func(SlabStorage, Value, Storable) (bool, error)
+
+type StorableComparator func(Storable, Storable) bool


### PR DESCRIPTION
## Description

Values (and keys) in arrays and maps may not always be deep equal in memory, so use a custom comparator to determine equality

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
