### PR TITLE
Bump safer-golangci-lint.yml to 1.43.0

### DIFF
--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -28,10 +28,12 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.42.1 (September 29, 2021)
-#   - Bump golangci-lint to 1.42.1.
-#   - sha256(linux-amd64.tar.gz) is 214b093c15863430c4b66dd39df677dab6e38fc873ded147e331740d50eea51f
-#   - sha384(linux-amd64.tar.gz) is 80e7e4afb5a58985fdd2ee7c099086541bc41a46b59dac1ae04f73c25abeafe30e5cd91dd1a57dc754efaad779c849cb
+# Release v1.43.0 (Dec 5, 2021)
+#   - Bump Go to 1.17.x.
+#   - Bump golangci-lint to 1.43.0.
+#   - Checksum for golangci-lint-1.43.0-linux-amd64.tar.gz
+#     - SHA-256 is f3515cebec926257da703ba0a2b169e4a322c11dc31a8b4656b50a43e48877f4
+#     - SHA-384 is 0a5e9adc3cc93fbc2e3c8f4daee061e77407fe3e702001021ef03c8bdf39a81c36c42d35e8ba970f4f09db2279c881bf
 #
 name: linters
 
@@ -42,9 +44,9 @@ on:
     branches: [main, master]
 
 env:
-  GOLINTERS_VERSION: 1.42.1
+  GOLINTERS_VERSION: 1.43.0
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 80e7e4afb5a58985fdd2ee7c099086541bc41a46b59dac1ae04f73c25abeafe30e5cd91dd1a57dc754efaad779c849cb
+  GOLINTERS_TGZ_DGST: 0a5e9adc3cc93fbc2e3c8f4daee061e77407fe3e702001021ef03c8bdf39a81c36c42d35e8ba970f4f09db2279c881bf
   GOLINTERS_TIMEOUT: 5m
   OPENSSL_DGST_CMD: openssl dgst -sha384 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
@@ -62,7 +64,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.x
+          go-version: 1.17.x
                       
       - name: Install golangci-lint
         run: |


### PR DESCRIPTION
Closes #235.
Updates #230 but this is useful on its own.

## Description

Update safer.golangci-lint.yml (GitHub Actions workflow used for running lint checkers).

Changes in the yml:
- bump Go to 1.17.x
- bump [golangci-lint](https://github.com/golangci/golangci-lint) to 1.43.0

The bump in golangci-lint updates various lint checkers that it wraps to get bugfixes.  This new version is working fine on my open source projects.
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
