### PR TITLE
Check found flag returned by SlabStorage.Retrieve

### DIFF
--- a/array.go
+++ b/array.go
@@ -2153,13 +2153,18 @@ func (a *Array) string(meta *ArrayMetaDataSlab) string {
 }
 
 func getArraySlab(storage SlabStorage, id StorageID) (ArraySlab, error) {
-	slab, _, err := storage.Retrieve(id)
-
-	if arraySlab, ok := slab.(ArraySlab); ok {
-		return arraySlab, nil
+	slab, found, err := storage.Retrieve(id)
+	if err != nil {
+		return nil, err
 	}
-
-	return nil, NewSlabNotFoundErrorf(id, "getArraySlab failed: %w", err)
+	if !found {
+		return nil, NewSlabNotFoundErrorf(id, "array slab not found")
+	}
+	arraySlab, ok := slab.(ArraySlab)
+	if !ok {
+		return nil, NewSlabDataErrorf("slab %d is not ArraySlab", id)
+	}
+	return arraySlab, nil
 }
 
 func firstArrayDataSlab(storage SlabStorage, slab ArraySlab) (ArraySlab, error) {


### PR DESCRIPTION
Closes #181 

## Description

Making sure found flag is checked when slabs are retrieved is good practice. The motivation to look for 
 this came from resolving issue #170.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
