### PR TITLE
Add PersistentSlabStorage.Deltas()

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -914,12 +914,13 @@ func (s *PersistentSlabStorage) Count() int {
 	return s.baseStorage.SegmentCounts()
 }
 
-// Deltas returns number of uncommitted slabs.
-func (s *PersistentSlabStorage) Deltas(excludeTempAddress bool) uint {
-	if !excludeTempAddress {
-		return uint(len(s.deltas))
-	}
+// Deltas returns number of uncommitted slabs, including slabs with temp addresses.
+func (s *PersistentSlabStorage) Deltas() uint {
+	return uint(len(s.deltas))
+}
 
+// DeltasWithoutTempAddresses returns number of uncommitted slabs, excluding slabs with temp addresses.
+func (s *PersistentSlabStorage) DeltasWithoutTempAddresses() uint {
 	deltas := uint(0)
 	for k := range s.deltas {
 		// exclude the ones that are not owned by accounts

--- a/storage.go
+++ b/storage.go
@@ -909,3 +909,19 @@ func (s *PersistentSlabStorage) Remove(id StorageID) error {
 func (s *PersistentSlabStorage) Count() int {
 	return s.baseStorage.SegmentCounts()
 }
+
+// Deltas returns number of uncommitted slabs.
+func (s *PersistentSlabStorage) Deltas(excludeTempAddress bool) uint {
+	if !excludeTempAddress {
+		return uint(len(s.deltas))
+	}
+
+	deltas := uint(0)
+	for k := range s.deltas {
+		// exclude the ones that are not owned by accounts
+		if k.Address != AddressUndefined {
+			deltas++
+		}
+	}
+	return deltas
+}

--- a/storage.go
+++ b/storage.go
@@ -729,6 +729,10 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 	// this part ensures the keys are sorted so commit operation is deterministic
 	keysWithOwners := s.sortedOwnedDeltaKeys()
 
+	if len(keysWithOwners) == 0 {
+		return nil
+	}
+
 	// construct job queue
 	jobs := make(chan StorageID, len(keysWithOwners))
 	for _, id := range keysWithOwners {

--- a/storage_test.go
+++ b/storage_test.go
@@ -580,8 +580,8 @@ func TestPersistentStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 
-		require.Equal(t, uint(0), storage.Deltas(true))
-		require.Equal(t, uint(0), storage.Deltas(false))
+		require.Equal(t, uint(0), storage.DeltasWithoutTempAddresses())
+		require.Equal(t, uint(0), storage.Deltas())
 	})
 
 	t.Run("temp address", func(t *testing.T) {
@@ -605,14 +605,14 @@ func TestPersistentStorage(t *testing.T) {
 		err = storage.Store(permStorageID, slab2)
 		require.NoError(t, err)
 
-		require.Equal(t, uint(1), storage.Deltas(true))
-		require.Equal(t, uint(2), storage.Deltas(false))
+		require.Equal(t, uint(1), storage.DeltasWithoutTempAddresses())
+		require.Equal(t, uint(2), storage.Deltas())
 
 		err = storage.Commit()
 		require.NoError(t, err)
 
-		require.Equal(t, uint(0), storage.Deltas(true))
-		require.Equal(t, uint(1), storage.Deltas(false))
+		require.Equal(t, uint(0), storage.DeltasWithoutTempAddresses())
+		require.Equal(t, uint(1), storage.Deltas())
 
 		// Slab with temp storage id is NOT persisted in base storage.
 		_, found, err := baseStorage.Retrieve(tempStorageID)
@@ -660,8 +660,8 @@ func TestPersistentStorage(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, found)
 
-		require.Equal(t, uint(0), storage.Deltas(true))
-		require.Equal(t, uint(1), storage.Deltas(false))
+		require.Equal(t, uint(0), storage.DeltasWithoutTempAddresses())
+		require.Equal(t, uint(1), storage.Deltas())
 	})
 
 	t.Run("commit", func(t *testing.T) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -579,6 +579,9 @@ func TestPersistentStorage(t *testing.T) {
 		_, found, err = storage.Retrieve(permStorageID)
 		require.NoError(t, err)
 		require.False(t, found)
+
+		require.Equal(t, uint(0), storage.Deltas(true))
+		require.Equal(t, uint(0), storage.Deltas(false))
 	})
 
 	t.Run("temp address", func(t *testing.T) {
@@ -602,8 +605,14 @@ func TestPersistentStorage(t *testing.T) {
 		err = storage.Store(permStorageID, slab2)
 		require.NoError(t, err)
 
+		require.Equal(t, uint(1), storage.Deltas(true))
+		require.Equal(t, uint(2), storage.Deltas(false))
+
 		err = storage.Commit()
 		require.NoError(t, err)
+
+		require.Equal(t, uint(0), storage.Deltas(true))
+		require.Equal(t, uint(1), storage.Deltas(false))
 
 		// Slab with temp storage id is NOT persisted in base storage.
 		_, found, err := baseStorage.Retrieve(tempStorageID)
@@ -650,6 +659,9 @@ func TestPersistentStorage(t *testing.T) {
 		_, found, err = storage.Retrieve(tempStorageID)
 		require.NoError(t, err)
 		require.False(t, found)
+
+		require.Equal(t, uint(0), storage.Deltas(true))
+		require.Equal(t, uint(1), storage.Deltas(false))
 	})
 
 	t.Run("commit", func(t *testing.T) {


### PR DESCRIPTION
## Description

Add `PersistentSlabStorage.Deltas()` to return number of uncommitted slabs.  It can be used by Cadence for memory metering.

Closes #263 

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
