### PR TITLE
Update CircleHash to newer version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Inspired by patterns used in modern variants of B+ Trees, Atree provides two typ
 
 - __Scalable Array Type (SAT)__ is a heterogeneous variable-size array, storing any type of values into a smaller ordered list of values and provides efficient functionality to lookup, insert and remove elements anywhere in the array.
 
-- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.  OMT uses [CircleHash64 with Deferred+Segmented BLAKE3 Digests](https://github.com/onflow/atree/edit/fxamacker/upgrade-circlehash/README.md#omt-uses-circlehash64-with-deferredsegmented-blake3-digests).
+- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.  OMT uses [CircleHash64 with Deferred+Segmented BLAKE3 Digests](#omt-uses-circlehash64-with-deferredsegmented-blake3-digests).
 
 ## Under the Hood
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/onflow/atree/ec159f3a81cbc6f1338f7f594987f483ddd1e0bd/files/logo.png" width="150"/>
+  <img src="https://user-images.githubusercontent.com/33205765/156051157-ebcd2b1d-97ae-4a65-800a-bcca2a12b27b.png" width="150"/>
 </p>
 
 <p align="center">
@@ -81,4 +81,3 @@ The Atree library is licensed under the terms of the Apache license. See [LICENS
 Logo is based on the artwork of Raisul Hadi licensed under Creative Commons.
 
 Copyright © 2021-2022 Dapper Labs, Inc.
-

--- a/README.md
+++ b/README.md
@@ -17,26 +17,7 @@ Inspired by patterns used in modern variants of B+ Trees, Atree provides two typ
 
 - __Scalable Array Type (SAT)__ is a heterogeneous variable-size array, storing any type of values into a smaller ordered list of values and provides efficient functionality to lookup, insert and remove elements anywhere in the array.
 
-- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.
-
-## OMT uses CircleHash64 with Deferred+Segmented BLAKE3 Digests
-
-Inputs hashed by OMT are typically short inputs (usually smaller than 128 bytes).  OMT uses state-of-the-art hash algorithms and a novel collision-handling design to balance speed, security, and storage space.
-
-|              | CircleHash64 🏅<br/>(seeded) | SipHash <br/>(seeded) | BLAKE3 🏅<br/>(crypto) | SHA3-256 <br/>(crypto) |
-|:-------------|:---:|:---:|:---:|:---:|
-| 4 bytes | 1.34 GB/s | 0.361 GB/s | 0.027 GB/s | 0.00491 GB/s |
-| 8 bytes | 2.70 GB/s | 0.642 GB/s | 0.106 GB/s | 0.00984 GB/s |
-| 16 bytes | 5.48 GB/s | 1.03 GB/s | 0.217 GB/s | 0.0197 GB/s |
-| 32 bytes | 8.01 GB/s | 1.46 GB/s | 0.462 GB/s | 0.0399 GB/s |
-| 64 bytes | 10.3 GB/s | 1.83 GB/s | 0.911 GB/s | 0.0812 GB/s |
-| 128 bytes | 12.8 GB/s | 2.09 GB/s | 1.03 GB/s | 0.172 GB/s |
-| 192 bytes | 14.2 GB/s | 2.17 GB/s | 1.04 GB/s | 0.158 GB/s |
-| 256 bytes | 15.0 GB/s | 2.22 GB/s | 1.06 GB/s | 0.219 GB/s |
-
-- Using Go 1.17.7, darwin_amd64, i7-1068N7 CPU.
-- Results are from `go test -bench=. -count=20` and `benchstat`.
-- Some hash libraries have slowdowns at some larger sizes.
+- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.  OMT uses [CircleHash64 with Deferred+Segmented BLAKE3 Digests](https://github.com/onflow/atree/edit/fxamacker/upgrade-circlehash/README.md#omt-uses-circlehash64-with-deferredsegmented-blake3-digests).
 
 ## Under the Hood
 
@@ -63,6 +44,25 @@ In order to minimize the number of bytes touched after each operation, Atree use
 **5** - Atree Ordered Map uses a collision handling design that is performant and resilient against hash-flooding attacks. It uses multi-level hashing that combines a fast 64-bit non-cryptographic hash with a 256-bit cryptographic hash. For speed, the cryptographic hash is only computed if there's a collision. For smaller storage size, the digests are divided into 64-bit segments with only the minimum required being stored. Collisions that cannot be resolved by hashes will eventually use linear lookup, but that is very unlikely as it would require collisions on two different hashes (CircleHash64 + BLAKE3) from the same input.
 
 **6** - Forwarding data slab pointers are used to make sequential iterations more efficient.
+
+## OMT uses CircleHash64 with Deferred+Segmented BLAKE3 Digests
+
+Inputs hashed by OMT are typically short inputs (usually smaller than 128 bytes).  OMT uses state-of-the-art hash algorithms and a novel collision-handling design to balance speed, security, and storage space.
+
+|              | CircleHash64 🏅<br/>(seeded) | SipHash <br/>(seeded) | BLAKE3 🏅<br/>(crypto) | SHA3-256 <br/>(crypto) |
+|:-------------|:---:|:---:|:---:|:---:|
+| 4 bytes | 1.34 GB/s | 0.361 GB/s | 0.027 GB/s | 0.00491 GB/s |
+| 8 bytes | 2.70 GB/s | 0.642 GB/s | 0.106 GB/s | 0.00984 GB/s |
+| 16 bytes | 5.48 GB/s | 1.03 GB/s | 0.217 GB/s | 0.0197 GB/s |
+| 32 bytes | 8.01 GB/s | 1.46 GB/s | 0.462 GB/s | 0.0399 GB/s |
+| 64 bytes | 10.3 GB/s | 1.83 GB/s | 0.911 GB/s | 0.0812 GB/s |
+| 128 bytes | 12.8 GB/s | 2.09 GB/s | 1.03 GB/s | 0.172 GB/s |
+| 192 bytes | 14.2 GB/s | 2.17 GB/s | 1.04 GB/s | 0.158 GB/s |
+| 256 bytes | 15.0 GB/s | 2.22 GB/s | 1.06 GB/s | 0.219 GB/s |
+
+- Using Go 1.17.7, darwin_amd64, i7-1068N7 CPU.
+- Results are from `go test -bench=. -count=20` and `benchstat`.
+- Some hash libraries have slowdowns at some larger sizes.
 
 ## API Reference
 

--- a/README.md
+++ b/README.md
@@ -11,19 +11,40 @@
 
 # Atree 
 
-*Atree* provides scalable arrays and scalable ordered maps.  It is used by [Cadence](https://github.com/onflow/cadence) in the [Flow](https://github.com/onflow/flow-go) blockchain.
+__Atree__ provides scalable arrays and scalable ordered maps.  It is used by [Cadence](https://github.com/onflow/cadence) in the [Flow](https://github.com/onflow/flow-go) blockchain.
 
-Inspired by patterns used in modern variants of B+ Trees, Atree provides two types of data structures: Ordered Map Type (OMT) and Scalable Array Type (SAT).
+Inspired by patterns used in modern variants of B+ Trees, Atree provides two types of data structures: Scalable Array Type (SAT) and Ordered Map Type (OMT).
 
-Scalable Array Type (SAT) is a heterogeneous variable-size array, storing any type of values into a smaller ordered list of values and provides efficient functionality to lookup, insert and remove elements anywhere in the array.
+- __Scalable Array Type (SAT)__ is a heterogeneous variable-size array, storing any type of values into a smaller ordered list of values and provides efficient functionality to lookup, insert and remove elements anywhere in the array.
 
-Ordered Map Type (OMT) is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.
+- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.
 
-Under the hood, Atree uses some new type of high-fanout B+ tree and some heuristics to balance the trade-off between latency of operations and the number of reads and writes.
+## OMT uses CircleHash64 with Deferred+Segmented BLAKE3 Digests
+
+Inputs hashed by OMT are typically short inputs (usually smaller than 128 bytes).  OMT uses state-of-the-art hash algorithms and a novel collision-handling design to balance speed, security, and storage space.
+
+|              | CircleHash64 🏅<br/>(seeded) | SipHash <br/>(seeded) | BLAKE3 🏅<br/>(crypto) | SHA3-256 <br/>(crypto) |
+|:-------------|:---:|:---:|:---:|:---:|
+| 4 bytes | 1.34 GB/s | 0.361 GB/s | 0.027 GB/s | 0.00491 GB/s |
+| 8 bytes | 2.70 GB/s | 0.642 GB/s | 0.106 GB/s | 0.00984 GB/s |
+| 16 bytes | 5.48 GB/s | 1.03 GB/s | 0.217 GB/s | 0.0197 GB/s |
+| 32 bytes | 8.01 GB/s | 1.46 GB/s | 0.462 GB/s | 0.0399 GB/s |
+| 64 bytes | 10.3 GB/s | 1.83 GB/s | 0.911 GB/s | 0.0812 GB/s |
+| 128 bytes | 12.8 GB/s | 2.09 GB/s | 1.03 GB/s | 0.172 GB/s |
+| 192 bytes | 14.2 GB/s | 2.17 GB/s | 1.04 GB/s | 0.158 GB/s |
+| 256 bytes | 15.0 GB/s | 2.22 GB/s | 1.06 GB/s | 0.219 GB/s |
+
+- Using Go 1.17.7, darwin_amd64, i7-1068N7 CPU.
+- Results are from `go test -bench=. -count=20` and `benchstat`.
+- Some hash libraries have slowdowns at some larger sizes.
+
+## Under the Hood
+
+Atree uses new types of high-fanout B+ tree and some heuristics to balance the trade-off between latency of operations and the number of reads and writes.
 
 Each data structure holds the data as several relatively fixed-size segments of bytes (also known as slabs) forming a tree and as the size of data structures grows or shrinks, it adjusts the number of segments used. After each operation, Atree tries to keep segment size within an acceptable size range by merging segments when needed (lower than min threshold) and splitting large-size slabs (above max threshold) or moving some values to neighbouring segments (rebalancing). For ordered maps and arrays with small number of elements, Atree is designed to have a very minimal overhead in compare to less scalable standard array and ordermaps (using a single data segment at start). 
 
-In order to minimize the number of bytes touched after each operation, Atree uses a deterministic greedy approach ("Optimistic Encasing Algorithm") to postpone merge, split and rebalancing the tree as much as possible. in other words, It tolerates the tree to get unbalanced with the cost of keeping some space for future insertions or growing a segment a bit larger than what it should be which would minimize the number of segments (and bytes) that are touched at each operation.
+In order to minimize the number of bytes touched after each operation, Atree uses a deterministic greedy approach ("Optimistic Encasing Algorithm") to postpone merge, split and rebalancing the tree as much as possible. In other words, it tolerates the tree to get unbalanced with the cost of keeping some space for future insertions or growing a segment a bit larger than what it should be which would minimize the number of segments (and bytes) that are touched at each operation.
 
 ## Example 
 
@@ -59,5 +80,5 @@ The Atree library is licensed under the terms of the Apache license. See [LICENS
 
 Logo is based on the artwork of Raisul Hadi licensed under Creative Commons.
 
-Copyright © 2021 Dapper Labs, Inc.
+Copyright © 2021-2022 Dapper Labs, Inc.
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41
-	github.com/fxamacker/circlehash v0.1.0
+	github.com/fxamacker/circlehash v0.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/zeebo/blake3 v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41 h1:adk2SdM72B9LVdNPVgLDO+UBdGW5JmDIJEdzlI2ZYC8=
 github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/circlehash v0.1.0 h1:wXK52nkcBzGM+FyYc3wFYshm+0523BfX7h1XsUJLl70=
-github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
+github.com/fxamacker/circlehash v0.2.0 h1:IFBaLm/4NChHcIptw/A7Ha/DemC8M9jGbjWzsN6XDrc=
+github.com/fxamacker/circlehash v0.2.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=


### PR DESCRIPTION
## Description

- Update to newer version of CircleHash64 which is faster and 100% backward compatible.
- Update README to add section "OMT uses CircleHash64 with Deferred+Segmented BLAKE3 Digests"
    - Show comparison of CircleHash64 vs SipHash, and BLAKE3 vs SHA3-256 to help explain our algorithm choices

Closes #243 

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
