### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,16 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        go-version: [1.15.x, 1.16.x, 1.17.x]
+        go-version: [1.16.x, 1.17.x, 1.18.x]
         
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
         
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 1
         

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/atree
 
-go 1.15
+go 1.17
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.1-0.20220314011055-12f5cb4b5eb0
@@ -8,4 +8,14 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/zeebo/blake3 v0.2.2
 	lukechampine.com/blake3 v1.1.7
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
+	golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
## Description

- Bump actions/checkout to v3.
- Bump actions/setup-go to v3.
- Add Go 1.18, remove Go 1.16 (test latest 3 versions).

fixes: https://github.com/onflow/atree/issues/230

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
