### PR TITLE
Move code from ChildIDs() with ChildStorables()

### DIFF
--- a/array.go
+++ b/array.go
@@ -99,7 +99,6 @@ type ArrayMetaDataSlab struct {
 }
 
 var _ ArraySlab = &ArrayMetaDataSlab{}
-var _ MetaDataSlab = &ArrayMetaDataSlab{}
 
 func (a *ArrayMetaDataSlab) StoredValue(storage SlabStorage) (Value, error) {
 	if a.extraData == nil {
@@ -999,14 +998,11 @@ func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 }
 
 func (a *ArrayMetaDataSlab) ChildStorables() []Storable {
-	return nil
-}
 
-func (a *ArrayMetaDataSlab) ChildIDs() []StorageID {
-	childIDs := make([]StorageID, len(a.childrenHeaders))
+	childIDs := make([]Storable, len(a.childrenHeaders))
 
 	for i, h := range a.childrenHeaders {
-		childIDs[i] = h.id
+		childIDs[i] = StorageIDStorable(h.id)
 	}
 
 	return childIDs

--- a/map.go
+++ b/map.go
@@ -247,7 +247,6 @@ type MapMetaDataSlab struct {
 }
 
 var _ MapSlab = &MapMetaDataSlab{}
-var _ MetaDataSlab = &MapMetaDataSlab{}
 
 type MapSlab interface {
 	Slab
@@ -2651,14 +2650,10 @@ func (m *MapMetaDataSlab) StoredValue(storage SlabStorage) (Value, error) {
 }
 
 func (m *MapMetaDataSlab) ChildStorables() []Storable {
-	return nil
-}
-
-func (m *MapMetaDataSlab) ChildIDs() []StorageID {
-	childIDs := make([]StorageID, len(m.childrenHeaders))
+	childIDs := make([]Storable, len(m.childrenHeaders))
 
 	for i, h := range m.childrenHeaders {
-		childIDs[i] = h.id
+		childIDs[i] = StorageIDStorable(h.id)
 	}
 
 	return childIDs

--- a/slab.go
+++ b/slab.go
@@ -32,11 +32,6 @@ type Slab interface {
 	BorrowFromRight(Slab) error
 }
 
-type MetaDataSlab interface {
-	Slab
-	ChildIDs() []StorageID
-}
-
 // TODO: make it inline.
 func IsRootOfAnObject(slabData []byte) (bool, error) {
 	if len(slabData) < 2 {


### PR DESCRIPTION
Needed by PR #186

## Description

This helps PR #186 avoid creating false positives in slab health checks.

Removed ChildIDs() and move its code to ChildStorables().

ChildIDs() is only used for slab health check. This change simplifies code for slab health check.
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
