### PR TITLE
Rename StorageID related types, vars, and funcs

### DIFF
--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -204,7 +204,7 @@ func setupArray(b *testing.B, r *rand.Rand, storage *PersistentSlabStorage, init
 	err = storage.Commit()
 	require.NoError(b, err)
 
-	arrayID := array.StorageID()
+	arrayID := array.SlabID()
 
 	storage.DropCache()
 

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -99,7 +99,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	require.NoError(b, storage.Commit())
 	b.ResetTimer()
 
-	arrayID := array.StorageID()
+	arrayID := array.SlabID()
 
 	// append
 	storage.DropCache()

--- a/array_test.go
+++ b/array_test.go
@@ -100,12 +100,12 @@ func verifyArray(
 	rootIDSet, err := CheckStorageHealth(storage, 1)
 	require.NoError(t, err)
 
-	rootIDs := make([]StorageID, 0, len(rootIDSet))
+	rootIDs := make([]SlabID, 0, len(rootIDSet))
 	for id := range rootIDSet {
 		rootIDs = append(rootIDs, id)
 	}
 	require.Equal(t, 1, len(rootIDs))
-	require.Equal(t, array.StorageID(), rootIDs[0])
+	require.Equal(t, array.SlabID(), rootIDs[0])
 
 	if !hasNestedArrayMapElement {
 		// Need to call Commit before calling storage.Count() for PersistentSlabStorage.
@@ -483,8 +483,8 @@ func TestArrayRemove(t *testing.T) {
 
 			valueEqual(t, typeInfoComparator, values[i], existingValue)
 
-			if id, ok := existingStorable.(StorageIDStorable); ok {
-				err = array.Storage.Remove(StorageID(id))
+			if id, ok := existingStorable.(SlabIDStorable); ok {
+				err = array.Storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 
@@ -530,8 +530,8 @@ func TestArrayRemove(t *testing.T) {
 
 			valueEqual(t, typeInfoComparator, values[i], existingValue)
 
-			if id, ok := existingStorable.(StorageIDStorable); ok {
-				err = array.Storage.Remove(StorageID(id))
+			if id, ok := existingStorable.(SlabIDStorable); ok {
+				err = array.Storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 
@@ -580,8 +580,8 @@ func TestArrayRemove(t *testing.T) {
 
 			valueEqual(t, typeInfoComparator, v, existingValue)
 
-			if id, ok := existingStorable.(StorageIDStorable); ok {
-				err = array.Storage.Remove(StorageID(id))
+			if id, ok := existingStorable.(SlabIDStorable); ok {
+				err = array.Storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 
@@ -1025,7 +1025,7 @@ func TestArrayIterateRange(t *testing.T) {
 	})
 }
 
-func TestArrayRootStorageID(t *testing.T) {
+func TestArrayRootSlabID(t *testing.T) {
 	SetThreshold(256)
 	defer SetThreshold(1024)
 
@@ -1038,14 +1038,14 @@ func TestArrayRootStorageID(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	savedRootID := array.StorageID()
-	require.NotEqual(t, StorageIDUndefined, savedRootID)
+	savedRootID := array.SlabID()
+	require.NotEqual(t, SlabIDUndefined, savedRootID)
 
 	// Append elements
 	for i := uint64(0); i < arraySize; i++ {
 		err := array.Append(Uint64Value(i))
 		require.NoError(t, err)
-		require.Equal(t, savedRootID, array.StorageID())
+		require.Equal(t, savedRootID, array.SlabID())
 	}
 
 	require.True(t, typeInfoComparator(typeInfo, array.Type()))
@@ -1057,13 +1057,13 @@ func TestArrayRootStorageID(t *testing.T) {
 		storable, err := array.Remove(0)
 		require.NoError(t, err)
 		require.Equal(t, Uint64Value(i), storable)
-		require.Equal(t, savedRootID, array.StorageID())
+		require.Equal(t, savedRootID, array.SlabID())
 	}
 
 	require.True(t, typeInfoComparator(typeInfo, array.Type()))
 	require.Equal(t, address, array.Address())
 	require.Equal(t, uint64(0), array.Count())
-	require.Equal(t, savedRootID, array.StorageID())
+	require.Equal(t, savedRootID, array.SlabID())
 }
 
 func TestArraySetRandomValues(t *testing.T) {
@@ -1232,8 +1232,8 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 		copy(values[k:], values[k+1:])
 		values = values[:len(values)-1]
 
-		if id, ok := existingStorable.(StorageIDStorable); ok {
-			err = storage.Remove(StorageID(id))
+		if id, ok := existingStorable.(SlabIDStorable); ok {
+			err = storage.Remove(SlabID(id))
 			require.NoError(t, err)
 		}
 	}
@@ -1297,8 +1297,8 @@ func testArrayAppendSetInsertRemoveRandomValues(
 			require.NoError(t, err)
 			valueEqual(t, typeInfoComparator, oldV, existingValue)
 
-			if id, ok := existingStorable.(StorageIDStorable); ok {
-				err = storage.Remove(StorageID(id))
+			if id, ok := existingStorable.(SlabIDStorable); ok {
+				err = storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 
@@ -1330,8 +1330,8 @@ func testArrayAppendSetInsertRemoveRandomValues(
 			copy(values[k:], values[k+1:])
 			values = values[:len(values)-1]
 
-			if id, ok := existingStorable.(StorageIDStorable); ok {
-				err = storage.Remove(StorageID(id))
+			if id, ok := existingStorable.(SlabIDStorable); ok {
+				err = storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 		}
@@ -1545,13 +1545,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 		slabData, err := storage.Encode()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(slabData))
-		require.Equal(t, expectedData, slabData[array.StorageID()])
+		require.Equal(t, expectedData, slabData[array.SlabID()])
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, slabData)
 
 		// Test new array from storage2
-		array2, err := NewArrayWithRootID(storage2, array.StorageID())
+		array2, err := NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
 		verifyEmptyArray(t, storage2, typeInfo, address, array2)
@@ -1594,13 +1594,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 		slabData, err := storage.Encode()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(slabData))
-		require.Equal(t, expectedData, slabData[array.StorageID()])
+		require.Equal(t, expectedData, slabData[array.SlabID()])
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, slabData)
 
 		// Test new array from storage2
-		array2, err := NewArrayWithRootID(storage2, array.StorageID())
+		array2, err := NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
 		verifyArray(t, storage2, typeInfo, address, array2, values, false)
@@ -1639,13 +1639,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 		require.Equal(t, uint64(arraySize), array.Count())
 		require.Equal(t, uint64(1), nestedArray.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 3}}
-		id4 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 4}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id4 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
 
-		// Expected serialized slab data with storage id
-		expected := map[StorageID][]byte{
+		// Expected serialized slab data with slab id
+		expected := map[SlabID][]byte{
 
 			// (metadata slab) headers: [{id:2 size:228 count:9} {id:3 size:270 count:11} ]
 			id1: {
@@ -1665,7 +1665,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x81,
 				// child header count
 				0x00, 0x02,
-				// child header 1 (storage id, count, size)
+				// child header 1 (slab id, count, size)
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 				0x00, 0x00, 0x00, 0x09,
 				0x00, 0x00, 0x00, 0xe4,
@@ -1681,7 +1681,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x00,
 				// array data slab flag
 				0x00,
-				// next storage id
+				// next slab id
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x09,
@@ -1697,13 +1697,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x76, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
 			},
 
-			// (data slab) next: 0, data: [aaaaaaaaaaaaaaaaaaaaaa ... StorageID(...)]
+			// (data slab) next: 0, data: [aaaaaaaaaaaaaaaaaaaaaa ... SlabID(...)]
 			id3: {
 				// version
 				0x00,
 				// array data slab flag
 				0x40,
-				// next storage id
+				// next slab id
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
@@ -1756,7 +1756,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		storage2 := newTestPersistentStorageWithData(t, m)
 
 		// Test new array from storage2
-		array2, err := NewArrayWithRootID(storage2, array.StorageID())
+		array2, err := NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
 		verifyArray(t, storage2, typeInfo, address, array2, values, false)
@@ -1784,7 +1784,7 @@ func TestArrayEncodeDecodeRandomValues(t *testing.T) {
 	storage2 := newTestPersistentStorageWithBaseStorage(t, storage.baseStorage)
 
 	// Test new array from storage2
-	array2, err := NewArrayWithRootID(storage2, array.StorageID())
+	array2, err := NewArrayWithRootID(storage2, array.SlabID())
 	require.NoError(t, err)
 
 	verifyArray(t, storage2, typeInfo, address, array2, values, false)
@@ -1956,7 +1956,7 @@ func TestArrayStoredValue(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	rootID := array.StorageID()
+	rootID := array.SlabID()
 
 	slabIterator, err := storage.SlabIterator()
 	require.NoError(t, err)
@@ -1964,7 +1964,7 @@ func TestArrayStoredValue(t *testing.T) {
 	for {
 		id, slab := slabIterator()
 
-		if id == StorageIDUndefined {
+		if id == SlabIDUndefined {
 			break
 		}
 
@@ -2102,7 +2102,7 @@ func TestArrayFromBatchData(t *testing.T) {
 				return iter.Next()
 			})
 		require.NoError(t, err)
-		require.NotEqual(t, copied.StorageID(), array.StorageID())
+		require.NotEqual(t, copied.SlabID(), array.SlabID())
 
 		verifyEmptyArray(t, storage, typeInfo, address, copied)
 	})
@@ -2143,7 +2143,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, copied.StorageID(), array.StorageID())
+		require.NotEqual(t, copied.SlabID(), array.SlabID())
 
 		verifyArray(t, storage, typeInfo, address, copied, values, false)
 	})
@@ -2186,7 +2186,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, array.StorageID(), copied.StorageID())
+		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
 		verifyArray(t, storage, typeInfo, address, copied, values, false)
 	})
@@ -2236,7 +2236,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, array.StorageID(), copied.StorageID())
+		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
 		verifyArray(t, storage, typeInfo, address, copied, values, false)
 	})
@@ -2286,7 +2286,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, array.StorageID(), copied.StorageID())
+		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
 		verifyArray(t, storage, typeInfo, address, copied, values, false)
 	})
@@ -2333,7 +2333,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, array.StorageID(), copied.StorageID())
+		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
 		verifyArray(t, storage, typeInfo, address, copied, values, false)
 	})
@@ -2387,7 +2387,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, array.StorageID(), copied.StorageID())
+		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
 		verifyArray(t, storage, typeInfo, address, copied, values, false)
 	})
@@ -2445,9 +2445,9 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	require.True(t, array.root.IsData())
 
 	// Size of root data slab with two elements of max inlined size is target slab size minus
-	// storage id size (next storage id is omitted in root slab), and minus 1 byte
+	// slab id size (next slab id is omitted in root slab), and minus 1 byte
 	// (for rounding when computing max inline array element size).
-	require.Equal(t, targetThreshold-storageIDSize-1, uint64(array.root.Header().size))
+	require.Equal(t, targetThreshold-slabIDSize-1, uint64(array.root.Header().size))
 
 	verifyArray(t, storage, typeInfo, address, array, values, false)
 }
@@ -2562,7 +2562,7 @@ func TestArraySlabDump(t *testing.T) {
 		require.NoError(t, err)
 
 		want := []string{
-			"level 1, ArrayDataSlab id:0x102030405060708.1 size:24 count:1 elements: [StorageIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]})]",
+			"level 1, ArrayDataSlab id:0x102030405060708.1 size:24 count:1 elements: [SlabIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]})]",
 			"overflow: &{0x102030405060708.2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}",
 		}
 
@@ -2598,7 +2598,7 @@ func TestArrayID(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	sid := array.StorageID()
+	sid := array.SlabID()
 	id := array.ID()
 
 	require.Equal(t, sid.Address[:], id[:8])

--- a/basicarray.go
+++ b/basicarray.go
@@ -50,7 +50,7 @@ func (a *BasicArray) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, err
 }
 
 func newBasicArrayDataSlabFromData(
-	id StorageID,
+	id SlabID,
 	data []byte,
 	decMode cbor.DecMode,
 	decodeStorable StorableDecoder,
@@ -80,7 +80,7 @@ func newBasicArrayDataSlabFromData(
 
 	elements := make([]Storable, elemCount)
 	for i := 0; i < int(elemCount); i++ {
-		storable, err := decodeStorable(cborDec, StorageIDUndefined)
+		storable, err := decodeStorable(cborDec, SlabIDUndefined)
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
 			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode array element")
@@ -89,7 +89,7 @@ func newBasicArrayDataSlabFromData(
 	}
 
 	return &BasicArrayDataSlab{
-		header:   ArraySlabHeader{id: id, size: uint32(len(data)), count: uint32(elemCount)},
+		header:   ArraySlabHeader{slabID: id, size: uint32(len(data)), count: uint32(elemCount)},
 		elements: elements,
 	}, nil
 }
@@ -155,10 +155,10 @@ func (a *BasicArrayDataSlab) Set(storage SlabStorage, index uint64, v Storable) 
 		oldElem.ByteSize() +
 		v.ByteSize()
 
-	err := storage.Store(a.header.id, a)
+	err := storage.Store(a.header.slabID, a)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.slabID))
 	}
 
 	return nil
@@ -180,10 +180,10 @@ func (a *BasicArrayDataSlab) Insert(storage SlabStorage, index uint64, v Storabl
 	a.header.count++
 	a.header.size += v.ByteSize()
 
-	err := storage.Store(a.header.id, a)
+	err := storage.Store(a.header.slabID, a)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.slabID))
 	}
 
 	return nil
@@ -209,10 +209,10 @@ func (a *BasicArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable
 	a.header.count--
 	a.header.size -= v.ByteSize()
 
-	err := storage.Store(a.header.id, a)
+	err := storage.Store(a.header.slabID, a)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.slabID))
 	}
 
 	return v, nil
@@ -230,8 +230,8 @@ func (a *BasicArrayDataSlab) ByteSize() uint32 {
 	return a.header.size
 }
 
-func (a *BasicArrayDataSlab) ID() StorageID {
-	return a.header.id
+func (a *BasicArrayDataSlab) SlabID() SlabID {
+	return a.header.slabID
 }
 
 func (a *BasicArrayDataSlab) String() string {
@@ -255,16 +255,16 @@ func (a *BasicArrayDataSlab) BorrowFromRight(_ Slab) error {
 }
 
 func NewBasicArray(storage SlabStorage, address Address) (*BasicArray, error) {
-	sID, err := storage.GenerateStorageID(address)
+	sID, err := storage.GenerateSlabID(address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate storage ID for address 0x%x", address))
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate slab ID for address 0x%x", address))
 	}
 
 	root := &BasicArrayDataSlab{
 		header: ArraySlabHeader{
-			id:   sID,
-			size: basicArrayDataSlabPrefixSize,
+			slabID: sID,
+			size:   basicArrayDataSlabPrefixSize,
 		},
 	}
 
@@ -274,17 +274,17 @@ func NewBasicArray(storage SlabStorage, address Address) (*BasicArray, error) {
 	}, nil
 }
 
-func (a *BasicArray) StorageID() StorageID {
-	return a.root.ID()
+func (a *BasicArray) SlabID() SlabID {
+	return a.root.SlabID()
 }
 
 func (a *BasicArray) Address() Address {
-	return a.StorageID().Address
+	return a.SlabID().Address
 }
 
-func NewBasicArrayWithRootID(storage SlabStorage, id StorageID) (*BasicArray, error) {
-	if id == StorageIDUndefined {
-		return nil, NewStorageIDErrorf("cannot create BasicArray from undefined storage id")
+func NewBasicArrayWithRootID(storage SlabStorage, id SlabID) (*BasicArray, error) {
+	if id == SlabIDUndefined {
+		return nil, NewSlabIDErrorf("cannot create BasicArray from undefined slab ID")
 	}
 	slab, found, err := storage.Retrieve(id)
 	if err != nil {

--- a/basicarray_benchmark_test.go
+++ b/basicarray_benchmark_test.go
@@ -88,7 +88,7 @@ func benchmarkBasicArray(b *testing.B, initialArraySize, numberOfElements int) {
 	require.NoError(b, storage.Commit())
 	b.ResetTimer()
 
-	arrayID := array.StorageID()
+	arrayID := array.SlabID()
 
 	// append
 	storage.DropCache()

--- a/basicarray_test.go
+++ b/basicarray_test.go
@@ -427,7 +427,7 @@ func TestBasicArrayDecodeEncodeRandomData(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	rootID := array.root.Header().id
+	rootID := array.root.Header().slabID
 
 	// Encode slabs with random data of mixed types
 	m1, err := storage.Encode()

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -86,15 +86,15 @@ func (i testTypeInfo) Equal(other atree.TypeInfo) bool {
 	return ok
 }
 
-func decodeStorable(dec *cbor.StreamDecoder, _ atree.StorageID) (atree.Storable, error) {
+func decodeStorable(dec *cbor.StreamDecoder, _ atree.SlabID) (atree.Storable, error) {
 	tagNumber, err := dec.DecodeTagNumber()
 	if err != nil {
 		return nil, err
 	}
 
 	switch tagNumber {
-	case atree.CBORTagStorageID:
-		return atree.DecodeStorageIDStorable(dec)
+	case atree.CBORTagSlabID:
+		return atree.DecodeSlabIDStorable(dec)
 
 	case cborTagUInt64Value:
 		n, err := dec.DecodeUint64()

--- a/cmd/stress/array.go
+++ b/cmd/stress/array.go
@@ -163,7 +163,7 @@ func testArray(
 			storage.DropCache()
 
 			// Load root slab from storage and cache it in read cache
-			rootID := array.StorageID()
+			rootID := array.SlabID()
 			array, err = atree.NewArrayWithRootID(storage, rootID)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to create array from root id %s: %s", rootID, err)
@@ -393,15 +393,15 @@ func testArray(
 				fmt.Fprintln(os.Stderr, err)
 				return
 			}
-			ids := make([]atree.StorageID, 0, len(rootIDs))
+			ids := make([]atree.SlabID, 0, len(rootIDs))
 			for id := range rootIDs {
 				// filter out root ids with empty address
 				if id.Address != atree.AddressUndefined {
 					ids = append(ids, id)
 				}
 			}
-			if len(ids) != 1 || ids[0] != array.StorageID() {
-				fmt.Fprintf(os.Stderr, "root storage ids %v in storage, want %s\n", ids, array.StorageID())
+			if len(ids) != 1 || ids[0] != array.SlabID() {
+				fmt.Fprintf(os.Stderr, "root slab ids %v in storage, want %s\n", ids, array.SlabID())
 				return
 			}
 		}

--- a/cmd/stress/map.go
+++ b/cmd/stress/map.go
@@ -151,7 +151,7 @@ func testMap(
 			elements = make(map[atree.Value]atree.Value, maxLength)
 
 			// Load root slab from storage and cache it in read cache
-			rootID := m.StorageID()
+			rootID := m.SlabID()
 			m, err = atree.NewMapWithRootID(storage, rootID, atree.NewDefaultDigesterBuilder())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Failed to create map from root id %s: %s", rootID, err)
@@ -366,15 +366,15 @@ func testMap(
 				fmt.Fprintln(os.Stderr, err)
 				return
 			}
-			ids := make([]atree.StorageID, 0, len(rootIDs))
+			ids := make([]atree.SlabID, 0, len(rootIDs))
 			for id := range rootIDs {
 				// filter out root ids with empty address
 				if id.Address != atree.AddressUndefined {
 					ids = append(ids, id)
 				}
 			}
-			if len(ids) != 1 || ids[0] != m.StorageID() {
-				fmt.Fprintf(os.Stderr, "root storage ids %v in storage, want %s\n", ids, m.StorageID())
+			if len(ids) != 1 || ids[0] != m.SlabID() {
+				fmt.Fprintf(os.Stderr, "root slab ids %v in storage, want %s\n", ids, m.SlabID())
 				return
 			}
 		}

--- a/cmd/stress/storable.go
+++ b/cmd/stress/storable.go
@@ -351,14 +351,14 @@ func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, 
 	if uint64(v.ByteSize()) > maxInlineSize {
 
 		// Create StorableSlab
-		id, err := storage.GenerateStorageID(address)
+		id, err := storage.GenerateSlabID(address)
 		if err != nil {
 			return nil, err
 		}
 
 		slab := &atree.StorableSlab{
-			StorageID: id,
-			Storable:  v,
+			ID:       id,
+			Storable: v,
 		}
 
 		// Store StorableSlab in storage
@@ -367,8 +367,8 @@ func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, 
 			return nil, err
 		}
 
-		// Return storage id as storable
-		return atree.StorageIDStorable(id), nil
+		// Return slab id as storable
+		return atree.SlabIDStorable(id), nil
 	}
 
 	return v, nil
@@ -432,7 +432,7 @@ func (v StringValue) String() string {
 	return v.str
 }
 
-func decodeStorable(dec *cbor.StreamDecoder, _ atree.StorageID) (atree.Storable, error) {
+func decodeStorable(dec *cbor.StreamDecoder, _ atree.SlabID) (atree.Storable, error) {
 	t, err := dec.NextType()
 	if err != nil {
 		return nil, err
@@ -454,8 +454,8 @@ func decodeStorable(dec *cbor.StreamDecoder, _ atree.StorageID) (atree.Storable,
 
 		switch tagNumber {
 
-		case atree.CBORTagStorageID:
-			return atree.DecodeStorageIDStorable(dec)
+		case atree.CBORTagSlabID:
+			return atree.DecodeSlabIDStorable(dec)
 
 		case cborTagUInt8Value:
 			n, err := dec.DecodeUint64()

--- a/cmd/stress/utils.go
+++ b/cmd/stress/utils.go
@@ -184,20 +184,20 @@ func copyMap(storage *atree.PersistentSlabStorage, address atree.Address, m *atr
 func removeValue(storage *atree.PersistentSlabStorage, value atree.Value) error {
 	switch v := value.(type) {
 	case *atree.Array:
-		return removeStorable(storage, atree.StorageIDStorable(v.StorageID()))
+		return removeStorable(storage, atree.SlabIDStorable(v.SlabID()))
 	case *atree.OrderedMap:
-		return removeStorable(storage, atree.StorageIDStorable(v.StorageID()))
+		return removeStorable(storage, atree.SlabIDStorable(v.SlabID()))
 	}
 	return nil
 }
 
 func removeStorable(storage *atree.PersistentSlabStorage, storable atree.Storable) error {
-	sid, ok := storable.(atree.StorageIDStorable)
+	sid, ok := storable.(atree.SlabIDStorable)
 	if !ok {
 		return nil
 	}
 
-	id := atree.StorageID(sid)
+	id := atree.SlabID(sid)
 
 	value, err := storable.StoredValue(storage)
 	if err != nil {
@@ -458,8 +458,8 @@ func newMap(storage *atree.PersistentSlabStorage, address atree.Address, length 
 }
 
 type InMemBaseStorage struct {
-	segments       map[atree.StorageID][]byte
-	storageIndex   map[atree.Address]atree.StorageIndex
+	segments       map[atree.SlabID][]byte
+	storageIndex   map[atree.Address]atree.SlabIndex
 	bytesRetrieved int
 	bytesStored    int
 }
@@ -468,40 +468,40 @@ var _ atree.BaseStorage = &InMemBaseStorage{}
 
 func NewInMemBaseStorage() *InMemBaseStorage {
 	return NewInMemBaseStorageFromMap(
-		make(map[atree.StorageID][]byte),
+		make(map[atree.SlabID][]byte),
 	)
 }
 
-func NewInMemBaseStorageFromMap(segments map[atree.StorageID][]byte) *InMemBaseStorage {
+func NewInMemBaseStorageFromMap(segments map[atree.SlabID][]byte) *InMemBaseStorage {
 	return &InMemBaseStorage{
 		segments:     segments,
-		storageIndex: make(map[atree.Address]atree.StorageIndex),
+		storageIndex: make(map[atree.Address]atree.SlabIndex),
 	}
 }
 
-func (s *InMemBaseStorage) Retrieve(id atree.StorageID) ([]byte, bool, error) {
+func (s *InMemBaseStorage) Retrieve(id atree.SlabID) ([]byte, bool, error) {
 	seg, ok := s.segments[id]
 	s.bytesRetrieved += len(seg)
 	return seg, ok, nil
 }
 
-func (s *InMemBaseStorage) Store(id atree.StorageID, data []byte) error {
+func (s *InMemBaseStorage) Store(id atree.SlabID, data []byte) error {
 	s.segments[id] = data
 	s.bytesStored += len(data)
 	return nil
 }
 
-func (s *InMemBaseStorage) Remove(id atree.StorageID) error {
+func (s *InMemBaseStorage) Remove(id atree.SlabID) error {
 	delete(s.segments, id)
 	return nil
 }
 
-func (s *InMemBaseStorage) GenerateStorageID(address atree.Address) (atree.StorageID, error) {
+func (s *InMemBaseStorage) GenerateSlabID(address atree.Address) (atree.SlabID, error) {
 	index := s.storageIndex[address]
 	nextIndex := index.Next()
 
 	s.storageIndex[address] = nextIndex
-	return atree.NewStorageID(address, nextIndex), nil
+	return atree.NewSlabID(address, nextIndex), nil
 }
 
 func (s *InMemBaseStorage) SegmentCounts() int {

--- a/encode.go
+++ b/encode.go
@@ -42,14 +42,14 @@ func NewEncoder(w io.Writer, encMode cbor.EncMode) *Encoder {
 
 type StorableDecoder func(
 	decoder *cbor.StreamDecoder,
-	storableSlabStorageID StorageID,
+	storableSlabID SlabID,
 ) (
 	Storable,
 	error,
 )
 
 func DecodeSlab(
-	id StorageID,
+	id SlabID,
 	data []byte,
 	decMode cbor.DecMode,
 	decodeStorable StorableDecoder,
@@ -101,8 +101,8 @@ func DecodeSlab(
 			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode slab storable")
 		}
 		return StorableSlab{
-			StorageID: id,
-			Storable:  storable,
+			ID:       id,
+			Storable: storable,
 		}, nil
 
 	default:

--- a/errors.go
+++ b/errors.go
@@ -145,11 +145,11 @@ func (e *IndexOutOfBoundsError) Error() string {
 
 // NotValueError is returned when we try to create Value objects from non-root slabs.
 type NotValueError struct {
-	id StorageID
+	id SlabID
 }
 
 // NewNotValueError constructs a NotValueError.
-func NewNotValueError(id StorageID) error {
+func NewNotValueError(id SlabID) error {
 	return NewFatalError(&NotValueError{id: id})
 }
 
@@ -210,43 +210,43 @@ func (e *HashError) Error() string {
 	return fmt.Sprintf("hasher error: %s", e.err.Error())
 }
 
-// StorageIDError is returned when storage id can't be created or it's invalid.
-type StorageIDError struct {
+// SlabIDError is returned when slab id can't be created or it's invalid.
+type SlabIDError struct {
 	msg string
 }
 
-// NewStorageIDError constructs a fatal error of StorageIDError.
-func NewStorageIDError(msg string) error {
-	return NewFatalError(&StorageIDError{msg: msg})
+// NewSlabIDError constructs a fatal error of SlabIDError.
+func NewSlabIDError(msg string) error {
+	return NewFatalError(&SlabIDError{msg: msg})
 }
 
-// NewStorageIDErrorf constructs a fatal error of StorageIDError.
-func NewStorageIDErrorf(msg string, args ...interface{}) error {
-	return NewStorageIDError(fmt.Sprintf(msg, args...))
+// NewSlabIDErrorf constructs a fatal error of SlabIDError.
+func NewSlabIDErrorf(msg string, args ...interface{}) error {
+	return NewSlabIDError(fmt.Sprintf(msg, args...))
 }
 
-func (e *StorageIDError) Error() string {
-	return fmt.Sprintf("storage id error: %s", e.msg)
+func (e *SlabIDError) Error() string {
+	return fmt.Sprintf("slab id error: %s", e.msg)
 }
 
 // SlabNotFoundError is always a fatal error returned when an slab is not found
 type SlabNotFoundError struct {
-	storageID StorageID
-	err       error
+	slabID SlabID
+	err    error
 }
 
 // NewSlabNotFoundError constructs a SlabNotFoundError
-func NewSlabNotFoundError(storageID StorageID, err error) error {
-	return NewFatalError(&SlabNotFoundError{storageID: storageID, err: err})
+func NewSlabNotFoundError(slabID SlabID, err error) error {
+	return NewFatalError(&SlabNotFoundError{slabID: slabID, err: err})
 }
 
 // NewSlabNotFoundErrorf constructs a new SlabNotFoundError with error formating
-func NewSlabNotFoundErrorf(storageID StorageID, msg string, args ...interface{}) error {
-	return NewSlabNotFoundError(storageID, fmt.Errorf(msg, args...))
+func NewSlabNotFoundErrorf(slabID SlabID, msg string, args ...interface{}) error {
+	return NewSlabNotFoundError(slabID, fmt.Errorf(msg, args...))
 }
 
 func (e *SlabNotFoundError) Error() string {
-	return fmt.Sprintf("slab (%s) not found: %s", e.storageID.String(), e.err.Error())
+	return fmt.Sprintf("slab (%s) not found: %s", e.slabID.String(), e.err.Error())
 }
 
 // SlabSplitError is always a fatal error returned when splitting an slab has failed

--- a/map_test.go
+++ b/map_test.go
@@ -171,12 +171,12 @@ func verifyMap(
 	rootIDSet, err := CheckStorageHealth(storage, 1)
 	require.NoError(t, err)
 
-	rootIDs := make([]StorageID, 0, len(rootIDSet))
+	rootIDs := make([]SlabID, 0, len(rootIDSet))
 	for id := range rootIDSet {
 		rootIDs = append(rootIDs, id)
 	}
 	require.Equal(t, 1, len(rootIDs))
-	require.Equal(t, m.StorageID(), rootIDs[0])
+	require.Equal(t, m.SlabID(), rootIDs[0])
 
 	if !hasNestedArrayMapElement {
 		// Need to call Commit before calling storage.Count() for PersistentSlabStorage.
@@ -688,13 +688,13 @@ func testMapRemoveElement(t *testing.T, m *OrderedMap, k Value, expectedV Value)
 	require.NoError(t, err)
 	valueEqual(t, typeInfoComparator, expectedV, removedValue)
 
-	if id, ok := removedKeyStorable.(StorageIDStorable); ok {
-		err = m.Storage.Remove(StorageID(id))
+	if id, ok := removedKeyStorable.(SlabIDStorable); ok {
+		err = m.Storage.Remove(SlabID(id))
 		require.NoError(t, err)
 	}
 
-	if id, ok := removedValueStorable.(StorageIDStorable); ok {
-		err = m.Storage.Remove(StorageID(id))
+	if id, ok := removedValueStorable.(SlabIDStorable); ok {
+		err = m.Storage.Remove(SlabID(id))
 		require.NoError(t, err)
 	}
 
@@ -1292,13 +1292,13 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 		require.NoError(t, err)
 		valueEqual(t, typeInfoComparator, v, removedValue)
 
-		if id, ok := removedKeyStorable.(StorageIDStorable); ok {
-			err = storage.Remove(StorageID(id))
+		if id, ok := removedKeyStorable.(SlabIDStorable); ok {
+			err = storage.Remove(SlabID(id))
 			require.NoError(t, err)
 		}
 
-		if id, ok := removedValueStorable.(StorageIDStorable); ok {
-			err = storage.Remove(StorageID(id))
+		if id, ok := removedValueStorable.(SlabIDStorable); ok {
+			err = storage.Remove(SlabID(id))
 			require.NoError(t, err)
 		}
 	}
@@ -1360,13 +1360,13 @@ func testMapRandomHashCollision(t *testing.T, r *rand.Rand, maxDigestLevel int) 
 		require.NoError(t, err)
 		valueEqual(t, typeInfoComparator, v, removedValue)
 
-		if id, ok := removedKeyStorable.(StorageIDStorable); ok {
-			err = storage.Remove(StorageID(id))
+		if id, ok := removedKeyStorable.(SlabIDStorable); ok {
+			err = storage.Remove(SlabID(id))
 			require.NoError(t, err)
 		}
 
-		if id, ok := removedValueStorable.(StorageIDStorable); ok {
-			err = storage.Remove(StorageID(id))
+		if id, ok := removedValueStorable.(SlabIDStorable); ok {
+			err = storage.Remove(SlabID(id))
 			require.NoError(t, err)
 		}
 	}
@@ -1457,8 +1457,8 @@ func testMapSetRemoveRandomValues(
 				require.NoError(t, err)
 				valueEqual(t, typeInfoComparator, oldv, existingValue)
 
-				if id, ok := existingStorable.(StorageIDStorable); ok {
-					err = storage.Remove(StorageID(id))
+				if id, ok := existingStorable.(SlabIDStorable); ok {
+					err = storage.Remove(SlabID(id))
 					require.NoError(t, err)
 				}
 			} else {
@@ -1484,13 +1484,13 @@ func testMapSetRemoveRandomValues(
 			require.NoError(t, err)
 			valueEqual(t, typeInfoComparator, keyValues[k], removedValue)
 
-			if id, ok := removedKeyStorable.(StorageIDStorable); ok {
-				err := storage.Remove(StorageID(id))
+			if id, ok := removedKeyStorable.(SlabIDStorable); ok {
+				err := storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 
-			if id, ok := removedValueStorable.(StorageIDStorable); ok {
-				err := storage.Remove(StorageID(id))
+			if id, ok := removedValueStorable.(SlabIDStorable); ok {
+				err := storage.Remove(SlabID(id))
 				require.NoError(t, err)
 			}
 
@@ -1537,9 +1537,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
-		expected := map[StorageID][]byte{
+		expected := map[SlabID][]byte{
 			id1: {
 				// extra data
 				// version
@@ -1623,10 +1623,10 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
-		// Expected serialized slab data with storage id
-		expected := map[StorageID][]byte{
+		// Expected serialized slab data with slab id
+		expected := map[SlabID][]byte{
 
 			id1: {
 				// extra data
@@ -1742,13 +1742,13 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 3}}
-		id4 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 4}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id4 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
 
-		// Expected serialized slab data with storage id
-		expected := map[StorageID][]byte{
+		// Expected serialized slab data with slab id
+		expected := map[SlabID][]byte{
 
 			// metadata slab
 			id1: {
@@ -1772,7 +1772,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x89,
 				// child header count
 				0x00, 0x02,
-				// child header 1 (storage id, first key, size)
+				// child header 1 (slab id, first key, size)
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				0x00, 0x00, 0x01, 0x02,
@@ -1788,7 +1788,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x00,
 				// flag: map data
 				0x08,
-				// next storage id
+				// next slab id
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
 
 				// the following encoded data is valid CBOR
@@ -1837,7 +1837,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x00,
 				// flag: has pointer + map data
 				0x48,
-				// next storage id
+				// next slab id
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 				// the following encoded data is valid CBOR
@@ -1874,7 +1874,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x82,
 				0x76, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67,
 				0x76, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67, 0x67,
-				// element: [hhhhhhhhhhhhhhhhhhhhhh:StorageID(1,2,3,4,5,6,7,8,0,0,0,0,0,0,0,4)]
+				// element: [hhhhhhhhhhhhhhhhhhhhhh:SlabID(1,2,3,4,5,6,7,8,0,0,0,0,0,0,0,4)]
 				0x82,
 				0x76, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68, 0x68,
 				0xd8, 0xff, 0x50, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04,
@@ -1961,10 +1961,10 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
-		// Expected serialized slab data with storage id
-		expected := map[StorageID][]byte{
+		// Expected serialized slab data with slab id
+		expected := map[SlabID][]byte{
 
 			// map metadata slab
 			id1: {
@@ -2154,10 +2154,10 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
-		// Expected serialized slab data with storage id
-		expected := map[StorageID][]byte{
+		// Expected serialized slab data with slab id
+		expected := map[SlabID][]byte{
 
 			// map metadata slab
 			id1: {
@@ -2397,12 +2397,12 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
 
-		// Expected serialized slab data with storage id
-		expected := map[StorageID][]byte{
+		// Expected serialized slab data with slab id
+		expected := map[SlabID][]byte{
 
 			// map data slab
 			id1: {
@@ -2445,14 +2445,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// external collision group corresponding to hkey 0
 				// (tag number CBORTagExternalCollisionGroup)
 				0xd8, 0xfe,
-				// (tag content: storage id)
+				// (tag content: slab id)
 				0xd8, 0xff, 0x50,
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 
 				// external collision group corresponding to hkey 1
 				// (tag number CBORTagExternalCollisionGroup)
 				0xd8, 0xfe,
-				// (tag content: storage id)
+				// (tag content: slab id)
 				0xd8, 0xff, 0x50,
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
 			},
@@ -2463,7 +2463,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x00,
 				// flag: any size + collision group
 				0x2b,
-				// next storage id
+				// next slab id
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 				// the following encoded data is valid CBOR
@@ -2528,7 +2528,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x00,
 				// flag: any size + collision group
 				0x2b,
-				// next storage id
+				// next slab id
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 				// the following encoded data is valid CBOR
@@ -2627,7 +2627,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(1), m.Count())
 
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
 		expectedNoPointer := []byte{
 
@@ -2720,9 +2720,9 @@ func TestMapEncodeDecode(t *testing.T) {
 			// elements (array of 1 elements)
 			// each element is encoded as CBOR array of 2 elements (key, value)
 			0x9b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
-			// element: [uint64(0), storage id]
+			// element: [uint64(0), slab id]
 			0x82, 0xd8, 0xa4, 0x00,
-			// (tag content: storage id)
+			// (tag content: slab id)
 			0xd8, 0xff, 0x50,
 			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 		}
@@ -2753,7 +2753,7 @@ func TestMapEncodeDecodeRandomValues(t *testing.T) {
 	storage2 := newTestPersistentStorageWithBaseStorage(t, storage.baseStorage)
 
 	// Create new map from new storage
-	m2, err := NewMapWithRootID(storage2, m.StorageID(), m.digesterBuilder)
+	m2, err := NewMapWithRootID(storage2, m.SlabID(), m.digesterBuilder)
 	require.NoError(t, err)
 
 	verifyMap(t, storage2, typeInfo, address, m2, keyValues, nil, false)
@@ -2786,7 +2786,7 @@ func TestMapStoredValue(t *testing.T) {
 		require.Nil(t, existingStorable)
 	}
 
-	rootID := m.StorageID()
+	rootID := m.SlabID()
 
 	slabIterator, err := storage.SlabIterator()
 	require.NoError(t, err)
@@ -2794,7 +2794,7 @@ func TestMapStoredValue(t *testing.T) {
 	for {
 		id, slab := slabIterator()
 
-		if id == StorageIDUndefined {
+		if id == SlabIDUndefined {
 			break
 		}
 
@@ -3115,7 +3115,7 @@ func TestMapFromBatchData(t *testing.T) {
 				return iter.Next()
 			})
 		require.NoError(t, err)
-		require.NotEqual(t, copied.StorageID(), m.StorageID())
+		require.NotEqual(t, copied.SlabID(), m.SlabID())
 
 		verifyEmptyMap(t, storage, typeInfo, address, copied)
 	})
@@ -3176,7 +3176,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, copied.StorageID(), m.StorageID())
+		require.NotEqual(t, copied.SlabID(), m.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3235,7 +3235,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, m.StorageID(), copied.StorageID())
+		require.NotEqual(t, m.SlabID(), copied.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3300,7 +3300,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, m.StorageID(), copied.StorageID())
+		require.NotEqual(t, m.SlabID(), copied.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3369,7 +3369,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, m.StorageID(), copied.StorageID())
+		require.NotEqual(t, m.SlabID(), copied.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3432,7 +3432,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, m.StorageID(), copied.StorageID())
+		require.NotEqual(t, m.SlabID(), copied.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3514,7 +3514,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, m.StorageID(), copied.StorageID())
+		require.NotEqual(t, m.SlabID(), copied.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3596,7 +3596,7 @@ func TestMapFromBatchData(t *testing.T) {
 			})
 
 		require.NoError(t, err)
-		require.NotEqual(t, m.StorageID(), copied.StorageID())
+		require.NotEqual(t, m.SlabID(), copied.SlabID())
 
 		verifyMap(t, storage, typeInfo, address, copied, keyValues, sortedKeys, false)
 	})
@@ -3700,8 +3700,8 @@ func TestMapMaxInlineElement(t *testing.T) {
 
 	// Size of root data slab with two elements (key+value pairs) of
 	// max inlined size is target slab size minus
-	// storage id size (next storage id is omitted in root slab)
-	require.Equal(t, targetThreshold-storageIDSize, uint64(m.root.Header().size))
+	// slab id size (next slab id is omitted in root slab)
+	require.Equal(t, targetThreshold-slabIDSize, uint64(m.root.Header().size))
 
 	verifyMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 }
@@ -3908,7 +3908,7 @@ func TestMapSlabDump(t *testing.T) {
 		require.Nil(t, existingStorable)
 
 		want := []string{
-			"level 1, MapDataSlab id:0x102030405060708.1 size:102 firstkey:0 elements: [0:StorageIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]}):bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]",
+			"level 1, MapDataSlab id:0x102030405060708.1 size:102 firstkey:0 elements: [0:SlabIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]}):bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]",
 			"overflow: &{0x102030405060708.2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}",
 		}
 		dumps, err := DumpMapSlabs(m)
@@ -3935,7 +3935,7 @@ func TestMapSlabDump(t *testing.T) {
 		require.Nil(t, existingStorable)
 
 		want := []string{
-			"level 1, MapDataSlab id:0x102030405060708.1 size:100 firstkey:0 elements: [0:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:StorageIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]})]",
+			"level 1, MapDataSlab id:0x102030405060708.1 size:100 firstkey:0 elements: [0:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:SlabIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]})]",
 			"overflow: &{0x102030405060708.2 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}",
 		}
 		dumps, err := DumpMapSlabs(m)
@@ -4180,7 +4180,7 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 	t.Run("large key", func(t *testing.T) {
 		// Value has larger max inline size when key is more than max map key size because
 		// when key size exceeds max map key size, it is stored in a separate storable slab,
-		// and StorageIDStorable is stored as key in the map, which is 19 bytes.
+		// and SlabIDStorable is stored as key in the map, which is 19 bytes.
 
 		SetThreshold(256)
 		defer SetThreshold(1024)
@@ -4226,7 +4226,7 @@ func TestMapID(t *testing.T) {
 	m, err := NewMap(storage, address, newBasicDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	sid := m.StorageID()
+	sid := m.SlabID()
 	id := m.ID()
 
 	require.Equal(t, sid.Address[:], id[:8])

--- a/slab.go
+++ b/slab.go
@@ -21,7 +21,7 @@ package atree
 type Slab interface {
 	Storable
 
-	ID() StorageID
+	SlabID() SlabID
 	Split(SlabStorage) (Slab, Slab, error)
 	Merge(Slab) error
 	// LendToRight rebalances slabs by moving elements from left to right

--- a/storable.go
+++ b/storable.go
@@ -41,21 +41,21 @@ const (
 	CBORTagInlineCollisionGroup   = 253
 	CBORTagExternalCollisionGroup = 254
 
-	CBORTagStorageID = 255
+	CBORTagSlabID = 255
 )
 
-type StorageIDStorable StorageID
+type SlabIDStorable SlabID
 
-var _ Storable = StorageIDStorable{}
+var _ Storable = SlabIDStorable{}
 
-func (v StorageIDStorable) ChildStorables() []Storable {
+func (v SlabIDStorable) ChildStorables() []Storable {
 	return nil
 }
 
-func (v StorageIDStorable) StoredValue(storage SlabStorage) (Value, error) {
-	id := StorageID(v)
+func (v SlabIDStorable) StoredValue(storage SlabStorage) (Value, error) {
+	id := SlabID(v)
 	if err := id.Valid(); err != nil {
-		// Don't need to wrap error as external error because err is already categorized by StorageID.Valid().
+		// Don't need to wrap error as external error because err is already categorized by SlabID.Valid().
 		return nil, err
 	}
 
@@ -75,16 +75,16 @@ func (v StorageIDStorable) StoredValue(storage SlabStorage) (Value, error) {
 	return value, nil
 }
 
-// Encode encodes StorageIDStorable as
+// Encode encodes SlabIDStorable as
 //
 //	cbor.Tag{
-//			Number:  cborTagStorageID,
+//			Number:  cborTagSlabID,
 //			Content: byte(v),
 //	}
-func (v StorageIDStorable) Encode(enc *Encoder) error {
+func (v SlabIDStorable) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
-		0xd8, CBORTagStorageID,
+		0xd8, CBORTagSlabID,
 	})
 	if err != nil {
 		return NewEncodingError(err)
@@ -93,7 +93,7 @@ func (v StorageIDStorable) Encode(enc *Encoder) error {
 	copy(enc.Scratch[:], v.Address[:])
 	copy(enc.Scratch[8:], v.Index[:])
 
-	err = enc.CBOR.EncodeBytes(enc.Scratch[:storageIDSize])
+	err = enc.CBOR.EncodeBytes(enc.Scratch[:slabIDSize])
 	if err != nil {
 		return NewEncodingError(err)
 	}
@@ -101,13 +101,13 @@ func (v StorageIDStorable) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (v StorageIDStorable) ByteSize() uint32 {
-	// tag number (2 bytes) + byte string header (1 byte) + storage id (16 bytes)
-	return 2 + 1 + storageIDSize
+func (v SlabIDStorable) ByteSize() uint32 {
+	// tag number (2 bytes) + byte string header (1 byte) + slab id (16 bytes)
+	return 2 + 1 + slabIDSize
 }
 
-func (v StorageIDStorable) String() string {
-	return fmt.Sprintf("StorageIDStorable(%d)", v)
+func (v SlabIDStorable) String() string {
+	return fmt.Sprintf("SlabIDStorable(%d)", v)
 }
 
 // Encode is a wrapper for Storable.Encode()
@@ -129,17 +129,17 @@ func Encode(storable Storable, encMode cbor.EncMode) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func DecodeStorageIDStorable(dec *cbor.StreamDecoder) (Storable, error) {
+func DecodeSlabIDStorable(dec *cbor.StreamDecoder) (Storable, error) {
 	b, err := dec.DecodeBytes()
 	if err != nil {
 		return nil, NewDecodingError(err)
 	}
 
-	id, err := NewStorageIDFromRawBytes(b)
+	id, err := NewSlabIDFromRawBytes(b)
 	if err != nil {
-		// Don't need to wrap error as external error because err is already categorized by NewStorageIDFromRawBytes().
+		// Don't need to wrap error as external error because err is already categorized by NewSlabIDFromRawBytes().
 		return nil, err
 	}
 
-	return StorageIDStorable(id), nil
+	return SlabIDStorable(id), nil
 }

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -24,8 +24,8 @@ package atree
 // other non-dictionary values (e.g. strings, integers, etc.) directly in accounts
 // (i.e. directly in slabs aka registers)
 type StorableSlab struct {
-	StorageID StorageID
-	Storable  Storable
+	ID       SlabID
+	Storable Storable
 }
 
 var _ Slab = StorableSlab{}
@@ -42,7 +42,7 @@ func (s StorableSlab) Encode(enc *Encoder) error {
 	flag := maskStorable
 	flag = setNoSizeLimit(flag)
 
-	if _, ok := s.Storable.(StorageIDStorable); ok {
+	if _, ok := s.Storable.(SlabIDStorable); ok {
 		flag = setHasPointers(flag)
 	}
 
@@ -66,8 +66,8 @@ func (s StorableSlab) ByteSize() uint32 {
 	return versionAndFlagSize + s.Storable.ByteSize()
 }
 
-func (s StorableSlab) ID() StorageID {
-	return s.StorageID
+func (s StorableSlab) SlabID() SlabID {
+	return s.ID
 }
 
 func (s StorableSlab) StoredValue(storage SlabStorage) (Value, error) {

--- a/storable_test.go
+++ b/storable_test.go
@@ -349,14 +349,14 @@ func (v StringValue) Storable(storage SlabStorage, address Address, maxInlineSiz
 	if uint64(v.ByteSize()) > maxInlineSize {
 
 		// Create StorableSlab
-		id, err := storage.GenerateStorageID(address)
+		id, err := storage.GenerateSlabID(address)
 		if err != nil {
 			return nil, err
 		}
 
 		slab := &StorableSlab{
-			StorageID: id,
-			Storable:  v,
+			ID:       id,
+			Storable: v,
 		}
 
 		// Store StorableSlab in storage
@@ -365,8 +365,8 @@ func (v StringValue) Storable(storage SlabStorage, address Address, maxInlineSiz
 			return nil, err
 		}
 
-		// Return storage id as storable
-		return StorageIDStorable(id), nil
+		// Return slab id as storable
+		return SlabIDStorable(id), nil
 	}
 
 	return v, nil
@@ -430,7 +430,7 @@ func (v StringValue) String() string {
 	return v.str
 }
 
-func decodeStorable(dec *cbor.StreamDecoder, id StorageID) (Storable, error) {
+func decodeStorable(dec *cbor.StreamDecoder, id SlabID) (Storable, error) {
 	t, err := dec.NextType()
 	if err != nil {
 		return nil, err
@@ -451,8 +451,8 @@ func decodeStorable(dec *cbor.StreamDecoder, id StorageID) (Storable, error) {
 		}
 
 		switch tagNumber {
-		case CBORTagStorageID:
-			return DecodeStorageIDStorable(dec)
+		case CBORTagSlabID:
+			return DecodeSlabIDStorable(dec)
 
 		case cborTagUInt8Value:
 			n, err := dec.DecodeUint64()

--- a/storage_test.go
+++ b/storage_test.go
@@ -30,214 +30,217 @@ import (
 )
 
 func TestStorageIndexNext(t *testing.T) {
-	index := StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}
-	want := StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}
+	index := SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}
+	want := SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}
 	require.Equal(t, want, index.Next())
 }
 
-func TestNewStorageID(t *testing.T) {
+func TestNewSlabID(t *testing.T) {
 	t.Run("temp address", func(t *testing.T) {
-		want := StorageID{Address: Address{}, Index: StorageIndex{1}}
-		require.Equal(t, want, NewStorageID(Address{}, StorageIndex{1}))
+		want := SlabID{Address: Address{}, Index: SlabIndex{1}}
+		require.Equal(t, want, NewSlabID(Address{}, SlabIndex{1}))
 	})
 	t.Run("perm address", func(t *testing.T) {
-		want := StorageID{Address: Address{1}, Index: StorageIndex{1}}
-		require.Equal(t, want, NewStorageID(Address{1}, StorageIndex{1}))
+		want := SlabID{Address: Address{1}, Index: SlabIndex{1}}
+		require.Equal(t, want, NewSlabID(Address{1}, SlabIndex{1}))
 	})
 }
 
-func TestNewStorageIDFromRawBytes(t *testing.T) {
-	t.Run("data length < storage id size", func(t *testing.T) {
+func TestNewSlabIDFromRawBytes(t *testing.T) {
+	t.Run("data length < slab id size", func(t *testing.T) {
 		var fatalError *FatalError
-		var storageIDError *StorageIDError
+		var slabIDError *SlabIDError
 
-		id, err := NewStorageIDFromRawBytes(nil)
-		require.Equal(t, StorageIDUndefined, id)
+		id, err := NewSlabIDFromRawBytes(nil)
+		require.Equal(t, SlabIDUndefined, id)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
-		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError, &storageIDError)
+		require.ErrorAs(t, err, &slabIDError)
+		require.ErrorAs(t, fatalError, &slabIDError)
 
-		id, err = NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 2})
-		require.Equal(t, StorageIDUndefined, id)
+		id, err = NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 2})
+		require.Equal(t, SlabIDUndefined, id)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
-		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError, &storageIDError)
+		require.ErrorAs(t, err, &slabIDError)
+		require.ErrorAs(t, fatalError, &slabIDError)
 	})
 
-	t.Run("data length == storage id size", func(t *testing.T) {
-		id, err := NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2})
+	t.Run("data length == slab id size", func(t *testing.T) {
+		id, err := NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2})
 
-		want := StorageID{
+		want := SlabID{
 			Address: Address{0, 0, 0, 0, 0, 0, 0, 1},
-			Index:   StorageIndex{0, 0, 0, 0, 0, 0, 0, 2},
+			Index:   SlabIndex{0, 0, 0, 0, 0, 0, 0, 2},
 		}
 		require.Equal(t, want, id)
 		require.NoError(t, err)
 	})
-	t.Run("data length > storage id size", func(t *testing.T) {
-		id, err := NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 3, 4, 5, 6, 7, 8})
+	t.Run("data length > slab id size", func(t *testing.T) {
+		id, err := NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 3, 4, 5, 6, 7, 8})
 
-		want := StorageID{
+		want := SlabID{
 			Address: Address{0, 0, 0, 0, 0, 0, 0, 1},
-			Index:   StorageIndex{0, 0, 0, 0, 0, 0, 0, 2},
+			Index:   SlabIndex{0, 0, 0, 0, 0, 0, 0, 2},
 		}
 		require.Equal(t, want, id)
 		require.NoError(t, err)
 	})
 }
 
-func TestStorageIDToRawBytes(t *testing.T) {
+func TestSlabIDToRawBytes(t *testing.T) {
 	t.Run("buffer nil", func(t *testing.T) {
 		var fatalError *FatalError
-		var storageIDError *StorageIDError
+		var slabIDError *SlabIDError
 
-		size, err := StorageIDUndefined.ToRawBytes(nil)
+		size, err := SlabIDUndefined.ToRawBytes(nil)
 		require.Equal(t, 0, size)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
-		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError, &storageIDError)
+		require.ErrorAs(t, err, &slabIDError)
+		require.ErrorAs(t, fatalError, &slabIDError)
 	})
 
 	t.Run("buffer too short", func(t *testing.T) {
 		var fatalError *FatalError
-		var storageIDError *StorageIDError
+		var slabIDError *SlabIDError
 
 		b := make([]byte, 8)
-		size, err := StorageIDUndefined.ToRawBytes(b)
+		size, err := SlabIDUndefined.ToRawBytes(b)
 		require.Equal(t, 0, size)
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
-		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError, &storageIDError)
+		require.ErrorAs(t, err, &slabIDError)
+		require.ErrorAs(t, fatalError, &slabIDError)
 	})
 
 	t.Run("undefined", func(t *testing.T) {
-		b := make([]byte, storageIDSize)
-		size, err := StorageIDUndefined.ToRawBytes(b)
+		b := make([]byte, slabIDSize)
+		size, err := SlabIDUndefined.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 		require.Equal(t, want, b)
-		require.Equal(t, storageIDSize, size)
+		require.Equal(t, slabIDSize, size)
 	})
 
 	t.Run("temp address", func(t *testing.T) {
-		id := NewStorageID(Address{0, 0, 0, 0, 0, 0, 0, 0}, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1})
-		b := make([]byte, storageIDSize)
+		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 0}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
+		b := make([]byte, slabIDSize)
 		size, err := id.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
 		require.Equal(t, want, b)
-		require.Equal(t, storageIDSize, size)
+		require.Equal(t, slabIDSize, size)
 	})
 
 	t.Run("temp index", func(t *testing.T) {
-		id := NewStorageID(Address{0, 0, 0, 0, 0, 0, 0, 1}, StorageIndex{0, 0, 0, 0, 0, 0, 0, 0})
-		b := make([]byte, storageIDSize)
+		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 1}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 0})
+		b := make([]byte, slabIDSize)
 		size, err := id.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}
 		require.Equal(t, want, b)
-		require.Equal(t, storageIDSize, size)
+		require.Equal(t, slabIDSize, size)
 	})
 
 	t.Run("perm", func(t *testing.T) {
-		id := NewStorageID(Address{0, 0, 0, 0, 0, 0, 0, 1}, StorageIndex{0, 0, 0, 0, 0, 0, 0, 2})
-		b := make([]byte, storageIDSize)
+		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 1}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
+		b := make([]byte, slabIDSize)
 		size, err := id.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2}
 		require.Equal(t, want, b)
-		require.Equal(t, storageIDSize, size)
+		require.Equal(t, slabIDSize, size)
 	})
 }
 
-func TestStorageIDAddressAsUint64(t *testing.T) {
+func TestSlabIDAddressAsUint64(t *testing.T) {
 	t.Run("temp", func(t *testing.T) {
-		id := NewStorageID(Address{}, StorageIndex{1})
+		id := NewSlabID(Address{}, SlabIndex{1})
 		require.Equal(t, uint64(0), id.AddressAsUint64())
 	})
 	t.Run("perm", func(t *testing.T) {
-		id := NewStorageID(Address{0, 0, 0, 0, 0, 0, 0, 1}, StorageIndex{1})
+		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 1}, SlabIndex{1})
 		require.Equal(t, uint64(1), id.AddressAsUint64())
 	})
 }
 
-func TestStorageIDIndexAsUint64(t *testing.T) {
+func TestSlabIDIndexAsUint64(t *testing.T) {
 	t.Run("temp", func(t *testing.T) {
-		id := NewStorageID(Address{}, StorageIndex{})
+		id := NewSlabID(Address{}, SlabIndex{})
 		require.Equal(t, uint64(0), id.IndexAsUint64())
 	})
 	t.Run("perm", func(t *testing.T) {
-		id := NewStorageID(Address{}, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1})
+		id := NewSlabID(Address{}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		require.Equal(t, uint64(1), id.IndexAsUint64())
 	})
 }
 
-func TestStorageIDValid(t *testing.T) {
+func TestSlabIDValid(t *testing.T) {
 	t.Run("undefined", func(t *testing.T) {
-		id := StorageIDUndefined
+		id := SlabIDUndefined
 		err := id.Valid()
 
 		var fatalError *FatalError
-		var storageIDError *StorageIDError
+		var slabIDError *SlabIDError
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
-		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError, &storageIDError)
+		require.ErrorAs(t, err, &slabIDError)
+		require.ErrorAs(t, fatalError, &slabIDError)
 	})
+
 	t.Run("temp index", func(t *testing.T) {
-		id := StorageID{Address: Address{1}, Index: StorageIndexUndefined}
+		id := SlabID{Address: Address{1}, Index: SlabIndexUndefined}
 		err := id.Valid()
 
 		var fatalError *FatalError
-		var storageIDError *StorageIDError
+		var slabIDError *SlabIDError
 		require.Equal(t, 1, errorCategorizationCount(err))
 		require.ErrorAs(t, err, &fatalError)
-		require.ErrorAs(t, err, &storageIDError)
-		require.ErrorAs(t, fatalError, &storageIDError)
+		require.ErrorAs(t, err, &slabIDError)
+		require.ErrorAs(t, fatalError, &slabIDError)
 	})
+
 	t.Run("temp address", func(t *testing.T) {
-		id := StorageID{Address: AddressUndefined, Index: StorageIndex{1}}
+		id := SlabID{Address: AddressUndefined, Index: SlabIndex{1}}
 		require.NoError(t, id.Valid())
 	})
+
 	t.Run("valid", func(t *testing.T) {
-		id := StorageID{Address: Address{1}, Index: StorageIndex{2}}
+		id := SlabID{Address: Address{1}, Index: SlabIndex{2}}
 		require.NoError(t, id.Valid())
 	})
 }
 
-func TestStorageIDCompare(t *testing.T) {
+func TestSlabIDCompare(t *testing.T) {
 	t.Run("same", func(t *testing.T) {
-		id1 := NewStorageID(Address{1}, StorageIndex{1})
-		id2 := NewStorageID(Address{1}, StorageIndex{1})
+		id1 := NewSlabID(Address{1}, SlabIndex{1})
+		id2 := NewSlabID(Address{1}, SlabIndex{1})
 		require.Equal(t, 0, id1.Compare(id2))
 		require.Equal(t, 0, id2.Compare(id1))
 	})
 
 	t.Run("different address", func(t *testing.T) {
-		id1 := NewStorageID(Address{1}, StorageIndex{1})
-		id2 := NewStorageID(Address{2}, StorageIndex{1})
+		id1 := NewSlabID(Address{1}, SlabIndex{1})
+		id2 := NewSlabID(Address{2}, SlabIndex{1})
 		require.Equal(t, -1, id1.Compare(id2))
 		require.Equal(t, 1, id2.Compare(id1))
 	})
 
 	t.Run("different index", func(t *testing.T) {
-		id1 := NewStorageID(Address{1}, StorageIndex{1})
-		id2 := NewStorageID(Address{1}, StorageIndex{2})
+		id1 := NewSlabID(Address{1}, SlabIndex{1})
+		id2 := NewSlabID(Address{1}, SlabIndex{2})
 		require.Equal(t, -1, id1.Compare(id2))
 		require.Equal(t, 1, id2.Compare(id1))
 	})
 
 	t.Run("different address and index", func(t *testing.T) {
-		id1 := NewStorageID(Address{1}, StorageIndex{1})
-		id2 := NewStorageID(Address{2}, StorageIndex{2})
+		id1 := NewSlabID(Address{1}, SlabIndex{1})
+		id2 := NewSlabID(Address{2}, SlabIndex{2})
 		require.Equal(t, -1, id1.Compare(id2))
 		require.Equal(t, 1, id2.Compare(id1))
 	})
@@ -248,9 +251,9 @@ func TestLedgerBaseStorageStore(t *testing.T) {
 	baseStorage := NewLedgerBaseStorage(ledger)
 
 	bytesStored := 0
-	values := map[StorageID][]byte{
-		{Address{1}, StorageIndex{1}}: {1, 2, 3},
-		{Address{1}, StorageIndex{2}}: {4, 5, 6},
+	values := map[SlabID][]byte{
+		{Address{1}, SlabIndex{1}}: {1, 2, 3},
+		{Address{1}, SlabIndex{2}}: {4, 5, 6},
 	}
 
 	// Store values
@@ -279,7 +282,7 @@ func TestLedgerBaseStorageStore(t *testing.T) {
 		if owner == nil {
 			break
 		}
-		var id StorageID
+		var id SlabID
 		copy(id.Address[:], owner)
 		copy(id.Index[:], key[1:])
 
@@ -295,7 +298,7 @@ func TestLedgerBaseStorageRetrieve(t *testing.T) {
 	ledger := newTestLedger()
 	baseStorage := NewLedgerBaseStorage(ledger)
 
-	id := StorageID{Address: Address{1}, Index: StorageIndex{1}}
+	id := SlabID{Address: Address{1}, Index: SlabIndex{1}}
 	value := []byte{1, 2, 3}
 	bytesStored := 0
 	bytesRetrieved := 0
@@ -318,7 +321,7 @@ func TestLedgerBaseStorageRetrieve(t *testing.T) {
 	require.Equal(t, value, b)
 
 	// Retrieve non-existent value
-	id = StorageID{Address: Address{1}, Index: StorageIndex{2}}
+	id = SlabID{Address: Address{1}, Index: SlabIndex{2}}
 	b, found, err = baseStorage.Retrieve(id)
 	require.NoError(t, err)
 	require.False(t, found)
@@ -332,7 +335,7 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 	ledger := newTestLedger()
 	baseStorage := NewLedgerBaseStorage(ledger)
 
-	id := StorageID{Address: Address{1}, Index: StorageIndex{1}}
+	id := SlabID{Address: Address{1}, Index: SlabIndex{1}}
 	value := []byte{1, 2, 3}
 
 	// Remove value from empty storage
@@ -351,7 +354,7 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove non-existent value
-	err = baseStorage.Remove(StorageID{Address: id.Address, Index: id.Index.Next()})
+	err = baseStorage.Remove(SlabID{Address: id.Address, Index: id.Index.Next()})
 	require.NoError(t, err)
 
 	// Retrieve removed value
@@ -368,7 +371,7 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 		if owner == nil {
 			break
 		}
-		var id StorageID
+		var id SlabID
 		copy(id.Address[:], owner)
 		copy(id.Index[:], key[1:])
 
@@ -380,27 +383,27 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 	require.Equal(t, 2, count)
 }
 
-func TestLedgerBaseStorageGenerateStorageID(t *testing.T) {
+func TestLedgerBaseStorageGenerateSlabID(t *testing.T) {
 	ledger := newTestLedger()
 	baseStorage := NewLedgerBaseStorage(ledger)
 
 	address1 := Address{1}
 	address2 := Address{2}
 
-	id, err := baseStorage.GenerateStorageID(address1)
+	id, err := baseStorage.GenerateSlabID(address1)
 	require.NoError(t, err)
 	require.Equal(t, address1, id.Address)
-	require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
 
-	id, err = baseStorage.GenerateStorageID(address1)
+	id, err = baseStorage.GenerateSlabID(address1)
 	require.NoError(t, err)
 	require.Equal(t, address1, id.Address)
-	require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
 
-	id, err = baseStorage.GenerateStorageID(address2)
+	id, err = baseStorage.GenerateSlabID(address2)
 	require.NoError(t, err)
 	require.Equal(t, address2, id.Address)
-	require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
 }
 
 func TestBasicSlabStorageStore(t *testing.T) {
@@ -408,9 +411,9 @@ func TestBasicSlabStorageStore(t *testing.T) {
 
 	r := newRand(t)
 	address := Address{1}
-	slabs := map[StorageID]Slab{
-		{address, StorageIndex{1}}: generateRandomSlab(address, r),
-		{address, StorageIndex{2}}: generateRandomSlab(address, r),
+	slabs := map[SlabID]Slab{
+		{address, SlabIndex{1}}: generateRandomSlab(address, r),
+		{address, SlabIndex{2}}: generateRandomSlab(address, r),
 	}
 
 	// Store values
@@ -442,7 +445,7 @@ func TestBasicSlabStorageRetrieve(t *testing.T) {
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
 
 	r := newRand(t)
-	id := StorageID{Address{1}, StorageIndex{1}}
+	id := SlabID{Address{1}, SlabIndex{1}}
 	slab := generateRandomSlab(id.Address, r)
 
 	// Retrieve value from empty storage
@@ -461,7 +464,7 @@ func TestBasicSlabStorageRetrieve(t *testing.T) {
 	require.Equal(t, slab, retrievedSlab)
 
 	// Retrieve non-existent value
-	id = StorageID{Address: Address{1}, Index: StorageIndex{2}}
+	id = SlabID{Address: Address{1}, Index: SlabIndex{2}}
 	retrievedSlab, found, err = storage.Retrieve(id)
 	require.NoError(t, err)
 	require.False(t, found)
@@ -472,7 +475,7 @@ func TestBasicSlabStorageRemove(t *testing.T) {
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
 
 	r := newRand(t)
-	id := StorageID{Address{1}, StorageIndex{1}}
+	id := SlabID{Address{1}, SlabIndex{1}}
 	slab := generateRandomSlab(id.Address, r)
 
 	// Remove value from empty storage
@@ -491,7 +494,7 @@ func TestBasicSlabStorageRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove non-existent value
-	err = storage.Remove(StorageID{Address: id.Address, Index: id.Index.Next()})
+	err = storage.Remove(SlabID{Address: id.Address, Index: id.Index.Next()})
 	require.NoError(t, err)
 
 	// Retrieve removed value
@@ -503,33 +506,33 @@ func TestBasicSlabStorageRemove(t *testing.T) {
 	require.Equal(t, 0, storage.Count())
 }
 
-func TestBasicSlabStorageGenerateStorageID(t *testing.T) {
+func TestBasicSlabStorageGenerateSlabID(t *testing.T) {
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
 
 	address1 := Address{1}
 	address2 := Address{2}
 
-	id, err := storage.GenerateStorageID(address1)
+	id, err := storage.GenerateSlabID(address1)
 	require.NoError(t, err)
 	require.Equal(t, address1, id.Address)
-	require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
 
-	id, err = storage.GenerateStorageID(address1)
+	id, err = storage.GenerateSlabID(address1)
 	require.NoError(t, err)
 	require.Equal(t, address1, id.Address)
-	require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
 
-	id, err = storage.GenerateStorageID(address2)
+	id, err = storage.GenerateSlabID(address2)
 	require.NoError(t, err)
 	require.Equal(t, address2, id.Address)
-	require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
 }
 
-func TestBasicSlabStorageStorageIDs(t *testing.T) {
+func TestBasicSlabStorageSlabIDs(t *testing.T) {
 	r := newRand(t)
 	address := Address{1}
-	index := StorageIndex{0, 0, 0, 0, 0, 0, 0, 0}
-	wantIDs := map[StorageID]bool{
+	index := SlabIndex{0, 0, 0, 0, 0, 0, 0, 0}
+	wantIDs := map[SlabID]bool{
 		{Address: address, Index: index.Next()}: true,
 		{Address: address, Index: index.Next()}: true,
 		{Address: address, Index: index.Next()}: true,
@@ -537,8 +540,8 @@ func TestBasicSlabStorageStorageIDs(t *testing.T) {
 
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
 
-	// Get storage ids from empty storgae
-	ids := storage.StorageIDs()
+	// Get slab ids from empty storgae
+	ids := storage.SlabIDs()
 	require.Equal(t, 0, len(ids))
 
 	// Store values
@@ -547,8 +550,8 @@ func TestBasicSlabStorageStorageIDs(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Get storage ids from non-empty storgae
-	ids = storage.StorageIDs()
+	// Get slab ids from non-empty storgae
+	ids = storage.SlabIDs()
 	require.Equal(t, len(wantIDs), len(ids))
 
 	for _, id := range ids {
@@ -559,13 +562,13 @@ func TestBasicSlabStorageStorageIDs(t *testing.T) {
 func TestBasicSlabStorageSlabIterat(t *testing.T) {
 	r := newRand(t)
 	address := Address{1}
-	index := StorageIndex{0, 0, 0, 0, 0, 0, 0, 0}
+	index := SlabIndex{0, 0, 0, 0, 0, 0, 0, 0}
 
-	id1 := StorageID{Address: address, Index: index.Next()}
-	id2 := StorageID{Address: address, Index: index.Next()}
-	id3 := StorageID{Address: address, Index: index.Next()}
+	id1 := SlabID{Address: address, Index: index.Next()}
+	id2 := SlabID{Address: address, Index: index.Next()}
+	id3 := SlabID{Address: address, Index: index.Next()}
 
-	want := map[StorageID]Slab{
+	want := map[SlabID]Slab{
 		id1: generateRandomSlab(id1.Address, r),
 		id2: generateRandomSlab(id2.Address, r),
 		id3: generateRandomSlab(id3.Address, r),
@@ -585,7 +588,7 @@ func TestBasicSlabStorageSlabIterat(t *testing.T) {
 	count := 0
 	for {
 		id, slab := iterator()
-		if id == StorageIDUndefined {
+		if id == SlabIDUndefined {
 			break
 		}
 		require.NotNil(t, want[id])
@@ -607,17 +610,17 @@ func TestPersistentStorage(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 		storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, nil, nil)
 
-		tempStorageID, err := NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+		tempSlabID, err := NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 		require.NoError(t, err)
 
-		permStorageID, err := NewStorageIDFromRawBytes([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+		permSlabID, err := NewSlabIDFromRawBytes([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 		require.NoError(t, err)
 
-		_, found, err := storage.Retrieve(tempStorageID)
+		_, found, err := storage.Retrieve(tempSlabID)
 		require.NoError(t, err)
 		require.False(t, found)
 
-		_, found, err = storage.Retrieve(permStorageID)
+		_, found, err = storage.Retrieve(permSlabID)
 		require.NoError(t, err)
 		require.False(t, found)
 
@@ -633,21 +636,21 @@ func TestPersistentStorage(t *testing.T) {
 		baseStorage := NewInMemBaseStorage()
 		storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, nil, nil)
 
-		tempStorageID, err := NewStorageIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+		tempSlabID, err := NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 		require.NoError(t, err)
 
-		permStorageID, err := NewStorageIDFromRawBytes([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+		permSlabID, err := NewSlabIDFromRawBytes([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 		require.NoError(t, err)
 
-		slab1 := generateRandomSlab(tempStorageID.Address, r)
-		slab2 := generateRandomSlab(permStorageID.Address, r)
+		slab1 := generateRandomSlab(tempSlabID.Address, r)
+		slab2 := generateRandomSlab(permSlabID.Address, r)
 
 		// no temp ids should be in the base storage
-		err = storage.Store(tempStorageID, slab1)
+		err = storage.Store(tempSlabID, slab1)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), storage.DeltasSizeWithoutTempAddresses())
 
-		err = storage.Store(permStorageID, slab2)
+		err = storage.Store(permSlabID, slab2)
 		require.NoError(t, err)
 
 		require.Equal(t, uint(1), storage.DeltasWithoutTempAddresses())
@@ -662,32 +665,32 @@ func TestPersistentStorage(t *testing.T) {
 		require.Equal(t, uint(1), storage.Deltas())
 		require.Equal(t, uint64(0), storage.DeltasSizeWithoutTempAddresses())
 
-		// Slab with temp storage id is NOT persisted in base storage.
-		_, found, err := baseStorage.Retrieve(tempStorageID)
+		// Slab with temp slab id is NOT persisted in base storage.
+		_, found, err := baseStorage.Retrieve(tempSlabID)
 		require.NoError(t, err)
 		require.False(t, found)
 
-		// Slab with temp storage id is cached in storage.
-		_, found, err = storage.Retrieve(tempStorageID)
+		// Slab with temp slab id is cached in storage.
+		_, found, err = storage.Retrieve(tempSlabID)
 		require.NoError(t, err)
 		require.True(t, found)
 
-		// Slab with perm storage id is persisted in base storage.
-		_, found, err = baseStorage.Retrieve(permStorageID)
+		// Slab with perm slab id is persisted in base storage.
+		_, found, err = baseStorage.Retrieve(permSlabID)
 		require.NoError(t, err)
 		require.True(t, found)
 
-		// Slab with perm storage id is cached in storage.
-		_, found, err = storage.Retrieve(permStorageID)
+		// Slab with perm slab id is cached in storage.
+		_, found, err = storage.Retrieve(permSlabID)
 		require.NoError(t, err)
 		require.True(t, found)
 
-		// Remove slab with perm storage id
-		err = storage.Remove(permStorageID)
+		// Remove slab with perm slab id
+		err = storage.Remove(permSlabID)
 		require.NoError(t, err)
 
-		// Remove slab with temp storage id
-		err = storage.Remove(tempStorageID)
+		// Remove slab with temp slab id
+		err = storage.Remove(tempSlabID)
 		require.NoError(t, err)
 
 		require.Equal(t, uint(1), storage.DeltasWithoutTempAddresses())
@@ -696,18 +699,18 @@ func TestPersistentStorage(t *testing.T) {
 		err = storage.Commit()
 		require.NoError(t, err)
 
-		// Slab with perm storage id is removed from base storage.
-		_, found, err = baseStorage.Retrieve(permStorageID)
+		// Slab with perm slab id is removed from base storage.
+		_, found, err = baseStorage.Retrieve(permSlabID)
 		require.NoError(t, err)
 		require.False(t, found)
 
-		// Slab with perm storage id is removed from cache in storage.
-		_, found, err = storage.Retrieve(permStorageID)
+		// Slab with perm slab id is removed from cache in storage.
+		_, found, err = storage.Retrieve(permSlabID)
 		require.NoError(t, err)
 		require.False(t, found)
 
-		// Slab with temp storage id is removed from cache in storage.
-		_, found, err = storage.Retrieve(tempStorageID)
+		// Slab with temp slab id is removed from cache in storage.
+		_, found, err = storage.Retrieve(tempSlabID)
 		require.NoError(t, err)
 		require.False(t, found)
 
@@ -726,7 +729,7 @@ func TestPersistentStorage(t *testing.T) {
 		baseStorage2 := newAccessOrderTrackerBaseStorage()
 		storageWithFastCommit := NewPersistentSlabStorage(baseStorage2, encMode, decMode, nil, nil)
 
-		simpleMap := make(map[StorageID][]byte)
+		simpleMap := make(map[SlabID][]byte)
 		slabSize := uint64(0)
 		// test random updates apply commit and check the order of committed values
 		for i := 0; i < numberOfAccounts; i++ {
@@ -735,18 +738,18 @@ func TestPersistentStorage(t *testing.T) {
 				slab := generateRandomSlab(addr, r)
 				slabSize += uint64(slab.ByteSize())
 
-				storageID, err := storage.GenerateStorageID(addr)
+				slabID, err := storage.GenerateSlabID(addr)
 				require.NoError(t, err)
-				err = storage.Store(storageID, slab)
+				err = storage.Store(slabID, slab)
 				require.NoError(t, err)
 
-				storageID2, err := storageWithFastCommit.GenerateStorageID(addr)
+				slabID2, err := storageWithFastCommit.GenerateSlabID(addr)
 				require.NoError(t, err)
-				err = storageWithFastCommit.Store(storageID2, slab)
+				err = storageWithFastCommit.Store(slabID2, slab)
 				require.NoError(t, err)
 
 				// capture data for accuracy testing
-				simpleMap[storageID], err = Encode(slab, encMode)
+				simpleMap[slabID], err = Encode(slab, encMode)
 				require.NoError(t, err)
 			}
 		}
@@ -844,14 +847,14 @@ func TestPersistentStorage(t *testing.T) {
 
 		address := Address{1}
 
-		id, err := storage.GenerateStorageID(address)
+		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
 
 		err = storage.Store(id, slabWithNonStorable)
 		require.NoError(t, err)
 
 		for i := 0; i < 500; i++ {
-			id, err := storage.GenerateStorageID(address)
+			id, err := storage.GenerateSlabID(address)
 			require.NoError(t, err)
 
 			err = storage.Store(id, slabWithSlowStorable)
@@ -878,7 +881,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 		count := 0
 		for {
 			id, _ := iterator()
-			if id == StorageIDUndefined {
+			if id == SlabIDUndefined {
 				break
 			}
 			count++
@@ -889,12 +892,12 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 	t.Run("not-empty storage", func(t *testing.T) {
 
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
-		id1 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 3}}
-		id4 := StorageID{Address: address, Index: StorageIndex{0, 0, 0, 0, 0, 0, 0, 4}}
+		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id4 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
 
-		data := map[StorageID][]byte{
+		data := map[SlabID][]byte{
 			// (metadata slab) headers: [{id:2 size:228 count:9} {id:3 size:270 count:11} ]
 			id1: {
 				// extra data
@@ -913,7 +916,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				0x81,
 				// child header count
 				0x00, 0x02,
-				// child header 1 (storage id, count, size)
+				// child header 1 (slab id, count, size)
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
 				0x00, 0x00, 0x00, 0x09,
 				0x00, 0x00, 0x00, 0xe4,
@@ -929,7 +932,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				0x00,
 				// array data slab flag
 				0x00,
-				// next storage id
+				// next slab id
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x09,
@@ -945,13 +948,13 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				0x76, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61, 0x61,
 			},
 
-			// (data slab) next: 0, data: [aaaaaaaaaaaaaaaaaaaaaa ... StorageID(...)]
+			// (data slab) next: 0, data: [aaaaaaaaaaaaaaaaaaaaaa ... SlabID(...)]
 			id3: {
 				// version
 				0x00,
 				// array data slab flag
 				0x40,
-				// next storage id
+				// next slab id
 				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
@@ -1003,7 +1006,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 		count := 0
 		for {
 			id, slab := iterator()
-			if id == StorageIDUndefined {
+			if id == SlabIDUndefined {
 				break
 			}
 
@@ -1017,35 +1020,35 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 	})
 }
 
-func TestPersistentStorageGenerateStorageID(t *testing.T) {
+func TestPersistentStorageGenerateSlabID(t *testing.T) {
 	baseStorage := NewInMemBaseStorage()
 	storage := NewPersistentSlabStorage(baseStorage, nil, nil, nil, nil)
 
 	t.Run("temp address", func(t *testing.T) {
 		address := Address{}
 
-		id, err := storage.GenerateStorageID(address)
+		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
 		require.Equal(t, address, id.Address)
-		require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
 
-		id, err = storage.GenerateStorageID(address)
+		id, err = storage.GenerateSlabID(address)
 		require.NoError(t, err)
 		require.Equal(t, address, id.Address)
-		require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
 	})
 	t.Run("perm address", func(t *testing.T) {
 		address := Address{1}
 
-		id, err := storage.GenerateStorageID(address)
+		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
 		require.Equal(t, address, id.Address)
-		require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
 
-		id, err = storage.GenerateStorageID(address)
+		id, err = storage.GenerateSlabID(address)
 		require.NoError(t, err)
 		require.Equal(t, address, id.Address)
-		require.Equal(t, StorageIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
 	})
 }
 
@@ -1054,9 +1057,9 @@ func generateRandomSlab(address Address, r *rand.Rand) Slab {
 
 	return &ArrayDataSlab{
 		header: ArraySlabHeader{
-			id:    NewStorageID(address, StorageIndex{1}),
-			size:  arrayRootDataSlabPrefixSize + storable.ByteSize(),
-			count: 1,
+			slabID: NewSlabID(address, SlabIndex{1}),
+			size:   arrayRootDataSlabPrefixSize + storable.ByteSize(),
+			count:  1,
 		},
 		elements: []Storable{storable},
 	}
@@ -1069,51 +1072,51 @@ func generateRandomAddress(r *rand.Rand) Address {
 }
 
 type accessOrderTrackerBaseStorage struct {
-	segTouchOrder []StorageID
+	segTouchOrder []SlabID
 	indexReqOrder []Address
-	segments      map[StorageID][]byte
-	storageIndex  map[Address]StorageIndex
+	segments      map[SlabID][]byte
+	storageIndex  map[Address]SlabIndex
 }
 
 func newAccessOrderTrackerBaseStorage() *accessOrderTrackerBaseStorage {
 	return &accessOrderTrackerBaseStorage{
-		segTouchOrder: make([]StorageID, 0),
+		segTouchOrder: make([]SlabID, 0),
 		indexReqOrder: make([]Address, 0),
-		segments:      make(map[StorageID][]byte),
-		storageIndex:  make(map[Address]StorageIndex),
+		segments:      make(map[SlabID][]byte),
+		storageIndex:  make(map[Address]SlabIndex),
 	}
 }
 
-func (s *accessOrderTrackerBaseStorage) SegTouchOrder() []StorageID {
+func (s *accessOrderTrackerBaseStorage) SegTouchOrder() []SlabID {
 	return s.segTouchOrder
 }
 
-func (s *accessOrderTrackerBaseStorage) Retrieve(id StorageID) ([]byte, bool, error) {
+func (s *accessOrderTrackerBaseStorage) Retrieve(id SlabID) ([]byte, bool, error) {
 	s.segTouchOrder = append(s.segTouchOrder, id)
 	seg, ok := s.segments[id]
 	return seg, ok, nil
 }
 
-func (s *accessOrderTrackerBaseStorage) Store(id StorageID, data []byte) error {
+func (s *accessOrderTrackerBaseStorage) Store(id SlabID, data []byte) error {
 	s.segTouchOrder = append(s.segTouchOrder, id)
 	s.segments[id] = data
 	return nil
 }
 
-func (s *accessOrderTrackerBaseStorage) Remove(id StorageID) error {
+func (s *accessOrderTrackerBaseStorage) Remove(id SlabID) error {
 	s.segTouchOrder = append(s.segTouchOrder, id)
 	delete(s.segments, id)
 	return nil
 }
 
-func (s *accessOrderTrackerBaseStorage) GenerateStorageID(address Address) (StorageID, error) {
+func (s *accessOrderTrackerBaseStorage) GenerateSlabID(address Address) (SlabID, error) {
 	s.indexReqOrder = append(s.indexReqOrder, address)
 
 	index := s.storageIndex[address]
 	nextIndex := index.Next()
 
 	s.storageIndex[address] = nextIndex
-	return NewStorageID(address, nextIndex), nil
+	return NewSlabID(address, nextIndex), nil
 }
 
 func (s *accessOrderTrackerBaseStorage) SegmentCounts() int { return len(s.segments) }
@@ -1134,7 +1137,7 @@ func (s *accessOrderTrackerBaseStorage) ResetReporter() {}
 
 type testLedger struct {
 	values map[string][]byte
-	index  map[string]StorageIndex
+	index  map[string]SlabIndex
 }
 
 var _ Ledger = &testLedger{}
@@ -1142,7 +1145,7 @@ var _ Ledger = &testLedger{}
 func newTestLedger() *testLedger {
 	return &testLedger{
 		values: make(map[string][]byte),
-		index:  make(map[string]StorageIndex),
+		index:  make(map[string]SlabIndex),
 	}
 }
 
@@ -1161,7 +1164,7 @@ func (l *testLedger) ValueExists(owner, key []byte) (exists bool, err error) {
 	return len(value) > 0, nil
 }
 
-func (l *testLedger) AllocateStorageIndex(owner []byte) (StorageIndex, error) {
+func (l *testLedger) AllocateSlabIndex(owner []byte) (SlabIndex, error) {
 	index := l.index[string(owner)]
 	next := index.Next()
 	l.index[string(owner)] = next


### PR DESCRIPTION
Updates #296 #292 https://github.com/onflow/flow-go/issues/1744
Updates PR #321 and more context at https://github.com/onflow/atree/pull/321#discussion_r1254622587

## Description

Renamed types:
- StorageID to SlabID
- StorageIndex to SlabIndex
- StorageIDStorable to SlabIDStorable
- StorageIDError to SlabIDError
- and etc.

Renamed functions:
- ID() to SlabID() in Slab interface
- Array.StorageID() to Array.SlabID()
- OrderedMap.StorageID() to OrderedMap.SlabID()
- DecodeStorageIDStorable() to DecodeSlabIDStorable()
- NewStorageID() to NewSlabID()
- GenerateStorageID() to GenerateSlabID()
- and etc.

Renamed variables:
- CBORTagStorageID to CBORTagSlabID
- and etc.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
