### PR TITLE
Add CI check for vulnerabilities affecting Go code

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,47 @@
+# GitHub Actions workflow for govulncheck.
+# Copied from https://github.com/fxamacker/cbor
+
+name: govulncheck
+
+# Revoke default permissions and grant what's needed in each job.
+permissions: {}
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at least once daily because vulnerability database might be updated.
+    - cron: '30 15 * * *'
+  pull_request:
+    paths:
+      - '**'
+      - '!**.md'
+  push:
+    paths:
+      - '**'
+      - '!**.md'
+    branches:
+      - 'main'
+    tags:
+      - 'v*'
+
+jobs:
+  Check:
+    runs-on: ubuntu-latest
+    permissions:
+      # Grant permission to read content.
+      contents: read
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 1
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.x
+        check-latest: true
+    - name: Install latest from golang.org
+      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+    - name: Run govulncheck
+      # Use -v flag to print a full call stack for each vulnerability found.
+      run: govulncheck -v ./...


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow to run govulncheck.

According to govulncheck docs:

> Govulncheck reports known vulnerabilities that affect Go code.  It uses static analysis of source code or a binary's symbol table  to narrow down reports to only those that could affect the application.
>
> By default, govulncheck makes requests to the Go vulnerability database at https://vuln.go.dev. Requests to the vulnerability database contain only module paths, not code or other properties of your program.

More info at:
- https://go.dev/security/vuln
- https://github.com/golang/vuln

Closes #293

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
