### PR TITLE
Add ignore filters to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "github.com/fxamacker/cbor/v2"
+      - dependency-name: "github.com/fxamacker/circlehash"
+


### PR DESCRIPTION
Prevent accidental version bumps to avoid potential compatibility issues for:
- fxamacker/cbor
- fxamacker/circlehash

E.g. We use stream-mode branch of fxamacker/cbor, etc. so we don't want automatic update suggestions like PR #288.
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
