### PR TITLE
Add a callback to the Encoder

### DIFF
--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -200,7 +200,7 @@ func setupArray(b *testing.B, r *rand.Rand, storage *PersistentSlabStorage, init
 		require.NoError(b, err)
 	}
 
-	err = storage.Commit()
+	err = storage.Commit(nil)
 	require.NoError(b, err)
 
 	arrayID := array.StorageID()

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -96,7 +96,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		err = array.Append(v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	b.ResetTimer()
 
 	arrayID := array.StorageID()
@@ -118,7 +118,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		err = array.Append(v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalAppendTime = time.Since(start)
 
 	// remove
@@ -134,7 +134,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		require.NoError(b, err)
 		totalRawDataSize -= storable.ByteSize()
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalRemoveTime = time.Since(start)
 
 	// insert
@@ -156,7 +156,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		err = array.Insert(uint64(ind), v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalInsertTime = time.Since(start)
 
 	// lookup
@@ -171,7 +171,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		_, err := array.Get(uint64(ind))
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalLookupTime = time.Since(start)
 
 	// random lookup
@@ -229,7 +229,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 		err = array.Append(v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	b.ResetTimer()
 
 	for i := 0; i < numberOfOps; i++ {
@@ -252,7 +252,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 			require.NoError(b, err)
 		}
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 
 	storageOverheadRatio := float64(storage.baseStorage.Size()) / float64(totalRawDataSize)
 	b.ReportMetric(float64(storage.baseStorage.SegmentsTouched()), "segments_touched")

--- a/array_debug.go
+++ b/array_debug.go
@@ -409,7 +409,7 @@ func validArraySlabSerialization(
 	}
 
 	// Encode slab
-	data, err := Encode(slab, cborEncMode)
+	data, err := Encode(slab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func validArraySlabSerialization(
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, cborEncMode)
+	dataFromDecodedSlab, err := Encode(decodedSlab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func getEncodedArrayExtraDataSize(extraData *ArrayExtraData, cborEncMode cbor.En
 	}
 
 	var buf bytes.Buffer
-	enc := NewEncoder(&buf, cborEncMode)
+	enc := NewEncoder(&buf, cborEncMode, nil)
 
 	// Normally the flag shouldn't be 0. But in this case we just need the encoded data size
 	// so the content of the flag doesn't matter.

--- a/array_debug.go
+++ b/array_debug.go
@@ -409,7 +409,7 @@ func validArraySlabSerialization(
 	}
 
 	// Encode slab
-	data, err := Encode(slab, cborEncMode, nil)
+	data, err := EncodeSlab(slab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func validArraySlabSerialization(
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, cborEncMode, nil)
+	dataFromDecodedSlab, err := EncodeSlab(decodedSlab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -620,7 +620,7 @@ func getEncodedArrayExtraDataSize(extraData *ArrayExtraData, cborEncMode cbor.En
 	}
 
 	var buf bytes.Buffer
-	enc := NewEncoder(&buf, cborEncMode, nil)
+	enc := NewEncoder(&buf, cborEncMode)
 
 	// Normally the flag shouldn't be 0. But in this case we just need the encoded data size
 	// so the content of the flag doesn't matter.

--- a/array_test.go
+++ b/array_test.go
@@ -112,7 +112,7 @@ func verifyArray(
 
 	if !hasNestedArrayMapElement {
 		// Need to call Commit before calling storage.Count() for PersistentSlabStorage.
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		stats, err := GetArrayStats(array)
@@ -1506,7 +1506,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			0x99, 0x00, 0x00,
 		}
 
-		slabData, err := storage.Encode()
+		slabData, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(slabData))
 		require.Equal(t, expectedData, slabData[array.StorageID()])
@@ -1555,7 +1555,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			0xd8, 0xa4, 0x00,
 		}
 
-		slabData, err := storage.Encode()
+		slabData, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(slabData))
 		require.Equal(t, expectedData, slabData[array.StorageID()])
@@ -1708,7 +1708,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			},
 		}
 
-		m, err := storage.Encode()
+		m, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, len(expected), len(m))
 		require.Equal(t, expected[id1], m[id1])

--- a/basicarray.go
+++ b/basicarray.go
@@ -112,8 +112,8 @@ func (a *BasicArrayDataSlab) Encode(enc *Encoder) error {
 		return NewEncodingError(err)
 	}
 
-	for i := 0; i < len(a.elements); i++ {
-		err := a.elements[i].Encode(enc)
+	for _, e := range a.elements {
+		err := e.Encode(enc)
 		if err != nil {
 			return NewEncodingError(err)
 		}

--- a/basicarray_benchmark_test.go
+++ b/basicarray_benchmark_test.go
@@ -85,7 +85,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		err = array.Append(v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	b.ResetTimer()
 
 	arrayID := array.StorageID()
@@ -104,7 +104,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		err = array.Append(v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalAppendTime = time.Since(start)
 
 	// remove
@@ -121,7 +121,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		require.NoError(b, err)
 		totalRawDataSize -= storable.ByteSize()
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalRemoveTime = time.Since(start)
 
 	// insert
@@ -139,7 +139,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		err = array.Insert(uint64(ind), v)
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalInsertTime = time.Since(start)
 
 	// lookup
@@ -153,7 +153,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		_, err := array.Get(uint64(ind))
 		require.NoError(b, err)
 	}
-	require.NoError(b, storage.Commit())
+	require.NoError(b, storage.Commit(nil))
 	totalLookupTime = time.Since(start)
 
 	// random lookup

--- a/basicarray_test.go
+++ b/basicarray_test.go
@@ -430,7 +430,7 @@ func TestBasicArrayDecodeEncodeRandomData(t *testing.T) {
 	rootID := array.root.Header().id
 
 	// Encode slabs with random data of mixed types
-	m1, err := storage.Encode()
+	m1, err := storage.Encode(nil)
 	require.NoError(t, err)
 
 	// Decode data to new storage

--- a/callback_test.go
+++ b/callback_test.go
@@ -1,0 +1,120 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright 2023 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"sync/atomic"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var _ Callback = &testCallback{}
+
+type testCallback struct {
+	beforeEncode func(uint32) error
+}
+
+func (t testCallback) BeforeEncode(size uint32) error {
+	return t.beforeEncode(size)
+}
+
+func TestCallbackOnEncode(t *testing.T) {
+
+	t.Parallel()
+
+	t.Run("strings", func(t *testing.T) {
+		t.Parallel()
+
+		typeInfo := testTypeInfo{42}
+		storage := newTestBasicStorage(t)
+		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+		array, err := NewArray(storage, address, typeInfo)
+		require.NoError(t, err)
+
+		const arraySize = 20
+		values := make([]Value, arraySize)
+		for i := 0; i < arraySize; i++ {
+			v := NewStringValue(strings.Repeat("a", 22))
+			values[i] = v
+			err := array.Append(v)
+			require.NoError(t, err)
+		}
+
+		var count, totalBytes uint32 = 0, 0
+
+		callback := &testCallback{
+			beforeEncode: func(size uint32) error {
+				atomic.AddUint32(&count, 1)
+				atomic.AddUint32(&totalBytes, size)
+				return nil
+			},
+		}
+
+		_, err = storage.Encode(callback)
+		require.NoError(t, err)
+		assert.Equal(t, arraySize, int(count))
+		assert.Equal(t, 460, int(totalBytes))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		typeInfo := testTypeInfo{42}
+		storage := newTestBasicStorage(t)
+		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+		array, err := NewArray(storage, address, typeInfo)
+		require.NoError(t, err)
+
+		const arraySize = 20
+		values := make([]Value, arraySize)
+		for i := 0; i < arraySize; i++ {
+			v := NewStringValue(strings.Repeat("a", 22))
+			values[i] = v
+			err := array.Append(v)
+			require.NoError(t, err)
+		}
+
+		var count, totalBytes uint32 = 0, 0
+		const terminateAt uint32 = 12
+
+		callback := &testCallback{
+			beforeEncode: func(size uint32) error {
+				atomic.AddUint32(&count, 1)
+				atomic.AddUint32(&totalBytes, size)
+				if atomic.LoadUint32(&count) >= terminateAt {
+					return fmt.Errorf("array too large")
+				}
+				return nil
+			},
+		}
+
+		_, err = storage.Encode(callback)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "array too large")
+		assert.Equal(t, terminateAt, count)
+		assert.Equal(t, 276, int(totalBytes))
+	})
+}

--- a/callback_test.go
+++ b/callback_test.go
@@ -73,7 +73,12 @@ func TestCallbackOnEncode(t *testing.T) {
 		_, err = storage.Encode(callback)
 		require.NoError(t, err)
 		assert.Equal(t, 1, int(count))
-		assert.Equal(t, 465, int(totalBytes))
+
+		var computedTotalBytes uint32
+		for _, slab := range storage.Slabs {
+			computedTotalBytes += slab.ByteSize()
+		}
+		assert.Equal(t, computedTotalBytes, totalBytes)
 	})
 
 	t.Run("nested arrays", func(t *testing.T) {
@@ -112,7 +117,12 @@ func TestCallbackOnEncode(t *testing.T) {
 		_, err = storage.Encode(callback)
 		require.NoError(t, err)
 		assert.Equal(t, arraySize+1, int(count))
-		assert.Equal(t, 945, int(totalBytes))
+
+		var computedTotalBytes uint32
+		for _, slab := range storage.Slabs {
+			computedTotalBytes += slab.ByteSize()
+		}
+		assert.Equal(t, computedTotalBytes, totalBytes)
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/cmd/stress/array.go
+++ b/cmd/stress/array.go
@@ -153,7 +153,7 @@ func testArray(
 			reduceHeapAllocs = false
 
 			// Commit slabs to storage and drop read and write to reduce mem
-			err = storage.FastCommit(runtime.NumCPU())
+			err = storage.FastCommit(runtime.NumCPU(), nil)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to commit to storage: %s", err)
 				return

--- a/cmd/stress/map.go
+++ b/cmd/stress/map.go
@@ -139,7 +139,7 @@ func testMap(
 			reduceHeapAllocs = false
 
 			// Commit slabs to storage and drop read and write to reduce mem
-			err = storage.FastCommit(runtime.NumCPU())
+			err = storage.FastCommit(runtime.NumCPU(), nil)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to commit to storage: %s", err)
 				return

--- a/encode.go
+++ b/encode.go
@@ -28,15 +28,23 @@ import (
 // Encoder writes atree slabs to io.Writer.
 type Encoder struct {
 	io.Writer
+	Callback
 	CBOR    *cbor.StreamEncoder
 	Scratch [64]byte
 }
 
-func NewEncoder(w io.Writer, encMode cbor.EncMode) *Encoder {
+// Callback is a wrapper with callback functions to be called during encoding.
+// Implementations of this interface must be concurrency-safe.
+type Callback interface {
+	BeforeEncode(size uint32) error
+}
+
+func NewEncoder(w io.Writer, encMode cbor.EncMode, callback Callback) *Encoder {
 	streamEncoder := encMode.NewStreamEncoder(w)
 	return &Encoder{
-		Writer: w,
-		CBOR:   streamEncoder,
+		Writer:   w,
+		CBOR:     streamEncoder,
+		Callback: callback,
 	}
 }
 

--- a/encode.go
+++ b/encode.go
@@ -28,7 +28,6 @@ import (
 // Encoder writes atree slabs to io.Writer.
 type Encoder struct {
 	io.Writer
-	Callback
 	CBOR    *cbor.StreamEncoder
 	Scratch [64]byte
 }
@@ -36,15 +35,14 @@ type Encoder struct {
 // Callback is a wrapper with callback functions to be called during encoding.
 // Implementations of this interface must be concurrency-safe.
 type Callback interface {
-	BeforeEncode(size uint32) error
+	BeforeEncodeSlab(size uint32) error
 }
 
-func NewEncoder(w io.Writer, encMode cbor.EncMode, callback Callback) *Encoder {
+func NewEncoder(w io.Writer, encMode cbor.EncMode) *Encoder {
 	streamEncoder := encMode.NewStreamEncoder(w)
 	return &Encoder{
-		Writer:   w,
-		CBOR:     streamEncoder,
-		Callback: callback,
+		Writer: w,
+		CBOR:   streamEncoder,
 	}
 }
 

--- a/map_debug.go
+++ b/map_debug.go
@@ -792,7 +792,7 @@ func validMapSlabSerialization(
 	}
 
 	// Encode slab
-	data, err := Encode(slab, cborEncMode, nil)
+	data, err := EncodeSlab(slab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -804,7 +804,7 @@ func validMapSlabSerialization(
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, cborEncMode, nil)
+	dataFromDecodedSlab, err := EncodeSlab(decodedSlab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -1317,7 +1317,7 @@ func getEncodedMapExtraDataSize(extraData *MapExtraData, cborEncMode cbor.EncMod
 	}
 
 	var buf bytes.Buffer
-	enc := NewEncoder(&buf, cborEncMode, nil)
+	enc := NewEncoder(&buf, cborEncMode)
 
 	err := extraData.Encode(enc, byte(0), byte(0))
 	if err != nil {

--- a/map_debug.go
+++ b/map_debug.go
@@ -792,7 +792,7 @@ func validMapSlabSerialization(
 	}
 
 	// Encode slab
-	data, err := Encode(slab, cborEncMode)
+	data, err := Encode(slab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -804,7 +804,7 @@ func validMapSlabSerialization(
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, cborEncMode)
+	dataFromDecodedSlab, err := Encode(decodedSlab, cborEncMode, nil)
 	if err != nil {
 		return err
 	}
@@ -1317,7 +1317,7 @@ func getEncodedMapExtraDataSize(extraData *MapExtraData, cborEncMode cbor.EncMod
 	}
 
 	var buf bytes.Buffer
-	enc := NewEncoder(&buf, cborEncMode)
+	enc := NewEncoder(&buf, cborEncMode, nil)
 
 	err := extraData.Encode(enc, byte(0), byte(0))
 	if err != nil {

--- a/map_test.go
+++ b/map_test.go
@@ -183,7 +183,7 @@ func verifyMap(
 
 	if !hasNestedArrayMapElement {
 		// Need to call Commit before calling storage.Count() for PersistentSlabStorage.
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		stats, err := GetMapStats(m)
@@ -1552,7 +1552,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		}
 
 		// Verify encoded data
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(stored))
 		require.Equal(t, expected[id1], stored[id1])
@@ -1644,7 +1644,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		}
 
 		// Verify encoded data
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 
 		require.Equal(t, len(expected), len(stored))
@@ -1877,7 +1877,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		}
 
 		// Verify encoded data
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 
 		require.Equal(t, len(expected), len(stored))
@@ -2081,7 +2081,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			},
 		}
 
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, len(expected), len(stored))
 		require.Equal(t, expected[id1], stored[id1])
@@ -2324,7 +2324,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			},
 		}
 
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, len(expected), len(stored))
 		require.Equal(t, expected[id1], stored[id1])
@@ -2562,7 +2562,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			},
 		}
 
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, len(expected), len(stored))
 		require.Equal(t, expected[id1], stored[id1])
@@ -2644,7 +2644,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		}
 
 		// Verify encoded data
-		stored, err := storage.Encode()
+		stored, err := storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(stored))
 		require.Equal(t, expectedNoPointer, stored[id1])
@@ -2701,7 +2701,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 		}
 
-		stored, err = storage.Encode()
+		stored, err = storage.Encode(nil)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(stored))
 		require.Equal(t, expectedHasPointer, stored[id1])
@@ -2799,7 +2799,7 @@ func TestMapPopIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, storage.Count())
@@ -2839,7 +2839,7 @@ func TestMapPopIterate(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, storage.Count())
@@ -2896,7 +2896,7 @@ func TestMapPopIterate(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -2967,7 +2967,7 @@ func TestMapPopIterate(t *testing.T) {
 
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		// Iterate key value pairs

--- a/storable.go
+++ b/storable.go
@@ -98,12 +98,19 @@ func (v StorageIDStorable) String() string {
 	return fmt.Sprintf("StorageIDStorable(%d)", v)
 }
 
-// Encode is a wrapper for Storable.Encode()
-func Encode(storable Storable, encMode cbor.EncMode, callback Callback) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := NewEncoder(&buf, encMode, callback)
+// EncodeSlab is a wrapper for Storable.Encode()
+func EncodeSlab(slab Slab, encMode cbor.EncMode, callback Callback) ([]byte, error) {
+	if callback != nil {
+		err := callback.BeforeEncodeSlab(slab.ByteSize())
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	err := storable.Encode(enc)
+	var buf bytes.Buffer
+	enc := NewEncoder(&buf, encMode)
+
+	err := slab.Encode(enc)
 	if err != nil {
 		return nil, err
 	}

--- a/storable.go
+++ b/storable.go
@@ -99,9 +99,9 @@ func (v StorageIDStorable) String() string {
 }
 
 // Encode is a wrapper for Storable.Encode()
-func Encode(storable Storable, encMode cbor.EncMode) ([]byte, error) {
+func Encode(storable Storable, encMode cbor.EncMode, callback Callback) ([]byte, error) {
 	var buf bytes.Buffer
-	enc := NewEncoder(&buf, encMode)
+	enc := NewEncoder(&buf, encMode, callback)
 
 	err := storable.Encode(enc)
 	if err != nil {

--- a/storable_test.go
+++ b/storable_test.go
@@ -41,14 +41,6 @@ type HashableValue interface {
 	HashInput(scratch []byte) ([]byte, error)
 }
 
-func beforeEncode(e *Encoder, v Storable) error {
-	if e.Callback == nil {
-		return nil
-	}
-
-	return e.Callback.BeforeEncode(v.ByteSize())
-}
-
 type Uint8Value uint8
 
 var _ Value = Uint8Value(0)
@@ -72,10 +64,6 @@ func (v Uint8Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, erro
 //			Content: uint8(v),
 //	}
 func (v Uint8Value) Encode(enc *Encoder) error {
-	if err := beforeEncode(enc, v); err != nil {
-		return err
-	}
-
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt8Value,
@@ -134,10 +122,6 @@ func (v Uint16Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 }
 
 func (v Uint16Value) Encode(enc *Encoder) error {
-	if err := beforeEncode(enc, v); err != nil {
-		return err
-	}
-
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt16Value,
@@ -207,10 +191,6 @@ func (v Uint32Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 //			Content: uint32(v),
 //	}
 func (v Uint32Value) Encode(enc *Encoder) error {
-	if err := beforeEncode(enc, v); err != nil {
-		return err
-	}
-
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt32Value,
@@ -287,10 +267,6 @@ func (v Uint64Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 //			Content: uint64(v),
 //	}
 func (v Uint64Value) Encode(enc *Encoder) error {
-	if err := beforeEncode(enc, v); err != nil {
-		return err
-	}
-
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt64Value,
@@ -397,10 +373,6 @@ func (v StringValue) Storable(storage SlabStorage, address Address, maxInlineSiz
 }
 
 func (v StringValue) Encode(enc *Encoder) error {
-	if err := beforeEncode(enc, v); err != nil {
-		return err
-	}
-
 	return enc.CBOR.EncodeString(v.str)
 }
 
@@ -671,10 +643,6 @@ func (v SomeStorable) ByteSize() uint32 {
 }
 
 func (v SomeStorable) Encode(enc *Encoder) error {
-	if err := beforeEncode(enc, v); err != nil {
-		return err
-	}
-
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagSomeValue,

--- a/storable_test.go
+++ b/storable_test.go
@@ -41,6 +41,14 @@ type HashableValue interface {
 	HashInput(scratch []byte) ([]byte, error)
 }
 
+func beforeEncode(e *Encoder, v Storable) error {
+	if e.Callback == nil {
+		return nil
+	}
+
+	return e.Callback.BeforeEncode(v.ByteSize())
+}
+
 type Uint8Value uint8
 
 var _ Value = Uint8Value(0)
@@ -64,6 +72,10 @@ func (v Uint8Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, erro
 //			Content: uint8(v),
 //	}
 func (v Uint8Value) Encode(enc *Encoder) error {
+	if err := beforeEncode(enc, v); err != nil {
+		return err
+	}
+
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt8Value,
@@ -122,6 +134,10 @@ func (v Uint16Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 }
 
 func (v Uint16Value) Encode(enc *Encoder) error {
+	if err := beforeEncode(enc, v); err != nil {
+		return err
+	}
+
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt16Value,
@@ -191,6 +207,10 @@ func (v Uint32Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 //			Content: uint32(v),
 //	}
 func (v Uint32Value) Encode(enc *Encoder) error {
+	if err := beforeEncode(enc, v); err != nil {
+		return err
+	}
+
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt32Value,
@@ -267,6 +287,10 @@ func (v Uint64Value) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 //			Content: uint64(v),
 //	}
 func (v Uint64Value) Encode(enc *Encoder) error {
+	if err := beforeEncode(enc, v); err != nil {
+		return err
+	}
+
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagUInt64Value,
@@ -373,6 +397,10 @@ func (v StringValue) Storable(storage SlabStorage, address Address, maxInlineSiz
 }
 
 func (v StringValue) Encode(enc *Encoder) error {
+	if err := beforeEncode(enc, v); err != nil {
+		return err
+	}
+
 	return enc.CBOR.EncodeString(v.str)
 }
 
@@ -643,6 +671,10 @@ func (v SomeStorable) ByteSize() uint32 {
 }
 
 func (v SomeStorable) Encode(enc *Encoder) error {
+	if err := beforeEncode(enc, v); err != nil {
+		return err
+	}
+
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagSomeValue,

--- a/storage.go
+++ b/storage.go
@@ -311,10 +311,10 @@ func (s *BasicSlabStorage) StorageIDs() []StorageID {
 
 // Encode returns serialized slabs in storage.
 // This is currently used for testing.
-func (s *BasicSlabStorage) Encode() (map[StorageID][]byte, error) {
+func (s *BasicSlabStorage) Encode(callback Callback) (map[StorageID][]byte, error) {
 	m := make(map[StorageID][]byte)
 	for id, slab := range s.Slabs {
-		b, err := Encode(slab, s.cborEncMode)
+		b, err := Encode(slab, s.cborEncMode, callback)
 		if err != nil {
 			return nil, err
 		}
@@ -676,7 +676,7 @@ func (s *PersistentSlabStorage) sortedOwnedDeltaKeys() []StorageID {
 	return keysWithOwners
 }
 
-func (s *PersistentSlabStorage) Commit() error {
+func (s *PersistentSlabStorage) Commit(callback Callback) error {
 	var err error
 
 	// this part ensures the keys are sorted so commit operation is deterministic
@@ -700,7 +700,7 @@ func (s *PersistentSlabStorage) Commit() error {
 		}
 
 		// serialize
-		data, err := Encode(slab, s.cborEncMode)
+		data, err := Encode(slab, s.cborEncMode, callback)
 		if err != nil {
 			return NewStorageError(err)
 		}
@@ -724,7 +724,7 @@ func (s *PersistentSlabStorage) Commit() error {
 	return nil
 }
 
-func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
+func (s *PersistentSlabStorage) FastCommit(numWorkers int, callback Callback) error {
 
 	// this part ensures the keys are sorted so commit operation is deterministic
 	keysWithOwners := s.sortedOwnedDeltaKeys()
@@ -777,7 +777,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 				continue
 			}
 			// serialize
-			data, err := Encode(slab, s.cborEncMode)
+			data, err := Encode(slab, s.cborEncMode, callback)
 			results <- &encodedSlabs{
 				storageID: id,
 				data:      data,

--- a/storage.go
+++ b/storage.go
@@ -314,7 +314,7 @@ func (s *BasicSlabStorage) StorageIDs() []StorageID {
 func (s *BasicSlabStorage) Encode(callback Callback) (map[StorageID][]byte, error) {
 	m := make(map[StorageID][]byte)
 	for id, slab := range s.Slabs {
-		b, err := Encode(slab, s.cborEncMode, callback)
+		b, err := EncodeSlab(slab, s.cborEncMode, callback)
 		if err != nil {
 			return nil, err
 		}
@@ -700,7 +700,7 @@ func (s *PersistentSlabStorage) Commit(callback Callback) error {
 		}
 
 		// serialize
-		data, err := Encode(slab, s.cborEncMode, callback)
+		data, err := EncodeSlab(slab, s.cborEncMode, callback)
 		if err != nil {
 			return NewStorageError(err)
 		}
@@ -777,7 +777,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int, callback Callback) er
 				continue
 			}
 			// serialize
-			data, err := Encode(slab, s.cborEncMode, callback)
+			data, err := EncodeSlab(slab, s.cborEncMode, callback)
 			results <- &encodedSlabs{
 				storageID: id,
 				data:      data,

--- a/storage_test.go
+++ b/storage_test.go
@@ -691,7 +691,7 @@ func TestPersistentStorage(t *testing.T) {
 				require.NoError(t, err)
 
 				// capture data for accuracy testing
-				simpleMap[storageID], err = Encode(slab, encMode, nil)
+				simpleMap[storageID], err = EncodeSlab(slab, encMode, nil)
 				require.NoError(t, err)
 			}
 		}
@@ -933,7 +933,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				break
 			}
 
-			encodedSlab, err := Encode(slab, storage.cborEncMode, nil)
+			encodedSlab, err := EncodeSlab(slab, storage.cborEncMode, nil)
 			require.NoError(t, err)
 
 			require.Equal(t, encodedSlab, data[id])

--- a/storage_test.go
+++ b/storage_test.go
@@ -607,7 +607,7 @@ func TestPersistentStorage(t *testing.T) {
 		require.Equal(t, uint(1), storage.DeltasWithoutTempAddresses())
 		require.Equal(t, uint(2), storage.Deltas())
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		require.Equal(t, uint(0), storage.DeltasWithoutTempAddresses())
@@ -641,7 +641,7 @@ func TestPersistentStorage(t *testing.T) {
 		err = storage.Remove(tempStorageID)
 		require.NoError(t, err)
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
 		// Slab with perm storage id is removed from base storage.
@@ -691,15 +691,15 @@ func TestPersistentStorage(t *testing.T) {
 				require.NoError(t, err)
 
 				// capture data for accuracy testing
-				simpleMap[storageID], err = Encode(slab, encMode)
+				simpleMap[storageID], err = Encode(slab, encMode, nil)
 				require.NoError(t, err)
 			}
 		}
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
-		err = storageWithFastCommit.FastCommit(10)
+		err = storageWithFastCommit.FastCommit(10, nil)
 		require.NoError(t, err)
 
 		require.Equal(t, len(simpleMap), storage.Count())
@@ -730,10 +730,10 @@ func TestPersistentStorage(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		err = storage.Commit()
+		err = storage.Commit(nil)
 		require.NoError(t, err)
 
-		err = storageWithFastCommit.FastCommit(10)
+		err = storageWithFastCommit.FastCommit(10, nil)
 		require.NoError(t, err)
 
 		require.Equal(t, 0, storage.Count())
@@ -789,7 +789,7 @@ func TestPersistentStorage(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		err = storage.FastCommit(2)
+		err = storage.FastCommit(2, nil)
 		require.ErrorIs(t, err, errEncodeNonStorable)
 	})
 }
@@ -933,7 +933,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				break
 			}
 
-			encodedSlab, err := Encode(slab, storage.cborEncMode)
+			encodedSlab, err := Encode(slab, storage.cborEncMode, nil)
 			require.NoError(t, err)
 
 			require.Equal(t, encodedSlab, data[id])


### PR DESCRIPTION
Work towards https://github.com/dapperlabs/cadence-private-issues/issues/64

## Description

It can be useful to have a callback function that gets called during the encoding (e.g: https://github.com/dapperlabs/cadence-private-issues/issues/64), to keep track of the operation.

This PR adds a generic `Callback` field to the `Encoder`, which wraps different callback functions. Users of the encoder can register callbacks when they create the encoder. For now, the callback only has one function `BeforeEncode` which is/should be invoked at the start of each value encoding.
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
