### PR TITLE
Add range iteration with Array.IterateRange

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -37,6 +37,39 @@ func (e *FatalError) Error() string {
 
 func (e *FatalError) Unwrap() error { return e.err }
 
+// SliceOutOfBoundsError is returned when index for array slice is out of bounds.
+type SliceOutOfBoundsError struct {
+	startIndex uint64
+	endIndex   uint64
+	min        uint64
+	max        uint64
+}
+
+// NewSliceOutOfBoundsError constructs a SliceOutOfBoundsError
+func NewSliceOutOfBoundsError(startIndex, endIndex, min, max uint64) *SliceOutOfBoundsError {
+	return &SliceOutOfBoundsError{startIndex: startIndex, endIndex: endIndex, min: min, max: max}
+}
+
+func (e *SliceOutOfBoundsError) Error() string {
+	return fmt.Sprintf("slice [%d:%d] is out of bounds with range %d-%d", e.startIndex, e.endIndex, e.min, e.max)
+}
+
+// InvalidSliceIndexError is returned when array slice index is invalid, such as startIndex > endIndex
+// This error can be returned even when startIndex and endIndex are both within bounds.
+type InvalidSliceIndexError struct {
+	startIndex uint64
+	endIndex   uint64
+}
+
+// NewInvalidSliceIndexError constructs an InvalidSliceIndexError
+func NewInvalidSliceIndexError(startIndex, endIndex uint64) *InvalidSliceIndexError {
+	return &InvalidSliceIndexError{startIndex: startIndex, endIndex: endIndex}
+}
+
+func (e *InvalidSliceIndexError) Error() string {
+	return fmt.Sprintf("invalid slice index: %d > %d", e.startIndex, e.endIndex)
+}
+
 // IndexOutOfBoundsError is returned when get, insert or delete operation is attempted on an array index which is out of bounds
 type IndexOutOfBoundsError struct {
 	index uint64


### PR DESCRIPTION
Closes #237

## Description

Add `Array.IterateRange` and `Array.RangeIterator` for range iteration with start index and end index.

Return `SliceOutOfBoundsError` when start index and/or end index is out of bounds.

Return `InvalidSliceIndexError` when start index > end index. This can happen even if range is within bounds.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
