### PR TITLE
Fix "data is too short" error on non-existent slab retrieval from storage

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -740,8 +740,8 @@ func (s *PersistentSlabStorage) Retrieve(id StorageID) (Slab, bool, error) {
 
 	// fetch from base storage last
 	data, ok, err := s.baseStorage.Retrieve(id)
-	if err != nil {
-		return nil, false, err
+	if !ok || err != nil {
+		return nil, ok, err
 	}
 	slab, err = DecodeSlab(id, data, s.cborDecMode, s.DecodeStorable, s.DecodeTypeInfo)
 	if err == nil {


### PR DESCRIPTION
Closes #170

## Description

When retrieving non-existent slab from storage, "data is too short" error is returned because found flag isn't checked and nil data is decoded.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
