### PR TITLE
Speed up seed generation from 494 ns/op to 3 ns/op

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b
-	github.com/fxamacker/circlehash v0.0.2
+	github.com/fxamacker/circlehash v0.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/zeebo/blake3 v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b h1:85oJb8jRevEXzzY3jtDas1Y5qw9iqsbOhdc5lH86vHs=
 github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/circlehash v0.0.2 h1:69lo0MXfjBh4bHOtklI0rXTXj9FOiP949lW1YSWCNQE=
-github.com/fxamacker/circlehash v0.0.2/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
+github.com/fxamacker/circlehash v0.1.0 h1:wXK52nkcBzGM+FyYc3wFYshm+0523BfX7h1XsUJLl70=
+github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=


### PR DESCRIPTION
Closes #190

## Description

Use `circlehash.Hash64Uint64x2()` which accepts two uint64 values to hash.  This avoids the need to create a new 16-byte slice and concatenation.

This code block is eliminated:

```Go
sIDBytes := make([]byte, storageIDSize)
_, err = sID.ToRawBytes(sIDBytes)
require.NoError(b, err)
```

Benchmark comparison on Haswell CPU with Go 1.16.9:

```
name             old time/op    new time/op    delta
HashSeedBytes-4     494ns ± 1%       3ns ± 0%  -99.45%  (p=0.000 n=20+19)
```

Hash64Uint64x2() is compatible with Hash64() for 16-byte inputs (given same inputs, they produce identical digests).
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
