### PR TITLE
Fix NewMapFromBatchData potentially exceeding size

### DIFF
--- a/map.go
+++ b/map.go
@@ -4112,8 +4112,16 @@ func NewMapFromBatchData(
 
 		putDigester(digester)
 
+		elem, err := newSingleElement(storage, address, key, value)
+		if err != nil {
+			return nil, err
+		}
+
 		// Finalize data slab
-		if mapDataSlabPrefixSize+elements.Size() >= uint32(targetThreshold) {
+		currentSlabSize := mapDataSlabPrefixSize + elements.Size()
+		newElementSize := digestSize + elem.Size()
+		if currentSlabSize >= uint32(targetThreshold) ||
+			currentSlabSize+newElementSize > uint32(maxThreshold) {
 
 			// Generate storge id for next data slab
 			nextID, err := storage.GenerateStorageID(address)
@@ -4145,11 +4153,6 @@ func NewMapFromBatchData(
 				hkeys: make([]Digest, 0, defaultElementCountInSlab),
 				elems: make([]element, 0, defaultElementCountInSlab),
 			}
-		}
-
-		elem, err := newSingleElement(storage, address, key, value)
-		if err != nil {
-			return nil, err
 		}
 
 		elements.hkeys = append(elements.hkeys, hkey)


### PR DESCRIPTION
Closes #193

## Description
Fixed an edge-case bug in NewMapFromBatchData where slab size can be
larger than maxThreshold by up to 8 bytes.

This fix only addresses NewMapFromBatchData().

We may need to update MaxInlineElementSize and maxInlineMapElementSize
to eliminate the root cause.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
