### PR TITLE
Make OrderedMap.Has distinguish KeyNotFoundError

### DIFF
--- a/map.go
+++ b/map.go
@@ -3386,7 +3386,14 @@ func NewMapWithRootID(storage SlabStorage, rootID StorageID, digestBuilder Diges
 
 func (m *OrderedMap) Has(comparator ValueComparator, hip HashInputProvider, key Value) (bool, error) {
 	_, err := m.Get(comparator, hip, key)
-	return err == nil, nil
+	if err != nil {
+		var knf *KeyNotFoundError
+		if errors.As(err, &knf) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (m *OrderedMap) Get(comparator ValueComparator, hip HashInputProvider, key Value) (Storable, error) {


### PR DESCRIPTION
Closes #213 

## Description

Modify` OrderedMap.Has` to distinguish `KeyNotFoundError` from other errors.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
