### PR TITLE
Reformat with gofmt 1.19

### DIFF
--- a/array.go
+++ b/array.go
@@ -211,16 +211,15 @@ func newArrayExtraDataFromData(
 //
 // Header (2 bytes):
 //
-//     +-----------------------------+--------------------------+
-//     | extra data version (1 byte) | extra data flag (1 byte) |
-//     +-----------------------------+--------------------------+
+//	+-----------------------------+--------------------------+
+//	| extra data version (1 byte) | extra data flag (1 byte) |
+//	+-----------------------------+--------------------------+
 //
 // Content (for now):
 //
-//   CBOR encoded array of extra data: cborArray{type info}
+//	CBOR encoded array of extra data: cborArray{type info}
 //
 // Extra data flag is the same as the slab flag it prepends.
-//
 func (a *ArrayExtraData) Encode(enc *Encoder, flag byte) error {
 	// Encode version
 	enc.Scratch[0] = 0
@@ -353,17 +352,16 @@ func newArrayDataSlabFromData(
 //
 // Header (18 bytes):
 //
-//   +-------------------------------+--------------------------------+
-//   | slab version + flag (2 bytes) | next sib storage ID (16 bytes) |
-//   +-------------------------------+--------------------------------+
+//	+-------------------------------+--------------------------------+
+//	| slab version + flag (2 bytes) | next sib storage ID (16 bytes) |
+//	+-------------------------------+--------------------------------+
 //
 // Content (for now):
 //
-//   CBOR encoded array of elements
+//	CBOR encoded array of elements
 //
 // If this is root slab, extra data section is prepended to slab's encoded content.
 // See ArrayExtraData.Encode() for extra data section format.
-//
 func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 
 	flag := maskArrayData
@@ -705,7 +703,6 @@ func (a *ArrayDataSlab) IsFull() bool {
 // IsUnderflow returns the number of bytes needed for the data slab
 // to reach the min threshold.
 // Returns true if the min threshold has not been reached yet.
-//
 func (a *ArrayDataSlab) IsUnderflow() (uint32, bool) {
 	if uint32(minThreshold) > a.header.size {
 		return uint32(minThreshold) - a.header.size, true
@@ -715,7 +712,6 @@ func (a *ArrayDataSlab) IsUnderflow() (uint32, bool) {
 
 // CanLendToLeft returns true if elements on the left of the slab could be removed
 // so that the slab still stores more than the min threshold.
-//
 func (a *ArrayDataSlab) CanLendToLeft(size uint32) bool {
 	if len(a.elements) < 2 {
 		return false
@@ -738,7 +734,6 @@ func (a *ArrayDataSlab) CanLendToLeft(size uint32) bool {
 
 // CanLendToRight returns true if elements on the right of the slab could be removed
 // so that the slab still stores more than the min threshold.
-//
 func (a *ArrayDataSlab) CanLendToRight(size uint32) bool {
 	if len(a.elements) < 2 {
 		return false
@@ -924,17 +919,16 @@ func newArrayMetaDataSlabFromData(
 //
 // Header (4 bytes):
 //
-//     +-----------------------+--------------------+------------------------------+
-//     | slab version (1 byte) | slab flag (1 byte) | child header count (2 bytes) |
-//     +-----------------------+--------------------+------------------------------+
+//	+-----------------------+--------------------+------------------------------+
+//	| slab version (1 byte) | slab flag (1 byte) | child header count (2 bytes) |
+//	+-----------------------+--------------------+------------------------------+
 //
 // Content (n * 16 bytes):
 //
-// 	[[count, size, storage id], ...]
+//	[[count, size, storage id], ...]
 //
 // If this is root slab, extra data section is prepended to slab's encoded content.
 // See ArrayExtraData.Encode() for extra data section format.
-//
 func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 
 	flag := maskArrayMeta
@@ -1271,7 +1265,6 @@ func (a *ArrayMetaDataSlab) SplitChildSlab(storage SlabStorage, child ArraySlab,
 // +-----------------------+-----------------------+----------------------+-----------------------+
 // | right sib can lend    | rebalance with right  | rebalance with right | rebalance with bigger |
 // +-----------------------+-----------------------+----------------------+-----------------------+
-//
 func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 	storage SlabStorage,
 	child ArraySlab,

--- a/basicarray_benchmark_test.go
+++ b/basicarray_benchmark_test.go
@@ -27,7 +27,9 @@ import (
 
 // GENERAL COMMENT:
 // running this test with
-//   go test -bench=.  -benchmem
+//
+//	go test -bench=.  -benchmem
+//
 // will track the heap allocations for the Benchmarks
 func BenchmarkXSBasicArray(b *testing.B) { benchmarkBasicArray(b, 10, 100) }
 

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -46,10 +46,11 @@ func (v Uint64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (a
 }
 
 // Encode encodes UInt64Value as
-// cbor.Tag{
-//		Number:  cborTagUInt64Value,
-//		Content: uint64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt64Value,
+//			Content: uint64(v),
+//	}
 func (v Uint64Value) Encode(enc *atree.Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number

--- a/cmd/stress/storable.go
+++ b/cmd/stress/storable.go
@@ -55,10 +55,11 @@ func (v Uint8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (at
 }
 
 // Encode encodes UInt8Value as
-// cbor.Tag{
-//		Number:  cborTagUInt8Value,
-//		Content: uint8(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt8Value,
+//			Content: uint8(v),
+//	}
 func (v Uint8Value) Encode(enc *atree.Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -183,10 +184,11 @@ func (v Uint32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (a
 }
 
 // Encode encodes UInt32Value as
-// cbor.Tag{
-//		Number:  cborTagUInt32Value,
-//		Content: uint32(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt32Value,
+//			Content: uint32(v),
+//	}
 func (v Uint32Value) Encode(enc *atree.Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -259,10 +261,11 @@ func (v Uint64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (a
 }
 
 // Encode encodes UInt64Value as
-// cbor.Tag{
-//		Number:  cborTagUInt64Value,
-//		Content: uint64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt64Value,
+//			Content: uint64(v),
+//	}
 func (v Uint64Value) Encode(enc *atree.Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number

--- a/map.go
+++ b/map.go
@@ -364,16 +364,15 @@ func newMapExtraDataFromData(
 //
 // Header (2 bytes):
 //
-//     +-----------------------------+--------------------------+
-//     | extra data version (1 byte) | extra data flag (1 byte) |
-//     +-----------------------------+--------------------------+
+//	+-----------------------------+--------------------------+
+//	| extra data version (1 byte) | extra data flag (1 byte) |
+//	+-----------------------------+--------------------------+
 //
 // Content (for now):
 //
-//   CBOR encoded array of extra data
+//	CBOR encoded array of extra data
 //
 // Extra data flag is the same as the slab flag it prepends.
-//
 func (m *MapExtraData) Encode(enc *Encoder, version byte, flag byte) error {
 
 	// Encode version
@@ -513,8 +512,7 @@ func newSingleElementFromData(cborDec *cbor.StreamDecoder, decodeStorable Storab
 
 // Encode encodes singleElement to the given encoder.
 //
-//   CBOR encoded array of 2 elements (key, value).
-//
+//	CBOR encoded array of 2 elements (key, value).
 func (e *singleElement) Encode(enc *Encoder) error {
 
 	// Encode CBOR array head for 2 elements
@@ -551,8 +549,9 @@ func (e *singleElement) Get(storage SlabStorage, _ Digester, _ uint, _ Digest, c
 
 // Set updates value if key matches, otherwise returns inlineCollisionGroup with existing and new elements.
 // NOTE: Existing key needs to be rehashed because we store minimum digest for non-collision element.
-//       Rehashing only happens when we create new inlineCollisionGroup.
-//       Adding new element to existing inlineCollisionGroup doesn't require rehashing.
+//
+//	Rehashing only happens when we create new inlineCollisionGroup.
+//	Adding new element to existing inlineCollisionGroup doesn't require rehashing.
 func (e *singleElement) Set(storage SlabStorage, address Address, b DigesterBuilder, digester Digester, level uint, hkey Digest, comparator ValueComparator, hip HashInputProvider, key Value, value Value) (element, MapValue, error) {
 
 	equal, err := comparator(storage, key, e.key)
@@ -668,8 +667,7 @@ func newInlineCollisionGroupFromData(cborDec *cbor.StreamDecoder, decodeStorable
 
 // Encode encodes inlineCollisionGroup to the given encoder.
 //
-//   CBOR tag (number: CBORTagInlineCollisionGroup, content: elements)
-//
+//	CBOR tag (number: CBORTagInlineCollisionGroup, content: elements)
 func (e *inlineCollisionGroup) Encode(enc *Encoder) error {
 
 	err := enc.CBOR.EncodeRawBytes([]byte{
@@ -832,8 +830,7 @@ func newExternalCollisionGroupFromData(cborDec *cbor.StreamDecoder, decodeStorab
 
 // Encode encodes externalCollisionGroup to the given encoder.
 //
-//   CBOR tag (number: CBORTagExternalCollisionGroup, content: storage ID)
-//
+//	CBOR tag (number: CBORTagExternalCollisionGroup, content: storage ID)
 func (e *externalCollisionGroup) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number CBORTagExternalCollisionGroup
@@ -1099,11 +1096,11 @@ func newHkeyElementsWithElement(level uint, hkey Digest, elem element) *hkeyElem
 
 // Encode encodes hkeyElements to the given encoder.
 //
-//   CBOR encoded array [
-//       0: level (uint)
-//       1: hkeys (byte string)
-//       2: elements (array)
-//   ]
+//	CBOR encoded array [
+//	    0: level (uint)
+//	    1: hkeys (byte string)
+//	    2: elements (array)
+//	]
 func (e *hkeyElements) Encode(enc *Encoder) error {
 
 	if e.level > maxDigestLevel {
@@ -1724,11 +1721,11 @@ func newSingleElementsWithElement(level uint, elem *singleElement) *singleElemen
 
 // Encode encodes singleElements to the given encoder.
 //
-//   CBOR encoded array [
-//       0: level (uint)
-//       1: hkeys (0 length byte string)
-//       2: elements (array)
-//   ]
+//	CBOR encoded array [
+//	    0: level (uint)
+//	    1: hkeys (0 length byte string)
+//	    2: elements (array)
+//	]
 func (e *singleElements) Encode(enc *Encoder) error {
 
 	if e.level > maxDigestLevel {
@@ -2048,17 +2045,16 @@ func newMapDataSlabFromData(
 //
 // Header (18 bytes):
 //
-//   +-------------------------------+--------------------------------+
-//   | slab version + flag (2 bytes) | next sib storage ID (16 bytes) |
-//   +-------------------------------+--------------------------------+
+//	+-------------------------------+--------------------------------+
+//	| slab version + flag (2 bytes) | next sib storage ID (16 bytes) |
+//	+-------------------------------+--------------------------------+
 //
 // Content (for now):
 //
-//   CBOR array of 3 elements (level, hkeys, elements)
+//	CBOR array of 3 elements (level, hkeys, elements)
 //
 // If this is root slab, extra data section is prepended to slab's encoded content.
 // See MapExtraData.Encode() for extra data section format.
-//
 func (m *MapDataSlab) Encode(enc *Encoder) error {
 
 	version := byte(0)
@@ -2356,7 +2352,6 @@ func (m *MapDataSlab) IsFull() bool {
 // IsUnderflow returns the number of bytes needed for the data slab
 // to reach the min threshold.
 // Returns true if the min threshold has not been reached yet.
-//
 func (m *MapDataSlab) IsUnderflow() (uint32, bool) {
 	if m.anySize {
 		return 0, false
@@ -2369,7 +2364,6 @@ func (m *MapDataSlab) IsUnderflow() (uint32, bool) {
 
 // CanLendToLeft returns true if elements on the left of the slab could be removed
 // so that the slab still stores more than the min threshold.
-//
 func (m *MapDataSlab) CanLendToLeft(size uint32) bool {
 	if m.anySize {
 		return false
@@ -2379,7 +2373,6 @@ func (m *MapDataSlab) CanLendToLeft(size uint32) bool {
 
 // CanLendToRight returns true if elements on the right of the slab could be removed
 // so that the slab still stores more than the min threshold.
-//
 func (m *MapDataSlab) CanLendToRight(size uint32) bool {
 	if m.anySize {
 		return false
@@ -2540,17 +2533,16 @@ func newMapMetaDataSlabFromData(
 //
 // Header (4 bytes):
 //
-//     +-----------------------+--------------------+------------------------------+
-//     | slab version (1 byte) | slab flag (1 byte) | child header count (2 bytes) |
-//     +-----------------------+--------------------+------------------------------+
+//	+-----------------------+--------------------+------------------------------+
+//	| slab version (1 byte) | slab flag (1 byte) | child header count (2 bytes) |
+//	+-----------------------+--------------------+------------------------------+
 //
 // Content (n * 28 bytes):
 //
-// 	[[storage id, first key, size], ...]
+//	[[storage id, first key, size], ...]
 //
 // If this is root slab, extra data section is prepended to slab's encoded content.
 // See MapExtraData.Encode() for extra data section format.
-//
 func (m *MapMetaDataSlab) Encode(enc *Encoder) error {
 
 	version := byte(0)

--- a/storable.go
+++ b/storable.go
@@ -69,10 +69,11 @@ func (v StorageIDStorable) StoredValue(storage SlabStorage) (Value, error) {
 }
 
 // Encode encodes StorageIDStorable as
-// cbor.Tag{
-//		Number:  cborTagStorageID,
-//		Content: byte(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagStorageID,
+//			Content: byte(v),
+//	}
 func (v StorageIDStorable) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -23,7 +23,6 @@ package atree
 // so this won't be needed, but during the refactor we have the need to store
 // other non-dictionary values (e.g. strings, integers, etc.) directly in accounts
 // (i.e. directly in slabs aka registers)
-//
 type StorableSlab struct {
 	StorageID StorageID
 	Storable  Storable

--- a/storable_test.go
+++ b/storable_test.go
@@ -58,10 +58,11 @@ func (v Uint8Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, erro
 }
 
 // Encode encodes UInt8Value as
-// cbor.Tag{
-//		Number:  cborTagUInt8Value,
-//		Content: uint8(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt8Value,
+//			Content: uint8(v),
+//	}
 func (v Uint8Value) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -184,10 +185,11 @@ func (v Uint32Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 }
 
 // Encode encodes UInt32Value as
-// cbor.Tag{
-//		Number:  cborTagUInt32Value,
-//		Content: uint32(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt32Value,
+//			Content: uint32(v),
+//	}
 func (v Uint32Value) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
@@ -259,10 +261,11 @@ func (v Uint64Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 }
 
 // Encode encodes UInt64Value as
-// cbor.Tag{
-//		Number:  cborTagUInt64Value,
-//		Content: uint64(v),
-// }
+//
+//	cbor.Tag{
+//			Number:  cborTagUInt64Value,
+//			Content: uint64(v),
+//	}
 func (v Uint64Value) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number


### PR DESCRIPTION
## Description

Go 1.19 changed how comments are formatted by `gofmt`.  This PR reformats comments to match `gofmt` in Go 1.19.

Updates #281 
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
