### PR TITLE
Optimize max map value size to reduce number of registers

### DIFF
--- a/array.go
+++ b/array.go
@@ -480,7 +480,7 @@ func (a *ArrayDataSlab) Set(storage SlabStorage, address Address, index uint64, 
 	oldElem := a.elements[index]
 	oldSize := oldElem.ByteSize()
 
-	storable, err := value.Storable(storage, address, MaxInlineArrayElementSize)
+	storable, err := value.Storable(storage, address, maxInlineArrayElementSize)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -503,7 +503,7 @@ func (a *ArrayDataSlab) Insert(storage SlabStorage, address Address, index uint6
 		return NewIndexOutOfBoundsError(index, 0, uint64(len(a.elements)))
 	}
 
-	storable, err := value.Storable(storage, address, MaxInlineArrayElementSize)
+	storable, err := value.Storable(storage, address, maxInlineArrayElementSize)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -2545,7 +2545,7 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 
 		}
 
-		storable, err := value.Storable(storage, address, MaxInlineArrayElementSize)
+		storable, err := value.Storable(storage, address, maxInlineArrayElementSize)
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by Value interface.
 			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -90,7 +90,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	// setup
 	for i := 0; i < initialArraySize; i++ {
 		v := RandomValue(r)
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 		totalRawDataSize += storable.ByteSize()
 		err = array.Append(v)
@@ -110,7 +110,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	for i := 0; i < numberOfElements; i++ {
 		v := RandomValue(r)
 
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 
 		totalRawDataSize += storable.ByteSize()
@@ -148,7 +148,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 		ind := r.Intn(int(array.Count()))
 		v := RandomValue(r)
 
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 
 		totalRawDataSize += storable.ByteSize()
@@ -221,7 +221,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 	for i := 0; i < initialArraySize; i++ {
 		v := RandomValue(r)
 
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 
 		totalRawDataSize += storable.ByteSize()
@@ -243,7 +243,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 		case 1: // insert
 			v := RandomValue(r)
 
-			storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+			storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 			require.NoError(b, err)
 
 			totalRawDataSize += storable.ByteSize()

--- a/array_debug.go
+++ b/array_debug.go
@@ -281,9 +281,9 @@ func validArraySlab(
 		for _, e := range dataSlab.elements {
 
 			// Verify element size is <= inline size
-			if e.ByteSize() > uint32(MaxInlineArrayElementSize) {
+			if e.ByteSize() > uint32(maxInlineArrayElementSize) {
 				return 0, nil, nil, NewFatalError(fmt.Errorf("data slab %d element %s size %d is too large, want < %d",
-					id, e, e.ByteSize(), MaxInlineArrayElementSize))
+					id, e, e.ByteSize(), maxInlineArrayElementSize))
 			}
 
 			computedSize += e.ByteSize()

--- a/array_test.go
+++ b/array_test.go
@@ -1095,7 +1095,7 @@ func TestArraySetRandomValues(t *testing.T) {
 
 	for i := uint64(0); i < arraySize; i++ {
 		oldValue := values[i]
-		newValue := randomValue(r, int(MaxInlineArrayElementSize))
+		newValue := randomValue(r, int(maxInlineArrayElementSize))
 		values[i] = newValue
 
 		existingStorable, err := array.Set(i, newValue)
@@ -1129,7 +1129,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 		values := make([]Value, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 			values[arraySize-i-1] = v
 
 			err := array.Insert(0, v)
@@ -1154,7 +1154,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 		values := make([]Value, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 			values[i] = v
 
 			err := array.Insert(i, v)
@@ -1180,7 +1180,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 		values := make([]Value, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
 			k := r.Intn(int(i) + 1)
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 
 			copy(values[k+1:], values[k:])
 			values[k] = v
@@ -1212,7 +1212,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 	values := make([]Value, arraySize)
 	// Insert n random values into array
 	for i := uint64(0); i < arraySize; i++ {
-		v := randomValue(r, int(MaxInlineArrayElementSize))
+		v := randomValue(r, int(maxInlineArrayElementSize))
 		values[i] = v
 
 		err := array.Insert(i, v)
@@ -1279,7 +1279,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 		switch nextOp {
 
 		case ArrayAppendOp:
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 			values = append(values, v)
 
 			err := array.Append(v)
@@ -1287,7 +1287,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 
 		case ArraySetOp:
 			k := r.Intn(int(array.Count()))
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 
 			oldV := values[k]
 
@@ -1307,7 +1307,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 
 		case ArrayInsertOp:
 			k := r.Intn(int(array.Count() + 1))
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 
 			if k == int(array.Count()) {
 				values = append(values, v)
@@ -1879,7 +1879,7 @@ func TestArrayStringElement(t *testing.T) {
 
 		r := newRand(t)
 
-		stringSize := int(MaxInlineArrayElementSize - 3)
+		stringSize := int(maxInlineArrayElementSize - 3)
 
 		values := make([]Value, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
@@ -1912,7 +1912,7 @@ func TestArrayStringElement(t *testing.T) {
 
 		r := newRand(t)
 
-		stringSize := int(MaxInlineArrayElementSize + 512)
+		stringSize := int(maxInlineArrayElementSize + 512)
 
 		values := make([]Value, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
@@ -2209,7 +2209,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		var values []Value
 		var v Value
 
-		v = NewStringValue(strings.Repeat("a", int(MaxInlineArrayElementSize-2)))
+		v = NewStringValue(strings.Repeat("a", int(maxInlineArrayElementSize-2)))
 		values = append(values, v)
 
 		err = array.Insert(0, v)
@@ -2265,7 +2265,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		v = NewStringValue(strings.Repeat("a", int(MaxInlineArrayElementSize-2)))
+		v = NewStringValue(strings.Repeat("a", int(maxInlineArrayElementSize-2)))
 		values = append(values, nil)
 		copy(values[25+1:], values[25:])
 		values[25] = v
@@ -2312,7 +2312,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		values := make([]Value, arraySize)
 		for i := uint64(0); i < arraySize; i++ {
-			v := randomValue(r, int(MaxInlineArrayElementSize))
+			v := randomValue(r, int(maxInlineArrayElementSize))
 			values[i] = v
 
 			err := array.Append(v)
@@ -2361,17 +2361,17 @@ func TestArrayFromBatchData(t *testing.T) {
 		var values []Value
 		var v Value
 
-		v = NewStringValue(randStr(r, int(MaxInlineArrayElementSize-2)))
+		v = NewStringValue(randStr(r, int(maxInlineArrayElementSize-2)))
 		values = append(values, v)
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		v = NewStringValue(randStr(r, int(MaxInlineArrayElementSize-2)))
+		v = NewStringValue(randStr(r, int(maxInlineArrayElementSize-2)))
 		values = append(values, v)
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		v = NewStringValue(randStr(r, int(MaxInlineArrayElementSize-2)))
+		v = NewStringValue(randStr(r, int(maxInlineArrayElementSize-2)))
 		values = append(values, v)
 		err = array.Append(v)
 		require.NoError(t, err)
@@ -2438,7 +2438,7 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	var values []Value
 	for i := 0; i < 2; i++ {
 		// String length is MaxInlineArrayElementSize - 3 to account for string encoding overhead.
-		v := NewStringValue(randStr(r, int(MaxInlineArrayElementSize-3)))
+		v := NewStringValue(randStr(r, int(maxInlineArrayElementSize-3)))
 		values = append(values, v)
 
 		err = array.Append(v)
@@ -2561,7 +2561,7 @@ func TestArraySlabDump(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		err = array.Append(NewStringValue(strings.Repeat("a", int(MaxInlineArrayElementSize))))
+		err = array.Append(NewStringValue(strings.Repeat("a", int(maxInlineArrayElementSize))))
 		require.NoError(t, err)
 
 		want := []string{

--- a/basicarray.go
+++ b/basicarray.go
@@ -316,7 +316,7 @@ func (a *BasicArray) Get(index uint64) (Value, error) {
 }
 
 func (a *BasicArray) Set(index uint64, v Value) error {
-	storable, err := v.Storable(a.storage, a.Address(), MaxInlineArrayElementSize)
+	storable, err := v.Storable(a.storage, a.Address(), maxInlineArrayElementSize)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -332,7 +332,7 @@ func (a *BasicArray) Append(v Value) error {
 }
 
 func (a *BasicArray) Insert(index uint64, v Value) error {
-	storable, err := v.Storable(a.storage, a.Address(), MaxInlineArrayElementSize)
+	storable, err := v.Storable(a.storage, a.Address(), maxInlineArrayElementSize)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")

--- a/basicarray_benchmark_test.go
+++ b/basicarray_benchmark_test.go
@@ -79,7 +79,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	// setup
 	for i := 0; i < initialArraySize; i++ {
 		v := RandomValue(r)
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 		totalRawDataSize += storable.ByteSize()
 		err = array.Append(v)
@@ -98,7 +98,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	start = time.Now()
 	for i := 0; i < numberOfElements; i++ {
 		v := RandomValue(r)
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 		totalRawDataSize += storable.ByteSize()
 		err = array.Append(v)
@@ -117,7 +117,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 		ind := r.Intn(int(array.Count()))
 		s, err := array.Remove(uint64(ind))
 		require.NoError(b, err)
-		storable, err := s.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := s.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 		totalRawDataSize -= storable.ByteSize()
 	}
@@ -133,7 +133,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	for i := 0; i < numberOfElements; i++ {
 		ind := r.Intn(int(array.Count()))
 		v := RandomValue(r)
-		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize)
+		storable, err := v.Storable(storage, array.Address(), maxInlineArrayElementSize)
 		require.NoError(b, err)
 		totalRawDataSize += storable.ByteSize()
 		err = array.Insert(uint64(ind), v)

--- a/map.go
+++ b/map.go
@@ -453,13 +453,13 @@ func newElementFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDeco
 
 func newSingleElement(storage SlabStorage, address Address, key Value, value Value) (*singleElement, error) {
 
-	ks, err := key.Storable(storage, address, MaxInlineMapKeyOrValueSize)
+	ks, err := key.Storable(storage, address, maxInlineMapKeySize)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get key's storable")
 	}
 
-	vs, err := value.Storable(storage, address, MaxInlineMapKeyOrValueSize)
+	vs, err := value.Storable(storage, address, maxInlineMapValueSize(uint64(ks.ByteSize())))
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -598,7 +598,7 @@ func (e *singleElement) Set(
 	if equal {
 		existingValue := e.value
 
-		valueStorable, err := value.Storable(storage, address, MaxInlineMapKeyOrValueSize)
+		valueStorable, err := value.Storable(storage, address, maxInlineMapValueSize(uint64(e.key.ByteSize())))
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by Value interface.
 			return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -1925,7 +1925,7 @@ func (e *singleElements) Set(storage SlabStorage, address Address, b DigesterBui
 
 			oldSize := elem.Size()
 
-			vs, err := value.Storable(storage, address, MaxInlineMapKeyOrValueSize)
+			vs, err := value.Storable(storage, address, maxInlineMapValueSize(uint64(elem.key.ByteSize())))
 			if err != nil {
 				// Wrap err as external error (if needed) because err is returned by Value interface.
 				return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")

--- a/settings.go
+++ b/settings.go
@@ -31,12 +31,12 @@ const (
 )
 
 var (
-	targetThreshold            uint64
-	minThreshold               uint64
-	maxThreshold               uint64
-	MaxInlineArrayElementSize  uint64
-	maxInlineMapElementSize    uint64
-	MaxInlineMapKeyOrValueSize uint64
+	targetThreshold           uint64
+	minThreshold              uint64
+	maxThreshold              uint64
+	maxInlineArrayElementSize uint64
+	maxInlineMapElementSize   uint64
+	maxInlineMapKeySize       uint64
 )
 
 func init() {
@@ -54,7 +54,7 @@ func SetThreshold(threshold uint64) (uint64, uint64, uint64, uint64) {
 
 	// Total slab size available for array elements, excluding slab encoding overhead
 	availableArrayElementsSize := targetThreshold - arrayDataSlabPrefixSize
-	MaxInlineArrayElementSize = availableArrayElementsSize / minElementCountInSlab
+	maxInlineArrayElementSize = availableArrayElementsSize / minElementCountInSlab
 
 	// Total slab size available for map elements, excluding slab encoding overhead
 	availableMapElementsSize := targetThreshold - mapDataSlabPrefixSize - hkeyElementsPrefixSize
@@ -65,8 +65,20 @@ func SetThreshold(threshold uint64) (uint64, uint64, uint64, uint64) {
 	// Max inline size for a map's element
 	maxInlineMapElementSize = availableMapElementsSize/minElementCountInSlab - mapElementOverheadSize
 
-	// Max inline size for a map's key or value, excluding element encoding overhead
-	MaxInlineMapKeyOrValueSize = (maxInlineMapElementSize - singleElementPrefixSize) / 2
+	// Max inline size for a map's key, excluding element overhead
+	maxInlineMapKeySize = (maxInlineMapElementSize - singleElementPrefixSize) / 2
 
-	return minThreshold, maxThreshold, MaxInlineArrayElementSize, MaxInlineMapKeyOrValueSize
+	return minThreshold, maxThreshold, maxInlineArrayElementSize, maxInlineMapKeySize
+}
+
+func MaxInlineArrayElementSize() uint64 {
+	return maxInlineArrayElementSize
+}
+
+func MaxInlineMapKeySize() uint64 {
+	return maxInlineMapKeySize
+}
+
+func maxInlineMapValueSize(keySize uint64) uint64 {
+	return maxInlineMapElementSize - keySize - singleElementPrefixSize
 }


### PR DESCRIPTION
Closes #313
Updates #296 #292 https://github.com/onflow/flow-go/issues/1744

## Description

Previously, both max map key size and max map value size were the same (about half of max map element size).  However, key size can be much smaller than max limit and max value size didn't benefit from smaller key.

Optimize this by computing max map value size to subtract encoded key size from max map element size.  So large value can be stored along with small key to reduce number of registers.

While at it, also replace exported settings with exported functions.

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
