### PR TITLE
Add go 1.15.x to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x]
         
     steps:
     - name: Install Go


### PR DESCRIPTION
## Description

CI was only testing with go 1.16 and 1.17.

Resolve this by updating `go-version` to [1.15.x, 1.16.x, 1.17.x]

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
