### PR TITLE
Bump go to 1.19 and actions/checkout to v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,12 +33,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
-    - name: Set up Go 1.17
+    - name: Set up Go 1.19
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.19'
         check-latest: true
 
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
## Description

In codeql-analysis.yml:
- bump go from 1.17 to 1.19
- bump actions/checkout from v2 to v3
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
