### PR TITLE
Change `OrderedMap.Get()` to return `Value` instead of `Storable`

### DIFF
--- a/cmd/stress/map.go
+++ b/cmd/stress/map.go
@@ -390,13 +390,9 @@ func checkMapDataLoss(m *atree.OrderedMap, elements map[atree.Value]atree.Value)
 
 	// Check every element
 	for k, v := range elements {
-		storable, err := m.Get(compare, hashInputProvider, k)
+		convertedValue, err := m.Get(compare, hashInputProvider, k)
 		if err != nil {
 			return fmt.Errorf("failed to get element with key %s: %w", k, err)
-		}
-		convertedValue, err := storable.StoredValue(m.Storage)
-		if err != nil {
-			return fmt.Errorf("failed to convert storable to value with key %s: %w", k, err)
 		}
 		err = valueEqual(v, convertedValue)
 		if err != nil {

--- a/map.go
+++ b/map.go
@@ -3606,7 +3606,7 @@ func NewMapWithRootID(storage SlabStorage, rootID StorageID, digestBuilder Diges
 }
 
 func (m *OrderedMap) Has(comparator ValueComparator, hip HashInputProvider, key Value) (bool, error) {
-	_, err := m.Get(comparator, hip, key)
+	_, err := m.get(comparator, hip, key)
 	if err != nil {
 		var knf *KeyNotFoundError
 		if errors.As(err, &knf) {
@@ -3618,7 +3618,23 @@ func (m *OrderedMap) Has(comparator ValueComparator, hip HashInputProvider, key 
 	return true, nil
 }
 
-func (m *OrderedMap) Get(comparator ValueComparator, hip HashInputProvider, key Value) (Storable, error) {
+func (m *OrderedMap) Get(comparator ValueComparator, hip HashInputProvider, key Value) (Value, error) {
+
+	storable, err := m.get(comparator, hip, key)
+	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by MapSlab.Get().
+		return nil, err
+	}
+
+	v, err := storable.StoredValue(m.Storage)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by Storable interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get storable's stored value")
+	}
+	return v, nil
+}
+
+func (m *OrderedMap) get(comparator ValueComparator, hip HashInputProvider, key Value) (Storable, error) {
 
 	keyDigest, err := m.digesterBuilder.Digest(hip, key)
 	if err != nil {

--- a/map_test.go
+++ b/map_test.go
@@ -119,10 +119,7 @@ func verifyMap(
 
 	// Verify map elements
 	for k, v := range keyValues {
-		s, err := m.Get(compare, hashInputProvider, k)
-		require.NoError(t, err)
-
-		e, err := s.StoredValue(m.Storage)
+		e, err := m.Get(compare, hashInputProvider, k)
 		require.NoError(t, err)
 
 		valueEqual(t, typeInfoComparator, v, e)


### PR DESCRIPTION
Closes #317
Updates #296 #292

## Description

This PR changes `OrderedMap.Get()` to return `Value` instead of `Storable`.

Currently, `OrderedMap.Get()` returns `Storable` and client converts returned `Storable` to `Value`.  However, it only makes sense to return `Storable` if client needs to remove register (slab) by `StorageID` (StorageIDStorable).

`Get()` should only provide value without possibility of client manipulating the underlying storable.

This is prep work for Atree Register Inlining (#292) and will also harden the API.

Corresponding PR for `Array.Get()` is PR #316. 

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
