### PR TITLE
Limit number of goroutines in FastCommit()

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -733,6 +733,11 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 		return nil
 	}
 
+	// limit the number of workers to the number of keys
+	if numWorkers > len(keysWithOwners) {
+		numWorkers = len(keysWithOwners)
+	}
+
 	// construct job queue
 	jobs := make(chan StorageID, len(keysWithOwners))
 	for _, id := range keysWithOwners {


### PR DESCRIPTION
Partially improves: #267

## Description
Currently, `PersistentSlabStorage.FastCommit()` creates goroutines during runtime.

This may be a bit inefficient in cases where there is a small number of keys and a high number of CPUs.  For now, simply upper-bound the number of goroutines by the number keys.
______

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
