### PR TITLE
Remove storage deltas map reset

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -524,8 +524,9 @@ func (s *PersistentSlabStorage) Commit() error {
 		// add to read cache
 		s.cache[id] = slab
 	}
-	// reset deltas
-	s.deltas = make(map[StorageID]Slab)
+
+	// Do NOT reset deltas because slabs with empty address are not saved.
+
 	return nil
 }
 
@@ -618,8 +619,8 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 		s.cache[id] = s.deltas[id]
 	}
 
-	// reset deltas
-	s.deltas = make(map[StorageID]Slab)
+	// Do NOT reset deltas because slabs with empty address are not saved.
+
 	return nil
 }
 


### PR DESCRIPTION
Closes #164 

## Description

Do NOT reset deltas map in storage during Commit() because
slabs with empty address are not saved.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
