### PR TITLE
Add CI for code coverage and update README

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
         run: go build ./...
 
       - name: Generate coverage report
-        run: go test -race -coverprofile=coverage.txt -covermode=atomic
+        run: go test -timeout 60m -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0  # use v2.1.0, we can manually update uploader version if needed

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,5 +30,5 @@ jobs:
         uses: codecov/codecov-action@v2.1.0  # use v2.1.0, we can manually update uploader version if needed
         with:
             files: ./coverage.txt
-            fail_ci_if_error: true # optional (default = false)
+            fail_ci_if_error: false # we can set this to true after "Could not find a repository" upload error is fixed
             verbose: true # optional (default = false)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,5 @@
 # coverage.yml  Generate and upload Go code coverage report to Codecov.
-# 2021-11-26    github.com/fxamacker    Created.
+# 2021-11-26    Created github.com/onflow/atree/.github/workflows/coverage.yml
 
 name: coverage
 on: [push, pull_request]
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v2.1.0  # use v2.1.0, we can manually update uploader version if needed
-          with:
+        with:
             files: ./coverage.txt
             fail_ci_if_error: true # optional (default = false)
             verbose: true # optional (default = false)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,6 @@
 # coverage.yml  Generate and upload Go code coverage report to Codecov.
-# 2021-11-26    Created github.com/onflow/atree/.github/workflows/coverage.yml
+# https://github.com/onflow/atree/blob/main/.github/workflows/coverage.yml
+# 2021-11-26    Created. 
 
 name: coverage
 on: [push, pull_request]

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,4 +31,5 @@ jobs:
         with:
             files: ./coverage.txt
             fail_ci_if_error: false # we can set this to true after "Could not find a repository" upload error is fixed
+            ignore: ./cmd
             verbose: true # optional (default = false)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,33 @@
+# coverage.yml  Generate and upload Go code coverage report to Codecov.
+# 2021-11-26    github.com/fxamacker    Created.
+
+name: coverage
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2  # allow GitHub to use latest v2.x of checkout
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-go@v2  # allow GitHub to use latest v2.x of setup-go
+        with:
+          go-version: '1.17.x'
+
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+
+      - name: Build project
+        run: go build ./...
+
+      - name: Generate coverage report
+        run: go test -race -coverprofile=coverage.txt -covermode=atomic
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v2.1.0  # use v2.1.0, we can manually update uploader version if needed
+          with:
+            files: ./coverage.txt
+            fail_ci_if_error: true # optional (default = false)
+            verbose: true # optional (default = false)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,5 +31,4 @@ jobs:
         with:
             files: ./coverage.txt
             fail_ci_if_error: false # we can set this to true after "Could not find a repository" upload error is fixed
-            ignore: ./cmd
             verbose: true # optional (default = false)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # Atree
 
+[![](https://github.com/onflow/atree/workflows/ci/badge.svg)](https://github.com/onflow/atree/actions?query=workflow%3Aci)
+[![](https://github.com/onflow/atree/workflows/linters/badge.svg)](https://github.com/onflow/atree/actions?query=workflow%3Alinters)
+[![CodeQL](https://github.com/onflow/atree/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/onflow/atree/actions/workflows/codeql-analysis.yml)
+[![](https://codecov.io/gh/onflow/atree/branch/main/graph/badge.svg)](https://codecov.io/gh/onflow/atree/branch/main)
+
+
 Atree provides scalable arrays and scalable ordered maps.  It is used by [Cadence](https://github.com/onflow/cadence) in the [Flow](https://github.com/onflow/flow-go) blockchain.
+
+## API Reference
+
+Atree's API is [documented](https://pkg.go.dev/github.com/onflow/atree#section-documentation) with godoc at pkg.go.dev and will be updated when new versions of Atree are tagged.  Additional documentation will be added as time allows.
+
+## Contributing
+
+If you would like to contribute to Cadence, have a look at the [contributing guide](https://github.com/onflow/atree/blob/main/CONTRIBUTING.md).
+
+Additionally, all non-error code paths must be covered by tests.  And pull requests should not lower the code coverage percent.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![](https://github.com/onflow/atree/workflows/ci/badge.svg)](https://github.com/onflow/atree/actions?query=workflow%3Aci)
 [![](https://github.com/onflow/atree/workflows/linters/badge.svg)](https://github.com/onflow/atree/actions?query=workflow%3Alinters)
 [![CodeQL](https://github.com/onflow/atree/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/onflow/atree/actions/workflows/codeql-analysis.yml)
-[![](https://codecov.io/gh/onflow/atree/branch/main/graph/badge.svg)](https://codecov.io/gh/onflow/atree/branch/main)
-
 
 Atree provides scalable arrays and scalable ordered maps.  It is used by [Cadence](https://github.com/onflow/cadence) in the [Flow](https://github.com/onflow/flow-go) blockchain.
 
@@ -14,7 +12,7 @@ Atree's API is [documented](https://pkg.go.dev/github.com/onflow/atree#section-d
 
 ## Contributing
 
-If you would like to contribute to Cadence, have a look at the [contributing guide](https://github.com/onflow/atree/blob/main/CONTRIBUTING.md).
+If you would like to contribute to Atree, have a look at the [contributing guide](https://github.com/onflow/atree/blob/main/CONTRIBUTING.md).
 
 Additionally, all non-error code paths must be covered by tests.  And pull requests should not lower the code coverage percent.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "cmd/"
+  - "logs/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 ignore:
-  - "cmd/"
+  - "cmd/**/*"
   - "logs/"


### PR DESCRIPTION
Closes #221

## Description

- add GitHub Actions (coverage.yml) to generate code coverage report and upload to Codecov
- update README to add badges for ci, linters, and codeql.
- update README to add API Reference section with link to online godoc
- update README to add Contributing section

## Caveats

Coverage reported by Go is around 81%, while Codecov reports roughly 10% lower.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 