### PR TITLE
Change digest level from int to uint

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -36,15 +36,15 @@ type DigesterBuilder interface {
 type Digester interface {
 	// DigestPrefix returns digests before specified level.
 	// If level is 0, DigestPrefix returns nil.
-	DigestPrefix(level int) ([]Digest, error)
+	DigestPrefix(level uint) ([]Digest, error)
 
 	// Digest returns digest at specified level.
-	Digest(level int) (Digest, error)
+	Digest(level uint) (Digest, error)
 
 	// Reset data for reuse
 	Reset()
 
-	Levels() int
+	Levels() uint
 }
 
 type basicDigesterBuilder struct {
@@ -122,13 +122,13 @@ func (bd *basicDigester) Reset() {
 	bd.msg = nil
 }
 
-func (bd *basicDigester) DigestPrefix(level int) ([]Digest, error) {
+func (bd *basicDigester) DigestPrefix(level uint) ([]Digest, error) {
 	if level > bd.Levels() {
 		// level must be [0, bd.Levels()] (inclusive) for prefix
 		return nil, NewHashLevelErrorf("cannot get digest < level %d: level must be [0, %d]", level, bd.Levels())
 	}
 	var prefix []Digest
-	for i := 0; i < level; i++ {
+	for i := uint(0); i < level; i++ {
 		d, err := bd.Digest(i)
 		if err != nil {
 			return nil, err
@@ -138,7 +138,7 @@ func (bd *basicDigester) DigestPrefix(level int) ([]Digest, error) {
 	return prefix, nil
 }
 
-func (bd *basicDigester) Digest(level int) (Digest, error) {
+func (bd *basicDigester) Digest(level uint) (Digest, error) {
 	if level >= bd.Levels() {
 		// level must be [0, bd.Levels()) (not inclusive) for digest
 		return 0, NewHashLevelErrorf("cannot get digest at level %d: level must be [0, %d)", level, bd.Levels())
@@ -163,6 +163,6 @@ func (bd *basicDigester) Digest(level int) (Digest, error) {
 	}
 }
 
-func (bd *basicDigester) Levels() int {
+func (bd *basicDigester) Levels() uint {
 	return 4
 }

--- a/map_debug.go
+++ b/map_debug.go
@@ -474,7 +474,7 @@ func validMapElements(
 	hip HashInputProvider,
 	id StorageID,
 	elements elements,
-	digestLevel int,
+	digestLevel uint,
 	hkeyPrefixes []Digest,
 ) (
 	elementCount uint64,
@@ -499,7 +499,7 @@ func validMapHkeyElements(
 	hip HashInputProvider,
 	id StorageID,
 	elements *hkeyElements,
-	digestLevel int,
+	digestLevel uint,
 	hkeyPrefixes []Digest,
 ) (
 	elementCount uint64,
@@ -627,7 +627,7 @@ func validMapSingleElements(
 	hip HashInputProvider,
 	id StorageID,
 	elements *singleElements,
-	digestLevel int,
+	digestLevel uint,
 	hkeyPrefixes []Digest,
 ) (
 	elementCount uint64,
@@ -683,7 +683,7 @@ func validSingleElement(
 	digests []Digest,
 ) (
 	size uint32,
-	digestMaxLevel int,
+	digestMaxLevel uint,
 	err error,
 ) {
 

--- a/map_test.go
+++ b/map_test.go
@@ -51,22 +51,22 @@ func (h *mockDigesterBuilder) Digest(hip HashInputProvider, value Value) (Digest
 	return args.Get(0).(mockDigester), nil
 }
 
-func (d mockDigester) DigestPrefix(level int) ([]Digest, error) {
-	if level > len(d.d) {
+func (d mockDigester) DigestPrefix(level uint) ([]Digest, error) {
+	if level > uint(len(d.d)) {
 		return nil, fmt.Errorf("digest level %d out of bounds", level)
 	}
 	return d.d[:level], nil
 }
 
-func (d mockDigester) Digest(level int) (Digest, error) {
-	if level >= len(d.d) {
+func (d mockDigester) Digest(level uint) (Digest, error) {
+	if level >= uint(len(d.d)) {
 		return 0, fmt.Errorf("digest level %d out of bounds", level)
 	}
 	return d.d[level], nil
 }
 
-func (d mockDigester) Levels() int {
-	return len(d.d)
+func (d mockDigester) Levels() uint {
+	return uint(len(d.d))
 }
 
 func (d mockDigester) Reset() {}


### PR DESCRIPTION
## Description

Digest level must be equal to larger than 0.  By changing its data type from int to uint, we can avoid the possiblity of negative value.

Closes #256 
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
