### PR TITLE
Add regression tests for BLAKE3

### DIFF
--- a/blake3_regression_test.go
+++ b/blake3_regression_test.go
@@ -1,0 +1,187 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright 2022 Dapper Labs, Inc.
+ * Copyright 2021 Faye Amacker
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ------------------------------------------------------------------------
+ *
+ * This file is a modified subset of circlehash64_test.go copied from
+ *
+ *     https://github.com/fxamacker/circlehash
+ *
+ * Expected digest values and some names of functions and variables were
+ * modified to check BLAKE3 instead of CircleHash64. Seeds were removed.
+ * Test data size was increased from 16KiB to 64KiB to be able to
+ * verify code paths in BLAKE3 that might be optimized for larger
+ * input sizes.
+ */
+
+package atree
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	blake3zeebo "github.com/zeebo/blake3"
+	blake3luke "lukechampine.com/blake3"
+)
+
+// Compatibility tests check 131072 BLAKE3 digests produced by hashing
+// input sizes of various lengths (0-64KiB bytes) and then hashing the
+// equivalent "concatenated" BLAKE3 digests with SHA-512.
+//
+// Additionally, each 131072 BLAKE3 digest is compared between
+// github.com/zeebo/blake3 and lukechampine.com/blake3 libraries.
+//
+// Tests use SHA-512 digest to represent many BLAKE3 digests because SHA-512 is
+// included in Go and is available in many languages. This approach eliminates
+// the need to store and separately compare 131072 BLAKE3 digests.
+//
+// Tests for input sizes greater than 128 bytes can help BLAKE3 implementations
+// that rely on input size to determine which optimized code path to execute.
+
+var countBLAKE3 uint64 // count calls to Hash256 (doesn't double count zeebo & luke)
+
+func TestBLAKE3Regression(t *testing.T) {
+
+	// Create 64 KiB of test data from SHA-512 using the simplest
+	// form of SHA-512 feedback loop (nothing-up-my-sleeve).
+	data := nonUniformBytes64KiB()
+
+	// Verify BLAKE3 digests produced from hashing portions of
+	// data. Input sizes vary from 1 to 64KiB bytes by varing
+	// starting pos and ending pos.
+	// We use 64KiB because BLAKE3 implementations can have
+	// special optimizations for large data sizes and we
+	// want to verify digests produced by all their code paths.
+
+	testCases := []struct {
+		name                     string
+		wantSHA512VaringStartPos []byte
+		wantSHA512VaringEndPos   []byte
+	}{
+		{
+			"noseed",
+			decodeHexOrPanic("8030991ad495219d9fdd346fab027d1f453887a3d157fa4bfcd67a4b213a6817817817f43779ddd2b274a243d8a942728141b72d8bcde9d49fdfc5d9a823983f"),
+			decodeHexOrPanic("a8a7c00fce5a6adc774e8bf5ff45b40f382954c932288d0d79d589755b094f8db6fa16780e2ca9a1434b56a0716a25fb7eecb545f1c6f7599b08214fd1b59a8a"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			h := sha512.New()
+
+			// test 65536 BLAKE3 digests by varying start pos of data
+			checksumVaryingStartPosNoSeed(t, h, data)
+			got := h.Sum(nil)
+			if !bytes.Equal(got, tc.wantSHA512VaringStartPos) {
+				t.Errorf("checksumVaryingStartPos(nonuniform16KiB) = 0x%0128x; want 0x%0128x",
+					got,
+					tc.wantSHA512VaringStartPos)
+			}
+
+			h.Reset()
+
+			// test another 65536 BLAKE3 digests by varying end pos of data
+			checksumVaryingEndPosNoSeed(t, h, data)
+			got = h.Sum(nil)
+			if !bytes.Equal(got, tc.wantSHA512VaringEndPos) {
+				t.Errorf("checksumVaryingEndPos(nonuniform16KiB) = 0x%0128x; want 0x%0128x",
+					got,
+					tc.wantSHA512VaringEndPos)
+			}
+		})
+	}
+
+	require.Equal(t, uint64(131072), countBLAKE3)
+}
+
+// checksumVaryingStartPosNoSeed updates cryptoHash512 with
+// concatenated BLAKE3 digests.
+func checksumVaryingStartPosNoSeed(t *testing.T, cryptoHash512 hash.Hash, data []byte) {
+
+	// vary the starting position and keep the ending position
+	for i := uint64(0); i < uint64(len(data)); i++ {
+
+		digest := countedAndComparedBLAKE3(t, data[i:])
+
+		// Feed digest into SHA-512, SHA3-512, etc.
+		cryptoHash512.Write(digest[:])
+	}
+}
+
+// checksumVaryingEndPosNoSeed updates cryptoHash512 with
+// concatenated BLAKE3 digests.
+func checksumVaryingEndPosNoSeed(t *testing.T, cryptoHash512 hash.Hash, data []byte) {
+
+	// keep the starting position at zero and increment the length
+	for i := uint64(1); i <= uint64(len(data)); i++ {
+		digest := countedAndComparedBLAKE3(t, data[:i])
+
+		// Feed digest into SHA-512, SHA3-512, etc.
+		cryptoHash512.Write(digest[:])
+	}
+}
+
+// nonUniformBytes64KiB returns 64KiB bytes of non-uniform bytes
+// produced from SHA-512 in a feedback loop. SHA-512 is used instead
+// of SHAKE-256 XOF or a stream cipher because SHA-512 is bundled with
+// Go and is available in most languages. One reason a simple PRNG
+// isn't used here is because different implementions in different
+// programming languages are sometimes incompatible due to errors
+// (like SplitMix64). SHA-512 will be compatible everywhere.
+// For BLAKE3, we should use at least 64KiB because implementations
+// might use optimized paths for various large input sizes.
+func nonUniformBytes64KiB() []byte {
+	b := make([]byte, 0, 1024*64)
+
+	// Each input to SHA-512 is 64 bytes. First 64-byte input is zeros.
+	// The next input to SHA-512 is the 64-byte output of SHA-512.
+	// Each output of SHA-512 is appended to the returned byte slice.
+	d := make([]byte, 64)
+	for i := 0; i < 1024; i++ {
+		a := sha512.Sum512(d)
+		d = a[:]
+		b = append(b, d...)
+	}
+
+	return b
+}
+
+func countedAndComparedBLAKE3(t *testing.T, data []byte) [32]byte {
+	digest := blake3zeebo.Sum256(data)
+	digest2 := blake3luke.Sum256(data)
+	if digest != digest2 {
+		t.Errorf("BLAKE3zeebo 0x%x != BLAKE3luke 0x%x", digest, digest2)
+	}
+
+	countBLAKE3++
+	return digest
+}
+
+func decodeHexOrPanic(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic(fmt.Sprintf("bad hex string: %s", err))
+	}
+	return b
+}

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/fxamacker/circlehash v0.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/zeebo/blake3 v0.2.0
+	lukechampine.com/blake3 v1.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41 h1:adk2SdM72B9
 github.com/fxamacker/cbor/v2 v2.3.1-0.20211029162100-5d5d7c3edd41/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/fxamacker/circlehash v0.1.0 h1:wXK52nkcBzGM+FyYc3wFYshm+0523BfX7h1XsUJLl70=
 github.com/fxamacker/circlehash v0.1.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
+github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
+github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
@@ -24,3 +26,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+lukechampine.com/blake3 v1.1.7 h1:GgRMhmdsuK8+ii6UZFDL8Nb+VyMwadAgcJyfYHxG6n0=
+lukechampine.com/blake3 v1.1.7/go.mod h1:tkKEOtDkNtklkXtLNEOGNq5tcV90tJiA1vAA12R78LA=


### PR DESCRIPTION
## Description

Add tests to verify 131107 BLAKE3 digests to detect compatibility regressions using input data sizes up to 102400 bytes.

Also compare 131107 BLAKE3 digests from two libraries to confirm they match
- github.com/zeebo/blake3
- lukchampine/blake3

The test file is a modified subset of circlehash64_test.go copied from [fxamacker/circlehash](https://github.com/fxamacker/circlehash).

The test uses SHA-512 to hash all 35 BLAKE3 digests that should match what is published by official BLAKE3 team.  This allows us to compare one hardcoded value instead of 35.

An additional 131072 BLAKE3 digests are verified using a more random input data set than is used by the BLAKE3 team.

Closes #246 
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
