### PR TITLE
Fix NewMapFromBatchData from creating invalid tree during edge case

### DIFF
--- a/map.go
+++ b/map.go
@@ -4171,11 +4171,6 @@ func NewMapFromBatchData(
 	// Append last data slab to slabs
 	slabs = append(slabs, dataSlab)
 
-	if len(slabs) == 1 {
-		// root is data slab, adjust its size
-		dataSlab.header.size = dataSlab.header.size - mapDataSlabPrefixSize + mapRootDataSlabPrefixSize
-	}
-
 	for len(slabs) > 1 {
 
 		lastSlab := slabs[len(slabs)-1]
@@ -4209,6 +4204,12 @@ func NewMapFromBatchData(
 
 		// All slabs are within target size range.
 
+		if len(slabs) == 1 {
+			// This happens when there were exactly two slabs and
+			// last slab has merged with the first slab.
+			break
+		}
+
 		// Store all slabs
 		for _, slab := range slabs {
 			err = storage.Store(slab.ID(), slab)
@@ -4227,6 +4228,15 @@ func NewMapFromBatchData(
 
 	// found root slab
 	root := slabs[0]
+
+	// root is data slab, adjust its size
+	if root.IsData() {
+		dataSlab, ok := root.(*MapDataSlab)
+		if !ok {
+			return nil, NewSlabDataError(fmt.Errorf("slab isn't MapDataSlab"))
+		}
+		dataSlab.header.size = dataSlab.header.size - mapDataSlabPrefixSize + mapRootDataSlabPrefixSize
+	}
 
 	extraData := &MapExtraData{TypeInfo: typeInfo, Count: count, Seed: seed}
 


### PR DESCRIPTION
Closes #179 

## Description

NewMapFromBatchData creates an invalid tree with root metadata slab
referencing only one data slab, when all the following conditions are
met:

- exactly two data slabs created from batch process
- second slab underflows
- first slab can't lend enough elements to second slab without
underflowing

The problem doesn't happen if any of the above conditions are not met.
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
