### PR TITLE
Update fxamacker/cbor to newer version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onflow/atree
 go 1.15
 
 require (
-	github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b
+	github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41
 	github.com/fxamacker/circlehash v0.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/zeebo/blake3 v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b h1:85oJb8jRevEXzzY3jtDas1Y5qw9iqsbOhdc5lH86vHs=
-github.com/fxamacker/cbor/v2 v2.2.1-0.20210927235116-3d6d5d1de29b/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41 h1:adk2SdM72B9LVdNPVgLDO+UBdGW5JmDIJEdzlI2ZYC8=
+github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.1.0 h1:wXK52nkcBzGM+FyYc3wFYshm+0523BfX7h1XsUJLl70=
 github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Closes #200
Updates #183

## Description

Updated fxamacker/cbor to latest commit in feature/stream-mode branch.

Master branch is merged into feature/stream-mode branch with these changes:
- Feature: Allow decoding to struct field of interface type (fxamacker/cbor@4a03f1c00317e4dffdcb1c4b94dc8a6dc6f72c95)
- Updates to README.md and other docs
- Updates to CI

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
