### PR TITLE
Add more tests for storage

### DIFF
--- a/cmd/stress/main.go
+++ b/cmd/stress/main.go
@@ -101,7 +101,7 @@ func main() {
 		return
 	}
 
-	baseStorage := atree.NewInMemBaseStorage()
+	baseStorage := NewInMemBaseStorage()
 
 	storage := atree.NewPersistentSlabStorage(
 		baseStorage,

--- a/storage.go
+++ b/storage.go
@@ -40,28 +40,16 @@ type (
 	}
 )
 
-func (id StorageID) String() string {
-	return fmt.Sprintf(
-		"0x%x.%d",
-		binary.BigEndian.Uint64(id.Address[:]),
-		binary.BigEndian.Uint64(id.Index[:]),
-	)
-}
-
-func (id StorageID) AddressAsUint64() uint64 {
-	return binary.BigEndian.Uint64(id.Address[:])
-}
-
-func (id StorageID) IndexAsUint64() uint64 {
-	return binary.BigEndian.Uint64(id.Index[:])
-}
-
 var (
 	AddressUndefined      = Address{}
 	StorageIndexUndefined = StorageIndex{}
 	StorageIDUndefined    = StorageID{}
 )
 
+// Next returns new StorageIndex with index+1 value.
+// The caller is responsible for preventing overflow
+// by checking if the index value is valid before
+// calling this function.
 func (index StorageIndex) Next() StorageIndex {
 	i := binary.BigEndian.Uint64(index[:])
 
@@ -96,6 +84,22 @@ func (id StorageID) ToRawBytes(b []byte) (int, error) {
 	copy(b, id.Address[:])
 	copy(b[8:], id.Index[:])
 	return storageIDSize, nil
+}
+
+func (id StorageID) String() string {
+	return fmt.Sprintf(
+		"0x%x.%d",
+		binary.BigEndian.Uint64(id.Address[:]),
+		binary.BigEndian.Uint64(id.Index[:]),
+	)
+}
+
+func (id StorageID) AddressAsUint64() uint64 {
+	return binary.BigEndian.Uint64(id.Address[:])
+}
+
+func (id StorageID) IndexAsUint64() uint64 {
+	return binary.BigEndian.Uint64(id.Index[:])
 }
 
 func (id StorageID) Valid() error {
@@ -133,105 +137,6 @@ type BaseStorage interface {
 	SegmentCounts() int // number of segments stored in the storage
 	Size() int          // total byte size stored
 	BaseStorageUsageReporter
-}
-
-type InMemBaseStorage struct {
-	segments         map[StorageID][]byte
-	storageIndex     map[Address]StorageIndex
-	bytesRetrieved   int
-	bytesStored      int
-	segmentsReturned map[StorageID]struct{}
-	segmentsUpdated  map[StorageID]struct{}
-	segmentsTouched  map[StorageID]struct{}
-}
-
-var _ BaseStorage = &InMemBaseStorage{}
-
-func NewInMemBaseStorage() *InMemBaseStorage {
-	return NewInMemBaseStorageFromMap(
-		make(map[StorageID][]byte),
-	)
-}
-
-func NewInMemBaseStorageFromMap(segments map[StorageID][]byte) *InMemBaseStorage {
-	return &InMemBaseStorage{
-		segments:         segments,
-		storageIndex:     make(map[Address]StorageIndex),
-		segmentsReturned: make(map[StorageID]struct{}),
-		segmentsUpdated:  make(map[StorageID]struct{}),
-		segmentsTouched:  make(map[StorageID]struct{}),
-	}
-}
-
-func (s *InMemBaseStorage) Retrieve(id StorageID) ([]byte, bool, error) {
-	seg, ok := s.segments[id]
-	s.bytesRetrieved += len(seg)
-	s.segmentsReturned[id] = struct{}{}
-	s.segmentsTouched[id] = struct{}{}
-	return seg, ok, nil
-}
-
-func (s *InMemBaseStorage) Store(id StorageID, data []byte) error {
-	s.segments[id] = data
-	s.bytesStored += len(data)
-	s.segmentsUpdated[id] = struct{}{}
-	s.segmentsTouched[id] = struct{}{}
-	return nil
-}
-
-func (s *InMemBaseStorage) Remove(id StorageID) error {
-	s.segmentsUpdated[id] = struct{}{}
-	s.segmentsTouched[id] = struct{}{}
-	delete(s.segments, id)
-	return nil
-}
-
-func (s *InMemBaseStorage) GenerateStorageID(address Address) (StorageID, error) {
-	index := s.storageIndex[address]
-	nextIndex := index.Next()
-
-	s.storageIndex[address] = nextIndex
-	return NewStorageID(address, nextIndex), nil
-}
-
-func (s *InMemBaseStorage) SegmentCounts() int {
-	return len(s.segments)
-}
-
-func (s *InMemBaseStorage) Size() int {
-	total := 0
-	for _, seg := range s.segments {
-		total += len(seg)
-	}
-	return total
-}
-
-func (s *InMemBaseStorage) BytesRetrieved() int {
-	return s.bytesRetrieved
-}
-
-func (s *InMemBaseStorage) BytesStored() int {
-	return s.bytesStored
-}
-
-func (s *InMemBaseStorage) SegmentsReturned() int {
-	return len(s.segmentsReturned)
-}
-
-func (s *InMemBaseStorage) SegmentsUpdated() int {
-	return len(s.segmentsUpdated)
-}
-
-func (s *InMemBaseStorage) SegmentsTouched() int {
-	return len(s.segmentsTouched)
-}
-
-func (s *InMemBaseStorage) ResetReporter() {
-	s.bytesStored = 0
-	s.bytesRetrieved = 0
-	s.segmentsReturned = make(map[StorageID]struct{})
-	s.segmentsUpdated = make(map[StorageID]struct{})
-	s.segmentsTouched = make(map[StorageID]struct{})
 }
 
 type Ledger interface {


### PR DESCRIPTION
Closes #218

## Description

- Add tests to cover the non-error paths of atree storage code
- Moved InMemBaseStorage to test file because it's only used in tests
- Moved some code in storage.go

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
