### PR TITLE
Add `Array.ID()` and `OrderedMap.ID()`

### DIFF
--- a/array.go
+++ b/array.go
@@ -2373,6 +2373,16 @@ func (a *Array) StorageID() StorageID {
 	return a.root.ID()
 }
 
+func (a *Array) ID() ID {
+	sid := a.StorageID()
+
+	var id ID
+	copy(id[:], sid.Address[:])
+	copy(id[8:], sid.Index[:])
+
+	return id
+}
+
 func (a *Array) Type() TypeInfo {
 	if extraData := a.root.ExtraData(); extraData != nil {
 		return extraData.TypeInfo

--- a/array_test.go
+++ b/array_test.go
@@ -2589,3 +2589,18 @@ func errorCategorizationCount(err error) int {
 	}
 	return count
 }
+
+func TestArrayID(t *testing.T) {
+	typeInfo := testTypeInfo{42}
+	storage := newTestPersistentStorage(t)
+	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+	array, err := NewArray(storage, address, typeInfo)
+	require.NoError(t, err)
+
+	sid := array.StorageID()
+	id := array.ID()
+
+	require.Equal(t, sid.Address[:], id[:8])
+	require.Equal(t, sid.Index[:], id[8:])
+}

--- a/map.go
+++ b/map.go
@@ -3862,6 +3862,16 @@ func (m *OrderedMap) StorageID() StorageID {
 	return m.root.Header().id
 }
 
+func (m *OrderedMap) ID() ID {
+	sid := m.StorageID()
+
+	var id ID
+	copy(id[:], sid.Address[:])
+	copy(id[8:], sid.Index[:])
+
+	return id
+}
+
 func (m *OrderedMap) StoredValue(_ SlabStorage) (Value, error) {
 	return m, nil
 }

--- a/map_test.go
+++ b/map_test.go
@@ -4217,3 +4217,18 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 		verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 }
+
+func TestMapID(t *testing.T) {
+	typeInfo := testTypeInfo{42}
+	storage := newTestPersistentStorage(t)
+	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+	m, err := NewMap(storage, address, newBasicDigesterBuilder(), typeInfo)
+	require.NoError(t, err)
+
+	sid := m.StorageID()
+	id := m.ID()
+
+	require.Equal(t, sid.Address[:], id[:8])
+	require.Equal(t, sid.Index[:], id[8:])
+}

--- a/storage.go
+++ b/storage.go
@@ -31,6 +31,8 @@ import (
 
 const LedgerBaseStorageSlabPrefix = "$"
 
+type ID [16]byte
+
 type (
 	Address      [8]byte
 	StorageIndex [8]byte


### PR DESCRIPTION
Closes #320
Updates #296 #292 https://github.com/onflow/flow-go/issues/1744

## Description

Currently `Array.StorageID()` and `OrderedMap.StorageID()` are used as identifier in client because storage IDs are guaranteed to unique. However, storage ID should be only used to retrieve slabs (registers) from storage.

Also, when Atree register inlining is implemented in the future, some resources may not be stored in separate slabs, so they will not have storage IDs anymore.

This PR adds `ID()` to uniquly identify `Array` and `OrderedMap`.  For now, this is implemented to be identical to `StorageID()` in raw bytes ([16]bytes).  In the future, this can be changed to be decoupled from storage ID completely.  

Clients should use `ID()` instead of `StorageID()` to identify Atree composite values.
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
