### PR TITLE
Bump safer-golangci-lint to 1.50.1

### DIFF
--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -6,9 +6,15 @@
 #
 # safer-golangci-lint.yml
 #
+# This workflow downloads, verifies, and runs golangci-lint in a
+# deterministic, reviewable, and safe manner.
+#
 # 100% of the script for downloading, installing, and running golangci-lint
-# is embedded in this file.  The embedded SHA384 digest is used to verify the 
-# downloaded golangci-lint tarball (golangci-lint-1.46.2-linux-amd64.tar.gz). 
+# is embedded in this file. The embedded SHA-256 digest is used to verify the
+# downloaded golangci-lint tarball (golangci-lint-1.xx.x-linux-amd64.tar.gz).
+#
+# The embedded SHA-256 digest matches golangci-lint-1.xx.x-checksums.txt at
+# https://github.com/golangci/golangci-lint/releases
 #
 # To use:
 #   Step 1. Copy this file into [github_repo]/.github/workflows/
@@ -20,15 +26,13 @@
 #   1. GOLINTERS_VERSION
 #   2. GOLINTERS_TGZ_DGST
 #
-# Release v1.46.2 (May 19, 2022)
-#   - actions/setup-go uses check-latest: true
-#   - Remove default permissions at top level and grant only read permission in the job.
-#   - Add workflow_dispatch.
-#   - Tidy some comments.
-#   - Bump golangci-lint to 1.46.2.
-#   - Checksum for golangci-lint-1.46.2-linux-amd64.tar.gz
-#     - SHA-256 is 242cd4f2d6ac0556e315192e8555784d13da5d1874e51304711570769c4f2b9b
-#     - SHA-384 is 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
+# Release v1.50.1 (October 22, 2022)
+#   - Bump golangci-lint to 1.50.1
+#   - Bump Go to 1.19 (latest version of 1.19.x because check-latest: true).
+#   - Hash of golangci-lint-1.50.1-linux-amd64.tar.gz
+#     - SHA-256: 4ba1dc9dbdf05b7bdc6f0e04bdfe6f63aa70576f51817be1b2540bbce017b69a
+#                This SHA-256 digest matches golangci-lint-1.50.1-checksums.txt at
+#                https://github.com/golangci/golangci-lint/releases
 #
 name: linters
 
@@ -43,11 +47,12 @@ on:
     branches: [main, master]
 
 env:
-  GOLINTERS_VERSION: 1.46.2
+  GO_VERSION: 1.19
+  GOLINTERS_VERSION: 1.50.1
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: 60ade95e447f8c9a2dfc507c271c2ff41a0e0856f077bf2f734bcd80dd8268addf8cf1625c3e47a6516eb14f23423315
-  GOLINTERS_TIMEOUT: 5m
-  OPENSSL_DGST_CMD: openssl dgst -sha384 -r
+  GOLINTERS_TGZ_DGST: 4ba1dc9dbdf05b7bdc6f0e04bdfe6f63aa70576f51817be1b2540bbce017b69a
+  GOLINTERS_TIMEOUT: 15m
+  OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail
 
 jobs:
@@ -65,7 +70,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
 
       - name: Install golangci-lint


### PR DESCRIPTION
## Description

This is configured to use Go 1.19 with golangci-lint 1.50.1.

Updates  #281

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
