### PR TITLE
Bump go 1.17 to 1.19 in coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,13 +16,13 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3  # allow GitHub to use latest v2.x of checkout
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v3  # allow GitHub to use latest v2.x of setup-go
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.19'
           check-latest: true
 
       - name: Get dependencies


### PR DESCRIPTION
## Description

Bump go 1.17 to 1.19 in coverage.yml (GitHub Actions Workflow).
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
