### PR TITLE
Add partial deltas map reset during storage commit

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -599,8 +599,11 @@ func (s *PersistentSlabStorage) Commit() error {
 			if err != nil {
 				return err
 			}
+			// Deleted slabs are removed from deltas and added to read cache so that:
+			// 1. next read is from in-memory read cache
+			// 2. deleted slabs are not re-committed in next commit
+			s.cache[id] = nil
 			delete(s.deltas, id)
-			delete(s.cache, id)
 			continue
 		}
 
@@ -618,6 +621,9 @@ func (s *PersistentSlabStorage) Commit() error {
 
 		// add to read cache
 		s.cache[id] = slab
+		// It's safe to remove slab from deltas because
+		// iteration is on non-temp slabs and temp slabs
+		// are still in deltas.
 		delete(s.deltas, id)
 	}
 
@@ -700,8 +706,11 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 			if err != nil {
 				return err
 			}
+			// Deleted slabs are removed from deltas and added to read cache so that:
+			// 1. next read is from in-memory read cache
+			// 2. deleted slabs are not re-committed in next commit
+			s.cache[id] = nil
 			delete(s.deltas, id)
-			delete(s.cache, id)
 			continue
 		}
 
@@ -712,6 +721,9 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 		}
 
 		s.cache[id] = s.deltas[id]
+		// It's safe to remove slab from deltas because
+		// iteration is on non-temp slabs and temp slabs
+		// are still in deltas.
 		delete(s.deltas, id)
 	}
 
@@ -738,7 +750,7 @@ func (s *PersistentSlabStorage) Retrieve(id StorageID) (Slab, bool, error) {
 
 	// check the read cache next
 	if slab, ok := s.cache[id]; ok {
-		return slab, true, nil
+		return slab, slab != nil, nil
 	}
 
 	// fetch from base storage last

--- a/storage_test.go
+++ b/storage_test.go
@@ -101,13 +101,12 @@ func TestPersistentStorage(t *testing.T) {
 		err = storage.Remove(permStorageID)
 		require.NoError(t, err)
 
-		err = storage.Commit()
+		// Remove slab with temp storage id
+		err = storage.Remove(tempStorageID)
 		require.NoError(t, err)
 
-		// Slab with temp storage id is still cached in storage.
-		_, found, err = storage.Retrieve(tempStorageID)
+		err = storage.Commit()
 		require.NoError(t, err)
-		require.True(t, found)
 
 		// Slab with perm storage id is removed from base storage.
 		_, found, err = baseStorage.Retrieve(permStorageID)
@@ -119,10 +118,7 @@ func TestPersistentStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 
-		// Remove slab with temp storage id
-		err = storage.Remove(tempStorageID)
-		require.NoError(t, err)
-
+		// Slab with temp storage id is removed from cache in storage.
 		_, found, err = storage.Retrieve(tempStorageID)
 		require.NoError(t, err)
 		require.False(t, found)


### PR DESCRIPTION
Closes #168 

## Description

Previously committed slabs were not removed from deltas map, so they get committed again which is not efficient.

This PR removes committed slabs (perm slabs) from deltas map and only keeps temp slabs.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
