### PR TITLE
Refactor error handling and recategorize errors

### DIFF
--- a/array.go
+++ b/array.go
@@ -20,7 +20,6 @@ package atree
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -167,13 +166,13 @@ func newArrayExtraDataFromData(
 ) {
 	// Check data length
 	if len(data) < versionAndFlagSize {
-		return nil, data, errors.New("data is too short for array extra data")
+		return nil, data, NewDecodingErrorf("data is too short for array extra data")
 	}
 
 	// Check flag
 	flag := data[1]
 	if !isRoot(flag) {
-		return nil, data, fmt.Errorf("data has invalid flag 0x%x, want root flag", flag)
+		return nil, data, NewDecodingError(fmt.Errorf("array extra data has invalid flag 0x%x, want root flag", flag))
 	}
 
 	// Decode extra data
@@ -182,20 +181,22 @@ func newArrayExtraDataFromData(
 
 	length, err := dec.DecodeArrayHead()
 	if err != nil {
-		return nil, data, err
+		return nil, data, NewDecodingError(err)
 	}
 
 	if length != arrayExtraDataLength {
-		return nil, data, fmt.Errorf(
-			"data has invalid length %d, want %d",
-			length,
-			arrayExtraDataLength,
-		)
+		return nil, data, NewDecodingError(
+			fmt.Errorf(
+				"data has invalid length %d, want %d",
+				length,
+				arrayExtraDataLength,
+			))
 	}
 
 	typeInfo, err := decodeTypeInfo(dec)
 	if err != nil {
-		return nil, data, err
+		// Wrap err as external error (if needed) because err is returned by TypeInfoDecoder callback.
+		return nil, data, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode type info")
 	}
 
 	// Reslice for remaining data
@@ -230,21 +231,27 @@ func (a *ArrayExtraData) Encode(enc *Encoder, flag byte) error {
 	// Write scratch content to encoder
 	_, err := enc.Write(enc.Scratch[:versionAndFlagSize])
 	if err != nil {
-		return err
+		return NewEncodingError(err)
 	}
 
 	// Encode extra data
 	err = enc.CBOR.EncodeArrayHead(arrayExtraDataLength)
 	if err != nil {
-		return err
+		return NewEncodingError(err)
 	}
 
 	err = a.TypeInfo.Encode(enc.CBOR)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by TypeInfo interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode type info")
 	}
 
-	return enc.CBOR.Flush()
+	err = enc.CBOR.Flush()
+	if err != nil {
+		return NewEncodingError(err)
+	}
+
+	return nil
 }
 
 func newArrayDataSlabFromData(
@@ -272,7 +279,8 @@ func newArrayDataSlabFromData(
 		var err error
 		extraData, data, err = newArrayExtraDataFromData(data, decMode, decodeTypeInfo)
 		if err != nil {
-			return nil, NewDecodingError(err)
+			// err is categorized already by newArrayExtraDataFromData.
+			return nil, err
 		}
 	}
 
@@ -308,7 +316,8 @@ func newArrayDataSlabFromData(
 		var err error
 		next, err = NewStorageIDFromRawBytes(data[nextStorageIDOffset:])
 		if err != nil {
-			return nil, NewDecodingError(err)
+			// error returned from NewStorageIDFromRawBytes is categorized already.
+			return nil, err
 		}
 
 		contentOffset = nextStorageIDOffset + storageIDSize
@@ -329,7 +338,8 @@ func newArrayDataSlabFromData(
 	for i := 0; i < int(elemCount); i++ {
 		storable, err := decodeStorable(cborDec, StorageIDUndefined)
 		if err != nil {
-			return nil, NewDecodingError(err)
+			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
+			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode array element")
 		}
 		elements[i] = storable
 	}
@@ -376,7 +386,8 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 
 		err := a.extraData.Encode(enc, flag)
 		if err != nil {
-			return NewEncodingError(err)
+			// err is already categorized by ArrayExtraData.Encode().
+			return err
 		}
 	}
 
@@ -395,7 +406,8 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 		const nextStorageIDOffset = versionAndFlagSize
 		_, err := a.next.ToRawBytes(enc.Scratch[nextStorageIDOffset:])
 		if err != nil {
-			return NewEncodingError(err)
+			// Don't need to wrap because err is already categorized by StorageID.ToRawBytes().
+			return err
 		}
 
 		contentOffset = nextStorageIDOffset + storageIDSize
@@ -425,7 +437,8 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 	for _, e := range a.elements {
 		err = e.Encode(enc)
 		if err != nil {
-			return NewEncodingError(err)
+			// Wrap err as external error (if needed) because err is returned by Storable interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode array element")
 		}
 	}
 
@@ -433,6 +446,7 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 	if err != nil {
 		return NewEncodingError(err)
 	}
+
 	return nil
 }
 
@@ -468,7 +482,8 @@ func (a *ArrayDataSlab) Set(storage SlabStorage, address Address, index uint64, 
 
 	storable, err := value.Storable(storage, address, MaxInlineArrayElementSize)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by Value interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
 	}
 
 	a.elements[index] = storable
@@ -476,7 +491,8 @@ func (a *ArrayDataSlab) Set(storage SlabStorage, address Address, index uint64, 
 
 	err = storage.Store(a.header.id, a)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 	}
 
 	return oldElem, nil
@@ -489,7 +505,8 @@ func (a *ArrayDataSlab) Insert(storage SlabStorage, address Address, index uint6
 
 	storable, err := value.Storable(storage, address, MaxInlineArrayElementSize)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by Value interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
 	}
 
 	if index == uint64(len(a.elements)) {
@@ -503,7 +520,13 @@ func (a *ArrayDataSlab) Insert(storage SlabStorage, address Address, index uint6
 	a.header.count++
 	a.header.size += storable.ByteSize()
 
-	return storage.Store(a.header.id, a)
+	err = storage.Store(a.header.id, a)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+	}
+
+	return nil
 }
 
 func (a *ArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable, error) {
@@ -529,7 +552,8 @@ func (a *ArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable, err
 
 	err := storage.Store(a.header.id, a)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 	}
 
 	return v, nil
@@ -566,7 +590,14 @@ func (a *ArrayDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 	// Construct right slab
 	sID, err := storage.GenerateStorageID(a.header.id.Address)
 	if err != nil {
-		return nil, nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf(
+				"failed to generate storage ID for address 0x%x",
+				a.header.id.Address,
+			),
+		)
 	}
 	rightSlabCount := len(a.elements) - leftCount
 	rightSlab := &ArrayDataSlab{
@@ -839,7 +870,8 @@ func newArrayMetaDataSlabFromData(
 		var err error
 		extraData, data, err = newArrayExtraDataFromData(data, decMode, decodeTypeInfo)
 		if err != nil {
-			return nil, NewDecodingError(err)
+			// Don't need to wrap because err is already categorized by newArrayExtraDataFromData().
+			return nil, err
 		}
 	}
 
@@ -880,7 +912,8 @@ func newArrayMetaDataSlabFromData(
 	for i := 0; i < int(childHeaderCount); i++ {
 		storageID, err := NewStorageIDFromRawBytes(data[offset:])
 		if err != nil {
-			return nil, NewDecodingError(err)
+			// Don't need to wrap because err is already categorized by NewStorageIDFromRawBytes().
+			return nil, err
 		}
 
 		countOffset := offset + storageIDSize
@@ -939,7 +972,8 @@ func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 
 		err := a.extraData.Encode(enc, flag)
 		if err != nil {
-			return NewEncodingError(err)
+			// Don't need to wrap because err is already categorized by ArrayExtraData.Encode().
+			return err
 		}
 	}
 
@@ -967,7 +1001,8 @@ func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 	for _, h := range a.childrenHeaders {
 		_, err := h.id.ToRawBytes(enc.Scratch[:])
 		if err != nil {
-			return NewEncodingError(err)
+			// Don't need to wrap because err is already categorized by StorageID.ToRawBytes().
+			return err
 		}
 
 		const countOffset = storageIDSize
@@ -1053,14 +1088,17 @@ func (a *ArrayMetaDataSlab) Get(storage SlabStorage, index uint64) (Storable, er
 
 	_, adjustedIndex, childID, err := a.childSlabIndexInfo(index)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArrayMetadataSlab.childSlabIndexInfo().
 		return nil, err
 	}
 
 	child, err := getArraySlab(storage, childID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return nil, err
 	}
 
+	// Don't need to wrap error as external error because err is already categorized by ArraySlab.Get().
 	return child.Get(storage, adjustedIndex)
 }
 
@@ -1068,16 +1106,19 @@ func (a *ArrayMetaDataSlab) Set(storage SlabStorage, address Address, index uint
 
 	childHeaderIndex, adjustedIndex, childID, err := a.childSlabIndexInfo(index)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArrayMetadataSlab.childSlabIndexInfo().
 		return nil, err
 	}
 
 	child, err := getArraySlab(storage, childID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return nil, err
 	}
 
 	existingElem, err := child.Set(storage, address, adjustedIndex, value)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Set().
 		return nil, err
 	}
 
@@ -1089,6 +1130,7 @@ func (a *ArrayMetaDataSlab) Set(storage SlabStorage, address Address, index uint
 	if child.IsFull() {
 		err = a.SplitChildSlab(storage, child, childHeaderIndex)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayMetaDataSlab.SplitChildSlab().
 			return nil, err
 		}
 		return existingElem, nil
@@ -1097,6 +1139,7 @@ func (a *ArrayMetaDataSlab) Set(storage SlabStorage, address Address, index uint
 	if underflowSize, underflow := child.IsUnderflow(); underflow {
 		err = a.MergeOrRebalanceChildSlab(storage, child, childHeaderIndex, underflowSize)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayMetaDataSlab.MergeOrRebalanceChildSlab().
 			return nil, err
 		}
 		return existingElem, nil
@@ -1104,7 +1147,8 @@ func (a *ArrayMetaDataSlab) Set(storage SlabStorage, address Address, index uint
 
 	err = storage.Store(a.header.id, a)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 	}
 	return existingElem, nil
 }
@@ -1129,17 +1173,20 @@ func (a *ArrayMetaDataSlab) Insert(storage SlabStorage, address Address, index u
 		var err error
 		childHeaderIndex, adjustedIndex, childID, err = a.childSlabIndexInfo(index)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayMetadataSlab.childSlabIndexInfo().
 			return err
 		}
 	}
 
 	child, err := getArraySlab(storage, childID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return err
 	}
 
 	err = child.Insert(storage, address, adjustedIndex, value)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Insert().
 		return err
 	}
 
@@ -1156,13 +1203,20 @@ func (a *ArrayMetaDataSlab) Insert(storage SlabStorage, address Address, index u
 	// check if full
 
 	if child.IsFull() {
+		// Don't need to wrap error as external error because err is already categorized by ArrayMetaDataSlab.SplitChildSlab().
 		return a.SplitChildSlab(storage, child, childHeaderIndex)
 	}
 
 	// Insertion always increases the size,
 	// so there is no need to check underflow
 
-	return storage.Store(a.header.id, a)
+	err = storage.Store(a.header.id, a)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+	}
+
+	return nil
 }
 
 func (a *ArrayMetaDataSlab) Remove(storage SlabStorage, index uint64) (Storable, error) {
@@ -1173,16 +1227,19 @@ func (a *ArrayMetaDataSlab) Remove(storage SlabStorage, index uint64) (Storable,
 
 	childHeaderIndex, adjustedIndex, childID, err := a.childSlabIndexInfo(index)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArrayMetadataSlab.childSlabIndexInfo().
 		return nil, err
 	}
 
 	child, err := getArraySlab(storage, childID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return nil, err
 	}
 
 	v, err := child.Remove(storage, adjustedIndex)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Remove().
 		return nil, err
 	}
 
@@ -1201,6 +1258,7 @@ func (a *ArrayMetaDataSlab) Remove(storage SlabStorage, index uint64) (Storable,
 	if underflowSize, isUnderflow := child.IsUnderflow(); isUnderflow {
 		err = a.MergeOrRebalanceChildSlab(storage, child, childHeaderIndex, underflowSize)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayMetaDataSlab.MergeOrRebalanceChildSlab().
 			return nil, err
 		}
 	}
@@ -1210,7 +1268,8 @@ func (a *ArrayMetaDataSlab) Remove(storage SlabStorage, index uint64) (Storable,
 
 	err = storage.Store(a.header.id, a)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 	}
 
 	return v, nil
@@ -1219,6 +1278,7 @@ func (a *ArrayMetaDataSlab) Remove(storage SlabStorage, index uint64) (Storable,
 func (a *ArrayMetaDataSlab) SplitChildSlab(storage SlabStorage, child ArraySlab, childHeaderIndex int) error {
 	leftSlab, rightSlab, err := child.Split(storage)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Split().
 		return err
 	}
 
@@ -1244,13 +1304,23 @@ func (a *ArrayMetaDataSlab) SplitChildSlab(storage SlabStorage, child ArraySlab,
 	// Store modified slabs
 	err = storage.Store(left.ID(), left)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", left.ID()))
 	}
+
 	err = storage.Store(right.ID(), right)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", right.ID()))
 	}
-	return storage.Store(a.header.id, a)
+
+	err = storage.Store(a.header.id, a)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+	}
+
+	return nil
 }
 
 // MergeOrRebalanceChildSlab merges or rebalances child slab.
@@ -1280,6 +1350,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		var err error
 		leftSib, err = getArraySlab(storage, leftSibID)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 			return err
 		}
 	}
@@ -1289,6 +1360,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		var err error
 		rightSib, err = getArraySlab(storage, rightSibID)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 			return err
 		}
 	}
@@ -1305,6 +1377,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 
 			err := child.BorrowFromRight(rightSib)
 			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by ArraySlab.BorrowFromRight().
 				return err
 			}
 
@@ -1317,13 +1390,20 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 			// Store modified slabs
 			err = storage.Store(child.ID(), child)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.ID()))
 			}
 			err = storage.Store(rightSib.ID(), rightSib)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", rightSib.ID()))
 			}
-			return storage.Store(a.header.id, a)
+			err = storage.Store(a.header.id, a)
+			if err != nil {
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+			}
+			return nil
 		}
 
 		// Rebalance with left sib
@@ -1332,6 +1412,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 
 			err := leftSib.LendToRight(child)
 			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by ArraySlab.LendToRight().
 				return err
 			}
 
@@ -1344,13 +1425,20 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 			// Store modified slabs
 			err = storage.Store(leftSib.ID(), leftSib)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.ID()))
 			}
 			err = storage.Store(child.ID(), child)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.ID()))
 			}
-			return storage.Store(a.header.id, a)
+			err = storage.Store(a.header.id, a)
+			if err != nil {
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+			}
+			return nil
 		}
 
 		// Rebalance with bigger sib
@@ -1359,6 +1447,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 
 			err := leftSib.LendToRight(child)
 			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by ArraySlab.LendToRight().
 				return err
 			}
 
@@ -1371,13 +1460,20 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 			// Store modified slabs
 			err = storage.Store(leftSib.ID(), leftSib)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.ID()))
 			}
 			err = storage.Store(child.ID(), child)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.ID()))
 			}
-			return storage.Store(a.header.id, a)
+			err = storage.Store(a.header.id, a)
+			if err != nil {
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+			}
+			return nil
 		} else {
 			// leftSib.ByteSize() <= rightSib.ByteSize
 
@@ -1385,6 +1481,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 
 			err := child.BorrowFromRight(rightSib)
 			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by ArraySlab.BorrowFromRight().
 				return err
 			}
 
@@ -1397,15 +1494,18 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 			// Store modified slabs
 			err = storage.Store(child.ID(), child)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.ID()))
 			}
 			err = storage.Store(rightSib.ID(), rightSib)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", rightSib.ID()))
 			}
 			err = storage.Store(a.header.id, a)
 			if err != nil {
-				return err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 			}
 			return nil
 		}
@@ -1418,6 +1518,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		// Merge with right
 		err := child.Merge(rightSib)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArraySlab.Merge().
 			return err
 		}
 
@@ -1436,15 +1537,24 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		// Store modified slabs in storage
 		err = storage.Store(child.ID(), child)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.ID()))
 		}
+
 		err = storage.Store(a.header.id, a)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 		}
 
 		// Remove right sib from storage
-		return storage.Remove(rightSib.ID())
+		err = storage.Remove(rightSib.ID())
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", rightSib.ID()))
+		}
+
+		return nil
 	}
 
 	if rightSib == nil {
@@ -1452,6 +1562,7 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		// Merge with left
 		err := leftSib.Merge(child)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArraySlab.Merge().
 			return err
 		}
 
@@ -1470,21 +1581,31 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		// Store modified slabs in storage
 		err = storage.Store(leftSib.ID(), leftSib)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.ID()))
 		}
+
 		err = storage.Store(a.header.id, a)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 		}
 
 		// Remove child from storage
-		return storage.Remove(child.ID())
+		err = storage.Remove(child.ID())
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", child.ID()))
+		}
+
+		return nil
 	}
 
 	// Merge with smaller sib
 	if leftSib.ByteSize() < rightSib.ByteSize() {
 		err := leftSib.Merge(child)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArraySlab.Merge().
 			return err
 		}
 
@@ -1503,21 +1624,29 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		// Store modified slabs in storage
 		err = storage.Store(leftSib.ID(), leftSib)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.ID()))
 		}
 		err = storage.Store(a.header.id, a)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 		}
 
 		// Remove child from storage
-		return storage.Remove(child.ID())
+		err = storage.Remove(child.ID())
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", child.ID()))
+		}
+		return nil
 
 	} else {
 		// leftSib.ByteSize > rightSib.ByteSize
 
 		err := child.Merge(rightSib)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArraySlab.Merge().
 			return err
 		}
 
@@ -1536,15 +1665,23 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 		// Store modified slabs in storage
 		err = storage.Store(child.ID(), child)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.ID()))
 		}
 		err = storage.Store(a.header.id, a)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
 		}
 
 		// Remove rightSib from storage
-		return storage.Remove(rightSib.ID())
+		err = storage.Remove(rightSib.ID())
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", rightSib.ID()))
+		}
+
+		return nil
 	}
 }
 
@@ -1587,7 +1724,10 @@ func (a *ArrayMetaDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 	// Construct right slab
 	sID, err := storage.GenerateStorageID(a.header.id.Address)
 	if err != nil {
-		return nil, nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf("failed to generate storage ID for address 0x%x", a.header.id.Address))
 	}
 
 	rightSlab := &ArrayMetaDataSlab{
@@ -1758,18 +1898,21 @@ func (a *ArrayMetaDataSlab) PopIterate(storage SlabStorage, fn ArrayPopIteration
 
 		child, err := getArraySlab(storage, childID)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 			return err
 		}
 
 		err = child.PopIterate(storage, fn)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArraySlab.PopIterate().
 			return err
 		}
 
 		// Remove child slab
 		err = storage.Remove(childID)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", childID))
 		}
 	}
 
@@ -1804,7 +1947,10 @@ func NewArray(storage SlabStorage, address Address, typeInfo TypeInfo) (*Array, 
 
 	sID, err := storage.GenerateStorageID(address)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf("failed to generate storage ID for address 0x%x", address))
 	}
 
 	root := &ArrayDataSlab{
@@ -1817,7 +1963,8 @@ func NewArray(storage SlabStorage, address Address, typeInfo TypeInfo) (*Array, 
 
 	err = storage.Store(root.header.id, root)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", root.header.id))
 	}
 
 	return &Array{
@@ -1833,6 +1980,7 @@ func NewArrayWithRootID(storage SlabStorage, rootID StorageID) (*Array, error) {
 
 	root, err := getArraySlab(storage, rootID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return nil, err
 	}
 
@@ -1848,18 +1996,21 @@ func NewArrayWithRootID(storage SlabStorage, rootID StorageID) (*Array, error) {
 }
 
 func (a *Array) Get(i uint64) (Storable, error) {
+	// Don't need to wrap error as external error because err is already categorized by ArraySlab.Get().
 	return a.root.Get(a.Storage, i)
 }
 
 func (a *Array) Set(index uint64, value Value) (Storable, error) {
 	existingStorable, err := a.root.Set(a.Storage, a.Address(), index, value)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Set().
 		return nil, err
 	}
 
 	if a.root.IsFull() {
 		err = a.splitRoot()
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by Array.splitRoot().
 			return nil, err
 		}
 		return existingStorable, nil
@@ -1870,6 +2021,7 @@ func (a *Array) Set(index uint64, value Value) (Storable, error) {
 		if len(root.childrenHeaders) == 1 {
 			err = a.promoteChildAsNewRoot(root.childrenHeaders[0].id)
 			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by Array.promoteChildAsNewRoot().
 				return nil, err
 			}
 		}
@@ -1879,16 +2031,19 @@ func (a *Array) Set(index uint64, value Value) (Storable, error) {
 }
 
 func (a *Array) Append(value Value) error {
+	// Don't need to wrap error as external error because err is already categorized by Array.Insert().
 	return a.Insert(a.Count(), value)
 }
 
 func (a *Array) Insert(index uint64, value Value) error {
 	err := a.root.Insert(a.Storage, a.Address(), index, value)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Insert().
 		return err
 	}
 
 	if a.root.IsFull() {
+		// Don't need to wrap error as external error because err is already categorized by Array.splitRoot().
 		return a.splitRoot()
 	}
 
@@ -1898,6 +2053,7 @@ func (a *Array) Insert(index uint64, value Value) error {
 func (a *Array) Remove(index uint64) (Storable, error) {
 	storable, err := a.root.Remove(a.Storage, index)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Remove().
 		return nil, err
 	}
 
@@ -1907,6 +2063,7 @@ func (a *Array) Remove(index uint64) (Storable, error) {
 		if len(root.childrenHeaders) == 1 {
 			err = a.promoteChildAsNewRoot(root.childrenHeaders[0].id)
 			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by Array.promoteChildAsNewRoot().
 				return nil, err
 			}
 		}
@@ -1932,7 +2089,10 @@ func (a *Array) splitRoot() error {
 	// Assign a new storage id to old root before splitting it.
 	sID, err := a.Storage.GenerateStorageID(a.Address())
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf("failed to generate storage ID for address 0x%x", a.Address()))
 	}
 
 	oldRoot := a.root
@@ -1941,6 +2101,7 @@ func (a *Array) splitRoot() error {
 	// Split old root
 	leftSlab, rightSlab, err := oldRoot.Split(a.Storage)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.Split().
 		return err
 	}
 
@@ -1963,15 +2124,18 @@ func (a *Array) splitRoot() error {
 
 	err = a.Storage.Store(left.ID(), left)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", left.ID()))
 	}
 	err = a.Storage.Store(right.ID(), right)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", right.ID()))
 	}
 	err = a.Storage.Store(a.root.ID(), a.root)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.root.ID()))
 	}
 
 	return nil
@@ -1981,6 +2145,7 @@ func (a *Array) promoteChildAsNewRoot(childID StorageID) error {
 
 	child, err := getArraySlab(a.Storage, childID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return err
 	}
 
@@ -2002,11 +2167,13 @@ func (a *Array) promoteChildAsNewRoot(childID StorageID) error {
 
 	err = a.Storage.Store(rootID, a.root)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", rootID))
 	}
 	err = a.Storage.Remove(childID)
 	if err != nil {
-		return err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", childID))
 	}
 
 	return nil
@@ -2034,7 +2201,8 @@ func (i *ArrayIterator) Next() (Value, error) {
 
 		slab, found, err := i.storage.Retrieve(i.id)
 		if err != nil {
-			return nil, err
+			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+			return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to retrieve slab %s", i.id))
 		}
 		if !found {
 			return nil, NewSlabNotFoundErrorf(i.id, "slab not found during array iteration")
@@ -2049,7 +2217,8 @@ func (i *ArrayIterator) Next() (Value, error) {
 	if i.index < len(i.dataSlab.elements) {
 		element, err = i.dataSlab.elements[i.index].StoredValue(i.storage)
 		if err != nil {
-			return nil, err
+			// Wrap err as external error (if needed) because err is returned by Storable interface.
+			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get storable's stored value")
 		}
 
 		i.index++
@@ -2068,6 +2237,7 @@ func (i *ArrayIterator) Next() (Value, error) {
 func (a *Array) Iterator() (*ArrayIterator, error) {
 	slab, err := firstArrayDataSlab(a.Storage, a.root)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by firstArrayDataSlab().
 		return nil, err
 	}
 
@@ -2105,6 +2275,7 @@ func (a *Array) RangeIterator(startIndex uint64, endIndex uint64) (*ArrayIterato
 		var err error
 		dataSlab, err = firstArrayDataSlab(a.Storage, a.root)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by firstArrayDataSlab().
 			return nil, err
 		}
 	} else {
@@ -2114,6 +2285,7 @@ func (a *Array) RangeIterator(startIndex uint64, endIndex uint64) (*ArrayIterato
 		// Adjusted index must be used as index when creating ArrayIterator.
 		dataSlab, index, err = getArrayDataSlabWithIndex(a.Storage, a.root, startIndex)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by getArrayDataSlabWithIndex().
 			return nil, err
 		}
 	}
@@ -2133,12 +2305,14 @@ func (a *Array) Iterate(fn ArrayIterationFunc) error {
 
 	iterator, err := a.Iterator()
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by Array.Iterator().
 		return err
 	}
 
 	for {
 		value, err := iterator.Next()
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayIterator.Next().
 			return err
 		}
 		if value == nil {
@@ -2146,7 +2320,8 @@ func (a *Array) Iterate(fn ArrayIterationFunc) error {
 		}
 		resume, err := fn(value)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by ArrayIterationFunc callback.
+			return wrapErrorAsExternalErrorIfNeeded(err)
 		}
 		if !resume {
 			return nil
@@ -2158,12 +2333,14 @@ func (a *Array) IterateRange(startIndex uint64, endIndex uint64, fn ArrayIterati
 
 	iterator, err := a.RangeIterator(startIndex, endIndex)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by Array.RangeIterator().
 		return err
 	}
 
 	for {
 		value, err := iterator.Next()
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayIterator.Next().
 			return err
 		}
 		if value == nil {
@@ -2171,7 +2348,8 @@ func (a *Array) IterateRange(startIndex uint64, endIndex uint64, fn ArrayIterati
 		}
 		resume, err := fn(value)
 		if err != nil {
-			return err
+			// Wrap err as external error (if needed) because err is returned by ArrayIterationFunc callback.
+			return wrapErrorAsExternalErrorIfNeeded(err)
 		}
 		if !resume {
 			return nil
@@ -2217,7 +2395,8 @@ func (a *Array) String() string {
 func getArraySlab(storage SlabStorage, id StorageID) (ArraySlab, error) {
 	slab, found, err := storage.Retrieve(id)
 	if err != nil {
-		return nil, err
+		// err can be an external error because storage is an interface.
+		return nil, wrapErrorAsExternalErrorIfNeeded(err)
 	}
 	if !found {
 		return nil, NewSlabNotFoundErrorf(id, "array slab not found")
@@ -2237,8 +2416,10 @@ func firstArrayDataSlab(storage SlabStorage, slab ArraySlab) (*ArrayDataSlab, er
 	firstChildID := meta.childrenHeaders[0].id
 	firstChild, err := getArraySlab(storage, firstChildID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return nil, err
 	}
+	// Don't need to wrap error as external error because err is already categorized by firstArrayDataSlab().
 	return firstArrayDataSlab(storage, firstChild)
 }
 
@@ -2255,14 +2436,17 @@ func getArrayDataSlabWithIndex(storage SlabStorage, slab ArraySlab, index uint64
 	metaSlab := slab.(*ArrayMetaDataSlab)
 	_, adjustedIndex, childID, err := metaSlab.childSlabIndexInfo(index)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArrayMetadataSlab.childSlabIndexInfo().
 		return nil, 0, err
 	}
 
 	child, err := getArraySlab(storage, childID)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by getArraySlab().
 		return nil, 0, err
 	}
 
+	// Don't need to wrap error as external error because err is already categorized by getArrayDataSlabWithIndex().
 	return getArrayDataSlabWithIndex(storage, child, adjustedIndex)
 }
 
@@ -2274,6 +2458,7 @@ func (a *Array) PopIterate(fn ArrayPopIterationFunc) error {
 
 	err := a.root.PopIterate(a.Storage, fn)
 	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by ArraySlab.PopIterate().
 		return err
 	}
 
@@ -2291,7 +2476,13 @@ func (a *Array) PopIterate(fn ArrayPopIterationFunc) error {
 	}
 
 	// Save root slab
-	return a.Storage.Store(a.root.ID(), a.root)
+	err = a.Storage.Store(a.root.ID(), a.root)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.root.ID()))
+	}
+
+	return nil
 }
 
 type ArrayElementProvider func() (Value, error)
@@ -2302,7 +2493,10 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 
 	id, err := storage.GenerateStorageID(address)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf("failed to generate storage ID for address 0x%x", address))
 	}
 
 	dataSlab := &ArrayDataSlab{
@@ -2316,7 +2510,8 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 	for {
 		value, err := fn()
 		if err != nil {
-			return nil, err
+			// Wrap err as external error (if needed) because err is returned by ArrayElementProvider callback.
+			return nil, wrapErrorAsExternalErrorIfNeeded(err)
 		}
 		if value == nil {
 			break
@@ -2328,7 +2523,10 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 			// Generate storge id for next data slab
 			nextID, err := storage.GenerateStorageID(address)
 			if err != nil {
-				return nil, err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return nil, wrapErrorfAsExternalErrorIfNeeded(
+					err,
+					fmt.Sprintf("failed to generate storage ID for address 0x%x", address))
 			}
 
 			// Save next slab's storage id in data slab
@@ -2349,7 +2547,8 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 
 		storable, err := value.Storable(storage, address, MaxInlineArrayElementSize)
 		if err != nil {
-			return nil, err
+			// Wrap err as external error (if needed) because err is returned by Value interface.
+			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
 		}
 
 		// Append new element
@@ -2375,6 +2574,7 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 				// Rebalance with left
 				err := leftSib.LendToRight(lastSlab)
 				if err != nil {
+					// Don't need to wrap error as external error because err is already categorized by ArraySlab.LeftToRight().
 					return nil, err
 				}
 
@@ -2383,6 +2583,7 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 				// Merge with left
 				err := leftSib.Merge(lastSlab)
 				if err != nil {
+					// Don't need to wrap error as external error because err is already categorized by ArraySlab.Merge().
 					return nil, err
 				}
 
@@ -2404,13 +2605,17 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 		for _, slab := range slabs {
 			err = storage.Store(slab.ID(), slab)
 			if err != nil {
-				return nil, err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return nil, wrapErrorfAsExternalErrorIfNeeded(
+					err,
+					fmt.Sprintf("failed to store slab %s", slab.ID()))
 			}
 		}
 
 		// Get next level meta slabs
 		slabs, err = nextLevelArraySlabs(storage, address, slabs)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by nextLevelArraySlabs().
 			return nil, err
 		}
 
@@ -2432,7 +2637,8 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 	// Store root
 	err = storage.Store(root.ID(), root)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", root.ID()))
 	}
 
 	return &Array{
@@ -2453,7 +2659,10 @@ func nextLevelArraySlabs(storage SlabStorage, address Address, slabs []ArraySlab
 	// Generate storge id
 	id, err := storage.GenerateStorageID(address)
 	if err != nil {
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf("failed to generate storage ID for address 0x%x", address))
 	}
 
 	metaSlab := &ArrayMetaDataSlab{
@@ -2473,7 +2682,10 @@ func nextLevelArraySlabs(storage SlabStorage, address Address, slabs []ArraySlab
 			// Generate storge id for next meta data slab
 			id, err = storage.GenerateStorageID(address)
 			if err != nil {
-				return nil, err
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return nil, wrapErrorfAsExternalErrorIfNeeded(
+					err,
+					fmt.Sprintf("failed to generate storage ID for address 0x%x", address))
 			}
 
 			metaSlab = &ArrayMetaDataSlab{

--- a/array.go
+++ b/array.go
@@ -172,7 +172,7 @@ func newArrayExtraDataFromData(
 	// Check flag
 	flag := data[1]
 	if !isRoot(flag) {
-		return nil, data, NewDecodingError(fmt.Errorf("array extra data has invalid flag 0x%x, want root flag", flag))
+		return nil, data, NewDecodingErrorf("array extra data has invalid flag 0x%x, want root flag", flag)
 	}
 
 	// Decode extra data

--- a/array_test.go
+++ b/array_test.go
@@ -161,7 +161,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 	var indexOutOfBoundsError *IndexOutOfBoundsError
 	require.ErrorAs(t, err, &userError)
 	require.ErrorAs(t, err, &indexOutOfBoundsError)
-	require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+	require.ErrorAs(t, userError, &indexOutOfBoundsError)
 
 	verifyArray(t, storage, typeInfo, address, array, values, false)
 }
@@ -327,7 +327,7 @@ func TestArraySetAndGet(t *testing.T) {
 		var indexOutOfBoundsError *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 
 		verifyArray(t, storage, typeInfo, address, array, values, false)
 	})
@@ -444,7 +444,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 		var indexOutOfBoundsError *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 
 		verifyArray(t, storage, typeInfo, address, array, values, false)
 	})
@@ -630,7 +630,7 @@ func TestArrayRemove(t *testing.T) {
 		var indexOutOfBounds *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBounds)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBounds)
+		require.ErrorAs(t, userError, &indexOutOfBounds)
 
 		verifyArray(t, storage, typeInfo, address, array, values, false)
 	})
@@ -870,7 +870,7 @@ func testArrayIterateRange(t *testing.T, storage *PersistentSlabStorage, array *
 	var userError *UserError
 	require.ErrorAs(t, err, &userError)
 	require.ErrorAs(t, err, &sliceOutOfBoundsError)
-	require.ErrorAs(t, userError.Unwrap(), &sliceOutOfBoundsError)
+	require.ErrorAs(t, userError, &sliceOutOfBoundsError)
 	require.Equal(t, uint64(0), i)
 
 	// If endIndex > count, IterateRange returns SliceOutOfBoundsError
@@ -881,7 +881,7 @@ func testArrayIterateRange(t *testing.T, storage *PersistentSlabStorage, array *
 	require.Equal(t, 1, errorCategorizationCount(err))
 	require.ErrorAs(t, err, &userError)
 	require.ErrorAs(t, err, &sliceOutOfBoundsError)
-	require.ErrorAs(t, userError.Unwrap(), &sliceOutOfBoundsError)
+	require.ErrorAs(t, userError, &sliceOutOfBoundsError)
 	require.Equal(t, uint64(0), i)
 
 	// If startIndex > endIndex, IterateRange returns InvalidSliceIndexError
@@ -893,7 +893,7 @@ func testArrayIterateRange(t *testing.T, storage *PersistentSlabStorage, array *
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &invalidSliceIndexError)
-		require.ErrorAs(t, userError.Unwrap(), &invalidSliceIndexError)
+		require.ErrorAs(t, userError, &invalidSliceIndexError)
 		require.Equal(t, uint64(0), i)
 	}
 
@@ -1811,7 +1811,7 @@ func TestEmptyArray(t *testing.T) {
 		var indexOutOfBoundsError *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 		require.Nil(t, s)
 	})
 
@@ -1822,7 +1822,7 @@ func TestEmptyArray(t *testing.T) {
 		var indexOutOfBoundsError *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 		require.Nil(t, s)
 	})
 
@@ -1833,7 +1833,7 @@ func TestEmptyArray(t *testing.T) {
 		var indexOutOfBoundsError *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 	})
 
 	t.Run("remove", func(t *testing.T) {
@@ -1843,7 +1843,7 @@ func TestEmptyArray(t *testing.T) {
 		var indexOutOfBoundsError *IndexOutOfBoundsError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
-		require.ErrorAs(t, userError.Unwrap(), &indexOutOfBoundsError)
+		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 		require.Nil(t, s)
 	})
 
@@ -1986,7 +1986,7 @@ func TestArrayStoredValue(t *testing.T) {
 			var notValueError *NotValueError
 			require.ErrorAs(t, err, &fatalError)
 			require.ErrorAs(t, err, &notValueError)
-			require.ErrorAs(t, fatalError.Unwrap(), &notValueError)
+			require.ErrorAs(t, fatalError, &notValueError)
 			require.Nil(t, value)
 		}
 	}

--- a/array_test.go
+++ b/array_test.go
@@ -822,8 +822,11 @@ func TestArrayIterate(t *testing.T) {
 			i++
 			return true, nil
 		})
+		// err is testErr wrapped in ExternalError.
 		require.Error(t, err)
-		require.Equal(t, testErr, err)
+		var externalError *ExternalError
+		require.ErrorAs(t, err, &externalError)
+		require.Equal(t, testErr, externalError.Unwrap())
 		require.Equal(t, count/2, i)
 	})
 }
@@ -984,8 +987,11 @@ func TestArrayIterateRange(t *testing.T) {
 			i++
 			return true, nil
 		})
+		// err is testErr wrapped in ExternalError.
 		require.Error(t, err)
-		require.Equal(t, testErr, err)
+		var externalError *ExternalError
+		require.ErrorAs(t, err, &externalError)
+		require.Equal(t, testErr, externalError.Unwrap())
 		require.Equal(t, count/2, i)
 	})
 }

--- a/cmd/stress/storable.go
+++ b/cmd/stress/storable.go
@@ -353,7 +353,7 @@ func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, 
 		// Create StorableSlab
 		id, err := storage.GenerateStorageID(address)
 		if err != nil {
-			return nil, atree.NewStorageError(err)
+			return nil, err
 		}
 
 		slab := &atree.StorableSlab{

--- a/encode.go
+++ b/encode.go
@@ -97,7 +97,8 @@ func DecodeSlab(
 		cborDec := decMode.NewByteStreamDecoder(data[versionAndFlagSize:])
 		storable, err := decodeStorable(cborDec, id)
 		if err != nil {
-			return nil, NewDecodingError(err)
+			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
+			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode slab storable")
 		}
 		return StorableSlab{
 			StorageID: id,

--- a/hash.go
+++ b/hash.go
@@ -107,7 +107,8 @@ func (bdb *basicDigesterBuilder) Digest(hip HashInputProvider, value Value) (Dig
 	msg, err := hip(value, digester.scratch[:])
 	if err != nil {
 		putDigester(digester)
-		return nil, err
+		// Wrap err as external error (if needed) because err is returned by HashInputProvider callback.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to generate hash input")
 	}
 
 	digester.msg = msg
@@ -131,6 +132,7 @@ func (bd *basicDigester) DigestPrefix(level uint) ([]Digest, error) {
 	for i := uint(0); i < level; i++ {
 		d, err := bd.Digest(i)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by basicDigester.Digest().
 			return nil, err
 		}
 		prefix = append(prefix, d)

--- a/map_test.go
+++ b/map_test.go
@@ -507,8 +507,12 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		k := NewStringValue(randStr(r, 1024))
 		storable, err := m.Get(compare, hashInputProvider, k)
 		require.Nil(t, storable)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
 		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -546,8 +550,12 @@ func TestMapGetKeyNotFound(t *testing.T) {
 
 		storable, err := m.Get(compare, hashInputProvider, k)
 		require.Nil(t, storable)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
 		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -585,8 +593,12 @@ func TestMapGetKeyNotFound(t *testing.T) {
 
 		storable, err := m.Get(compare, hashInputProvider, k)
 		require.Nil(t, storable)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
 		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -658,7 +670,7 @@ func TestMapHas(t *testing.T) {
 
 		exist, err := m.Has(compare, hashInputProvider, Uint64Value(0))
 		// err is testErr wrapped in ExternalError.
-		require.Error(t, err)
+		require.Equal(t, 1, errorCategorizationCount(err))
 		var externalError *ExternalError
 		require.ErrorAs(t, err, &externalError)
 		require.Equal(t, testErr, externalError.Unwrap())
@@ -691,7 +703,12 @@ func testMapRemoveElement(t *testing.T, m *OrderedMap, k Value, expectedV Value)
 
 	// Remove the same key for the second time.
 	removedKeyStorable, removedValueStorable, err = m.Remove(compare, hashInputProvider, k)
-	require.Error(t, err, KeyNotFoundError{})
+	require.Equal(t, 1, errorCategorizationCount(err))
+	var userError *UserError
+	var keyNotFoundError *KeyNotFoundError
+	require.ErrorAs(t, err, &userError)
+	require.ErrorAs(t, err, &keyNotFoundError)
+	require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 	require.Nil(t, removedKeyStorable)
 	require.Nil(t, removedValueStorable)
 }
@@ -976,8 +993,12 @@ func TestMapRemove(t *testing.T) {
 		existingKeyStorable, existingValueStorable, err := m.Remove(compare, hashInputProvider, k)
 		require.Nil(t, existingKeyStorable)
 		require.Nil(t, existingValueStorable)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
 		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -1016,8 +1037,12 @@ func TestMapRemove(t *testing.T) {
 		existingKeyStorable, existingValueStorable, err := m.Remove(compare, hashInputProvider, k)
 		require.Nil(t, existingKeyStorable)
 		require.Nil(t, existingValueStorable)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
 		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2786,7 +2811,12 @@ func TestMapStoredValue(t *testing.T) {
 
 			verifyMap(t, storage, typeInfo, address, m2, keyValues, nil, false)
 		} else {
-			require.Error(t, err)
+			require.Equal(t, 1, errorCategorizationCount(err))
+			var fatalError *FatalError
+			var notValueError *NotValueError
+			require.ErrorAs(t, err, &fatalError)
+			require.ErrorAs(t, err, &notValueError)
+			require.ErrorAs(t, fatalError.Unwrap(), &notValueError)
 			require.Nil(t, value)
 		}
 	}
@@ -3008,13 +3038,23 @@ func TestEmptyMap(t *testing.T) {
 
 	t.Run("get", func(t *testing.T) {
 		s, err := m.Get(compare, hashInputProvider, Uint64Value(0))
-		require.Error(t, err, KeyNotFoundError{})
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
+		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
+		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 		require.Nil(t, s)
 	})
 
 	t.Run("remove", func(t *testing.T) {
 		existingKey, existingValue, err := m.Remove(compare, hashInputProvider, Uint64Value(0))
-		require.Error(t, err, KeyNotFoundError{})
+		require.Equal(t, 1, errorCategorizationCount(err))
+		var userError *UserError
+		var keyNotFoundError *KeyNotFoundError
+		require.ErrorAs(t, err, &userError)
+		require.ErrorAs(t, err, &keyNotFoundError)
+		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
 		require.Nil(t, existingKey)
 		require.Nil(t, existingValue)
 	})
@@ -3937,8 +3977,12 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 
 		for k, v := range collisionKeyValues {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, v)
+			require.Equal(t, 1, errorCategorizationCount(err))
+			var fatalError *FatalError
 			var collisionLimitError *CollisionLimitError
+			require.ErrorAs(t, err, &fatalError)
 			require.ErrorAs(t, err, &collisionLimitError)
+			require.ErrorAs(t, fatalError.Unwrap(), &collisionLimitError)
 			require.Nil(t, existingStorable)
 		}
 
@@ -4007,8 +4051,12 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 
 		for k, v := range collisionKeyValues {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, v)
+			require.Equal(t, 1, errorCategorizationCount(err))
+			var fatalError *FatalError
 			var collisionLimitError *CollisionLimitError
+			require.ErrorAs(t, err, &fatalError)
 			require.ErrorAs(t, err, &collisionLimitError)
+			require.ErrorAs(t, fatalError.Unwrap(), &collisionLimitError)
 			require.Nil(t, existingStorable)
 		}
 

--- a/map_test.go
+++ b/map_test.go
@@ -657,7 +657,11 @@ func TestMapHas(t *testing.T) {
 		require.NoError(t, err)
 
 		exist, err := m.Has(compare, hashInputProvider, Uint64Value(0))
-		require.Equal(t, testErr, err)
+		// err is testErr wrapped in ExternalError.
+		require.Error(t, err)
+		var externalError *ExternalError
+		require.ErrorAs(t, err, &externalError)
+		require.Equal(t, testErr, externalError.Unwrap())
 		require.False(t, exist)
 	})
 }

--- a/map_test.go
+++ b/map_test.go
@@ -512,7 +512,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -555,7 +555,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -598,7 +598,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -708,7 +708,7 @@ func testMapRemoveElement(t *testing.T, m *OrderedMap, k Value, expectedV Value)
 	var keyNotFoundError *KeyNotFoundError
 	require.ErrorAs(t, err, &userError)
 	require.ErrorAs(t, err, &keyNotFoundError)
-	require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+	require.ErrorAs(t, userError, &keyNotFoundError)
 	require.Nil(t, removedKeyStorable)
 	require.Nil(t, removedValueStorable)
 }
@@ -998,7 +998,7 @@ func TestMapRemove(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -1042,7 +1042,7 @@ func TestMapRemove(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2816,7 +2816,7 @@ func TestMapStoredValue(t *testing.T) {
 			var notValueError *NotValueError
 			require.ErrorAs(t, err, &fatalError)
 			require.ErrorAs(t, err, &notValueError)
-			require.ErrorAs(t, fatalError.Unwrap(), &notValueError)
+			require.ErrorAs(t, fatalError, &notValueError)
 			require.Nil(t, value)
 		}
 	}
@@ -3043,7 +3043,7 @@ func TestEmptyMap(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 		require.Nil(t, s)
 	})
 
@@ -3054,7 +3054,7 @@ func TestEmptyMap(t *testing.T) {
 		var keyNotFoundError *KeyNotFoundError
 		require.ErrorAs(t, err, &userError)
 		require.ErrorAs(t, err, &keyNotFoundError)
-		require.ErrorAs(t, userError.Unwrap(), &keyNotFoundError)
+		require.ErrorAs(t, userError, &keyNotFoundError)
 		require.Nil(t, existingKey)
 		require.Nil(t, existingValue)
 	})
@@ -3982,7 +3982,7 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 			var collisionLimitError *CollisionLimitError
 			require.ErrorAs(t, err, &fatalError)
 			require.ErrorAs(t, err, &collisionLimitError)
-			require.ErrorAs(t, fatalError.Unwrap(), &collisionLimitError)
+			require.ErrorAs(t, fatalError, &collisionLimitError)
 			require.Nil(t, existingStorable)
 		}
 
@@ -4056,7 +4056,7 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 			var collisionLimitError *CollisionLimitError
 			require.ErrorAs(t, err, &fatalError)
 			require.ErrorAs(t, err, &collisionLimitError)
-			require.ErrorAs(t, fatalError.Unwrap(), &collisionLimitError)
+			require.ErrorAs(t, fatalError, &collisionLimitError)
 			require.Nil(t, existingStorable)
 		}
 

--- a/slab_test.go
+++ b/slab_test.go
@@ -60,21 +60,21 @@ func TestIsRootOfAnObject(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 
 		isRoot, err = IsRootOfAnObject([]byte{})
 		require.False(t, isRoot)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 
 		isRoot, err = IsRootOfAnObject([]byte{0x00})
 		require.False(t, isRoot)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 	})
 }
 
@@ -114,21 +114,21 @@ func TestHasPointers(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 
 		hasPointers, err = HasPointers([]byte{})
 		require.False(t, hasPointers)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 
 		hasPointers, err = HasPointers([]byte{0x00})
 		require.False(t, hasPointers)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 	})
 }
 
@@ -168,20 +168,20 @@ func TestHasSizeLimit(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 
 		hasSizeLimit, err = HasSizeLimit([]byte{})
 		require.False(t, hasSizeLimit)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 
 		hasSizeLimit, err = HasSizeLimit([]byte{0x00})
 		require.False(t, hasSizeLimit)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
-		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
+		require.ErrorAs(t, fatalError, &decodingError)
 	})
 }

--- a/slab_test.go
+++ b/slab_test.go
@@ -50,21 +50,31 @@ func TestIsRootOfAnObject(t *testing.T) {
 	}
 
 	t.Run("data too short", func(t *testing.T) {
+		var fatalError *FatalError
 		var decodingError *DecodingError
 		var isRoot bool
 		var err error
 
 		isRoot, err = IsRootOfAnObject(nil)
 		require.False(t, isRoot)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 
 		isRoot, err = IsRootOfAnObject([]byte{})
 		require.False(t, isRoot)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 
 		isRoot, err = IsRootOfAnObject([]byte{0x00})
 		require.False(t, isRoot)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 	})
 }
 
@@ -94,21 +104,31 @@ func TestHasPointers(t *testing.T) {
 	}
 
 	t.Run("data too short", func(t *testing.T) {
+		var fatalError *FatalError
 		var decodingError *DecodingError
 		var hasPointers bool
 		var err error
 
 		hasPointers, err = HasPointers(nil)
 		require.False(t, hasPointers)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 
 		hasPointers, err = HasPointers([]byte{})
 		require.False(t, hasPointers)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 
 		hasPointers, err = HasPointers([]byte{0x00})
 		require.False(t, hasPointers)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 	})
 }
 
@@ -138,20 +158,30 @@ func TestHasSizeLimit(t *testing.T) {
 	}
 
 	t.Run("data too short", func(t *testing.T) {
+		var fatalError *FatalError
 		var decodingError *DecodingError
 		var hasSizeLimit bool
 		var err error
 
 		hasSizeLimit, err = HasSizeLimit(nil)
 		require.False(t, hasSizeLimit)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 
 		hasSizeLimit, err = HasSizeLimit([]byte{})
 		require.False(t, hasSizeLimit)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 
 		hasSizeLimit, err = HasSizeLimit([]byte{0x00})
 		require.False(t, hasSizeLimit)
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &decodingError)
+		require.ErrorAs(t, fatalError.Unwrap(), &decodingError)
 	})
 }

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -55,7 +55,8 @@ func (s StorableSlab) Encode(enc *Encoder) error {
 
 	err = s.Storable.Encode(enc)
 	if err != nil {
-		return NewEncodingError(err)
+		// Wrap err as external error (if needed) because err is returned by Storable interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode storable")
 	}
 
 	return nil
@@ -70,7 +71,12 @@ func (s StorableSlab) ID() StorageID {
 }
 
 func (s StorableSlab) StoredValue(storage SlabStorage) (Value, error) {
-	return s.Storable.StoredValue(storage)
+	value, err := s.Storable.StoredValue(storage)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by Storable interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get storable's stored value")
+	}
+	return value, nil
 }
 
 func (StorableSlab) Split(_ SlabStorage) (Slab, Slab, error) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -56,14 +56,14 @@ func TestNewStorageIDFromRawBytes(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
+		require.ErrorAs(t, fatalError, &storageIDError)
 
 		id, err = NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 2})
 		require.Equal(t, StorageIDUndefined, id)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
+		require.ErrorAs(t, fatalError, &storageIDError)
 	})
 
 	t.Run("data length == storage id size", func(t *testing.T) {
@@ -98,7 +98,7 @@ func TestStorageIDToRawBytes(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
+		require.ErrorAs(t, fatalError, &storageIDError)
 	})
 
 	t.Run("buffer too short", func(t *testing.T) {
@@ -111,7 +111,7 @@ func TestStorageIDToRawBytes(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
+		require.ErrorAs(t, fatalError, &storageIDError)
 	})
 
 	t.Run("undefined", func(t *testing.T) {
@@ -190,7 +190,7 @@ func TestStorageIDValid(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
+		require.ErrorAs(t, fatalError, &storageIDError)
 	})
 	t.Run("temp index", func(t *testing.T) {
 		id := StorageID{Address: Address{1}, Index: StorageIndexUndefined}
@@ -201,7 +201,7 @@ func TestStorageIDValid(t *testing.T) {
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
 		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
+		require.ErrorAs(t, fatalError, &storageIDError)
 	})
 	t.Run("temp address", func(t *testing.T) {
 		id := StorageID{Address: AddressUndefined, Index: StorageIndex{1}}

--- a/storage_test.go
+++ b/storage_test.go
@@ -48,14 +48,24 @@ func TestNewStorageID(t *testing.T) {
 
 func TestNewStorageIDFromRawBytes(t *testing.T) {
 	t.Run("data length < storage id size", func(t *testing.T) {
+		var fatalError *FatalError
+		var storageIDError *StorageIDError
+
 		id, err := NewStorageIDFromRawBytes(nil)
 		require.Equal(t, StorageIDUndefined, id)
-		require.Error(t, err, &StorageIDError{})
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
+		require.ErrorAs(t, err, &storageIDError)
+		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
 
 		id, err = NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 2})
 		require.Equal(t, StorageIDUndefined, id)
-		require.Error(t, err, &StorageIDError{})
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
+		require.ErrorAs(t, err, &storageIDError)
+		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
 	})
+
 	t.Run("data length == storage id size", func(t *testing.T) {
 		id, err := NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2})
 
@@ -80,16 +90,28 @@ func TestNewStorageIDFromRawBytes(t *testing.T) {
 
 func TestStorageIDToRawBytes(t *testing.T) {
 	t.Run("buffer nil", func(t *testing.T) {
+		var fatalError *FatalError
+		var storageIDError *StorageIDError
+
 		size, err := StorageIDUndefined.ToRawBytes(nil)
 		require.Equal(t, 0, size)
-		require.Error(t, err, &StorageIDError{})
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
+		require.ErrorAs(t, err, &storageIDError)
+		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
 	})
 
 	t.Run("buffer too short", func(t *testing.T) {
+		var fatalError *FatalError
+		var storageIDError *StorageIDError
+
 		b := make([]byte, 8)
 		size, err := StorageIDUndefined.ToRawBytes(b)
 		require.Equal(t, 0, size)
-		require.Error(t, err, &StorageIDError{})
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
+		require.ErrorAs(t, err, &storageIDError)
+		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
 	})
 
 	t.Run("undefined", func(t *testing.T) {
@@ -161,11 +183,25 @@ func TestStorageIDIndexAsUint64(t *testing.T) {
 func TestStorageIDValid(t *testing.T) {
 	t.Run("undefined", func(t *testing.T) {
 		id := StorageIDUndefined
-		require.Error(t, id.Valid(), &StorageIDError{})
+		err := id.Valid()
+
+		var fatalError *FatalError
+		var storageIDError *StorageIDError
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
+		require.ErrorAs(t, err, &storageIDError)
+		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
 	})
 	t.Run("temp index", func(t *testing.T) {
 		id := StorageID{Address: Address{1}, Index: StorageIndexUndefined}
-		require.Error(t, id.Valid(), &StorageIDError{})
+		err := id.Valid()
+
+		var fatalError *FatalError
+		var storageIDError *StorageIDError
+		require.Equal(t, 1, errorCategorizationCount(err))
+		require.ErrorAs(t, err, &fatalError)
+		require.ErrorAs(t, err, &storageIDError)
+		require.ErrorAs(t, fatalError.Unwrap(), &storageIDError)
 	})
 	t.Run("temp address", func(t *testing.T) {
 		id := StorageID{Address: AddressUndefined, Index: StorageIndex{1}}
@@ -823,7 +859,12 @@ func TestPersistentStorage(t *testing.T) {
 		}
 
 		err = storage.FastCommit(2)
+		require.Equal(t, 1, errorCategorizationCount(err))
+
+		var externalError *ExternalError
+		require.ErrorAs(t, err, &externalError)
 		require.ErrorIs(t, err, errEncodeNonStorable)
+		require.ErrorIs(t, externalError.Unwrap(), errEncodeNonStorable)
 	})
 }
 


### PR DESCRIPTION
### Changes

This PR improves error handling and error passing between Atree, Cadence, and FVM.

- Categorize errors into `FatalError`, `ExternalError`, and `UserError`.
- Implement `Unwrap()` for `FatalError`, `ExternalError`, and `UserError`.
- Add tests for error categorization, etc.

Closes #285
Updates https://github.com/onflow/cadence/issues/1255 

### Details

Errors are categorized as early as feasible.  Changes only affect the error paths (avoids affecting the happy paths).

Here, the word "pluggable" describes interfaces or callback functions that might be implemented by packages external to Atree.

Basically, when Atree:
- Creates an error: create either FatalError or UserError.
- Receives error from known packages: wrap the error in FatalError or UserError.
- Receives error from pluggable interfaces or callback functions: wrap the error as ExternalError only if it is not categorized already.
- Receives error from its own functions:  there's no need to categorize error because it's already categorized, so just wrap the error with more context if needed.

Pluggable interfaces:
- `Ledger`
- `BaseStorage`
- `SlabStorage`
- `TypeInfo`
- `Value`
- `Storable`
- `DigesterBuilder`
- `Digester`

Pluggable callback functions:
- `StorableDecoder`
- `TypeInfoDecoder`
- `ValueComparator`
- `StorableComparator`
- `HashInputProvider`
- `ArrayElementProvider`
- `MapElementProvider`
- `ArrayIterationFunc`
- `MapEntryIterationFunc`
- `MapElementIterationFunc`
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
