### PR TITLE
Remove default permissions from top level of workflows, add workflow_dispatch, etc.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,45 @@
 # GitHub Actions - CI for Go to build & test.
-# Copied from https://github.com/fxamacker/cbor/workflows/ci.yml
-# 2021-08-06:  speed up CI by removing go 1.14, go 1.15, and windows-latest
+# Based on copy of https://github.com/fxamacker/cbor/workflows/ci.yml
 name: ci
-on: [push]
+
+# Remove default permissions at top level and grant in jobs.
+permissions: {}
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    - 'feature/**'
+    - 'v**'  
+  pull_request:
+    branches:
+    - main
+    - 'feature/**'
+    - 'v**'
+
+    
 jobs:
 
   # Test on various OS with default Go version. 
   tests:
     name: Test on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
+    
+    permissions:
+      contents: read
+    
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
-        go-version: [1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.16, 1.17, 1.18]
         
     steps:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
+        check-latest: true
         
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,40 +18,39 @@ on:
     - 'feature/**'
     - 'v**'
 
-    
 jobs:
 
   # Test on various OS with default Go version. 
   tests:
     name: Test on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
-    
+
     permissions:
       contents: read
-    
+
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
         go-version: [1.16, 1.17, 1.18]
-        
+
     steps:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go-version }}
         check-latest: true
-        
+
     - name: Checkout code
       uses: actions/checkout@v3
       with:
         fetch-depth: 1
-        
+
     - name: Get dependencies
       run: go get -v -t -d ./...
-      
+
     - name: Build project
       run: go build ./...
-      
+
     - name: Run tests
       run: |
         go version

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,11 +1,19 @@
 name: "CodeQL"
 
+# Remove default permissions at top level and grant in jobs.
+permissions: {}
+
 on:
   push:
-    branches: [ main ]
+    branches:
+    - main
+    - 'feature/**'
+    - 'v**'  
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches:
+    - main
+    - 'feature/**'
+    - 'v**'
   schedule:
     - cron: '30 5 * * 4'
 
@@ -26,16 +34,22 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      
+    - name: Set up Go 1.17
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.17'
+        check-latest: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
@@ -46,4 +60,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,21 +1,29 @@
 # coverage.yml  Generate and upload Go code coverage report to Codecov.
 # https://github.com/onflow/atree/blob/main/.github/workflows/coverage.yml
-# 2021-11-26    Created. 
 
 name: coverage
+
+# Remove permissions from top level and grant inside jobs.
+permissions: {}
+
 on: [push, pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v2  # allow GitHub to use latest v2.x of checkout
+      - uses: actions/checkout@v3  # allow GitHub to use latest v2.x of checkout
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v2  # allow GitHub to use latest v2.x of setup-go
+      - uses: actions/setup-go@v3  # allow GitHub to use latest v2.x of setup-go
         with:
-          go-version: '1.17.x'
+          go-version: '1.17'
+          check-latest: true
 
       - name: Get dependencies
         run: go get -v -t -d ./...

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@
 
 name: coverage
 
-# Remove permissions from top level and grant inside jobs.
+# Remove permissions from top level and grant in jobs.
 permissions: {}
 
 on: [push, pull_request]

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -37,6 +37,9 @@
 #
 name: linters
 
+# Remove permissions from top level and grant in jobs.
+permissions: {}
+
 on:  
   pull_request:
     types: [opened, synchronize, closed]
@@ -50,22 +53,27 @@ env:
   GOLINTERS_TIMEOUT: 5m
   OPENSSL_DGST_CMD: openssl dgst -sha384 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
-  
+
 jobs:
   main:
     name: Lint
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
-        
+
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
-                      
+          go-version: 1.17
+          check-latest: true
+
       - name: Install golangci-lint
         run: |
           GOLINTERS_URL_PREFIX="https://github.com/golangci/golangci-lint/releases/download/v${GOLINTERS_VERSION}/"
@@ -88,7 +96,7 @@ jobs:
           tar --no-same-owner -xzf "${GOLINTERS_TGZ}" --strip-components 1
           install golangci-lint $(go env GOPATH)/bin
         shell: bash
-          
+
       # Run required linters enabled in .golangci.yml (or default linters if yml doesn't exist)     
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run --timeout="${GOLINTERS_TIMEOUT}"

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -8,48 +8,44 @@
 #
 # 100% of the script for downloading, installing, and running golangci-lint
 # is embedded in this file.  The embedded SHA384 digest is used to verify the 
-# downloaded golangci-lint tarball (golangci-lint-1.42.0-linux-amd64.tar.gz). 
-#
-# Why?
-#   1. Avoid downloading and executing unverified wrapper scripts or actions each time a workflow runs.
-#      See https://www.securityweek.com/codecov-bash-uploader-dev-tool-compromised-supply-chain-hack
-#   2. Use embedded SHA384 instead of downloading CHECKSUM because CHECKSUM file isn't digitally signed.
-#   3. Use openssl instead of sha256sum because it's easier to change hash algo to BLAKE2s, SHA3-256, etc.
-#   4. Use binary instead of building from source because it's probably easier to detect backdoors in one binary 
-#      than all the combined source code of dozens of linters and all their required 3rd-party packages.
+# downloaded golangci-lint tarball (golangci-lint-1.46.2-linux-amd64.tar.gz). 
 #
 # To use:
 #   Step 1. Copy this file into [github_repo]/.github/workflows/
 #   Step 2. There's no step 2 if you like the default settings.
 #
-# You can create and use a config file (.golangci.yml) as described in golangci-lint docs.
+# Create and use a config file (.golangci.yml) as described in golangci-lint docs.
 #
 # To use a newer version of golangci-lint, change these values:
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.43.0 (Dec 5, 2021)
-#   - Bump Go to 1.17.x.
-#   - Bump golangci-lint to 1.43.0.
-#   - Checksum for golangci-lint-1.43.0-linux-amd64.tar.gz
-#     - SHA-256 is f3515cebec926257da703ba0a2b169e4a322c11dc31a8b4656b50a43e48877f4
-#     - SHA-384 is 0a5e9adc3cc93fbc2e3c8f4daee061e77407fe3e702001021ef03c8bdf39a81c36c42d35e8ba970f4f09db2279c881bf
+# Release v1.46.2 (May 19, 2022)
+#   - actions/setup-go uses check-latest: true
+#   - Remove default permissions at top level and grant only read permission in the job.
+#   - Add workflow_dispatch.
+#   - Tidy some comments.
+#   - Bump golangci-lint to 1.46.2.
+#   - Checksum for golangci-lint-1.46.2-linux-amd64.tar.gz
+#     - SHA-256 is 242cd4f2d6ac0556e315192e8555784d13da5d1874e51304711570769c4f2b9b
+#     - SHA-384 is 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
 #
 name: linters
 
-# Remove permissions from top level and grant in jobs.
+# Remove default permissions and grant only what is required in each job.
 permissions: {}
 
-on:  
+on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, closed]
   push:
     branches: [main, master]
 
 env:
-  GOLINTERS_VERSION: 1.43.0
+  GOLINTERS_VERSION: 1.46.2
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 0a5e9adc3cc93fbc2e3c8f4daee061e77407fe3e702001021ef03c8bdf39a81c36c42d35e8ba970f4f09db2279c881bf
+  GOLINTERS_TGZ_DGST: 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
   GOLINTERS_TIMEOUT: 5m
   OPENSSL_DGST_CMD: openssl dgst -sha384 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
@@ -58,10 +54,8 @@ jobs:
   main:
     name: Lint
     runs-on: ubuntu-latest
-
     permissions:
       contents: read
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Inspired by patterns used in modern variants of B+ Trees, Atree provides two typ
 
 - __Scalable Array Type (SAT)__ is a heterogeneous variable-size array, storing any type of values into a smaller ordered list of values and provides efficient functionality to lookup, insert and remove elements anywhere in the array.
 
-- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.  OMT uses [CircleHash64 with Deferred+Segmented BLAKE3 Digests](#omt-uses-circlehash64-with-deferredsegmented-blake3-digests).
+- __Ordered Map Type (OMT)__ is an ordered map of key-value pairs; keys can be any hashable type and values can be any serializable value type. It supports heterogeneous key or value types (e.g. first key storing a boolean and second key storing a string). OMT keeps values in specific sorted order and operations are deterministic so the state of the segments after a sequence of operations are always unique.  OMT uses [CircleHash64f with Deferred+Segmented BLAKE3 Digests](#omt-uses-circlehash64-with-deferredsegmented-blake3-digests).
 
 ## Under the Hood
 
@@ -41,15 +41,15 @@ In order to minimize the number of bytes touched after each operation, Atree use
 
 **4** - Extremely large objects are handled by storing them as an external data slab and using a pointer to the external data slab. This way we maintain the size requirements of slabs and preserve the performance of atree. In the future work external data slabs can be broken into a sequence of smaller size slabs. 
 
-**5** - Atree Ordered Map uses a collision handling design that is performant and resilient against hash-flooding attacks. It uses multi-level hashing that combines a fast 64-bit non-cryptographic hash with a 256-bit cryptographic hash. For speed, the cryptographic hash is only computed if there's a collision. For smaller storage size, the digests are divided into 64-bit segments with only the minimum required being stored. Collisions that cannot be resolved by hashes will eventually use linear lookup, but that is very unlikely as it would require collisions on two different hashes (CircleHash64 + BLAKE3) from the same input.
+**5** - Atree Ordered Map uses a collision handling design that is performant and resilient against hash-flooding attacks. It uses multi-level hashing that combines a fast 64-bit non-cryptographic hash with a 256-bit cryptographic hash. For speed, the cryptographic hash is only computed if there's a collision. For smaller storage size, the digests are divided into 64-bit segments with only the minimum required being stored. Collisions that cannot be resolved by hashes will eventually use linear lookup, but that is very unlikely as it would require collisions on two different hashes (CircleHash64f + BLAKE3) from the same input.
 
 **6** - Forwarding data slab pointers are used to make sequential iterations more efficient.
 
-## OMT uses CircleHash64 with Deferred+Segmented BLAKE3 Digests
+## OMT uses CircleHash64f with Deferred+Segmented BLAKE3 Digests
 
 Inputs hashed by OMT are typically short inputs (usually smaller than 128 bytes).  OMT uses state-of-the-art hash algorithms and a novel collision-handling design to balance speed, security, and storage space.
 
-|              | CircleHash64 🏅<br/>(seeded) | SipHash <br/>(seeded) | BLAKE3 🏅<br/>(crypto) | SHA3-256 <br/>(crypto) |
+|              | CircleHash64f 🏅<br/>(seeded) | SipHash <br/>(seeded) | BLAKE3 🏅<br/>(crypto) | SHA3-256 <br/>(crypto) |
 |:-------------|:---:|:---:|:---:|:---:|
 | 4 bytes | 1.34 GB/s | 0.361 GB/s | 0.027 GB/s | 0.00491 GB/s |
 | 8 bytes | 2.70 GB/s | 0.642 GB/s | 0.106 GB/s | 0.00984 GB/s |


### PR DESCRIPTION
## Description

- Remove default permissions at top level.
- Grant read permission in jobs.
- Bump actions/checkout from 2 to 3.
- Bump actions/setup-go from 2 to 3.
- Use check-latest feature of setup-go.
- Add workflow_dispatch trigger.
- Add dependabot.yml.
- Bump safer-golangci-lint to 1.46.2.
- Update README to avoid ambiguity between CircleHasht64f, CircleHash64fx, etc.

Closes #261
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
