### PR TITLE
Unexport `SlabID` fields to prevent misuse

### DIFF
--- a/array.go
+++ b/array.go
@@ -112,7 +112,6 @@ func (a *ArrayMetaDataSlab) StoredValue(storage SlabStorage) (Value, error) {
 
 type ArraySlab interface {
 	Slab
-	fmt.Stringer
 
 	Get(storage SlabStorage, index uint64) (Storable, error)
 	Set(storage SlabStorage, address Address, index uint64, value Value) (Storable, error)
@@ -2373,10 +2372,10 @@ func (a *Array) SlabID() SlabID {
 	return a.root.SlabID()
 }
 
-func (a *Array) ID() ID {
+func (a *Array) ValueID() ValueID {
 	sid := a.SlabID()
 
-	var id ID
+	var id ValueID
 	copy(id[:], sid.address[:])
 	copy(id[8:], sid.index[:])
 

--- a/array.go
+++ b/array.go
@@ -146,7 +146,7 @@ type Array struct {
 var _ Value = &Array{}
 
 func (a *Array) Address() Address {
-	return a.root.SlabID().Address
+	return a.root.SlabID().address
 }
 
 func (a *Array) Storable(_ SlabStorage, _ Address, _ uint64) (Storable, error) {
@@ -588,14 +588,14 @@ func (a *ArrayDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 	}
 
 	// Construct right slab
-	sID, err := storage.GenerateSlabID(a.header.slabID.Address)
+	sID, err := storage.GenerateSlabID(a.header.slabID.address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
 		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(
 			err,
 			fmt.Sprintf(
 				"failed to generate slab ID for address 0x%x",
-				a.header.slabID.Address,
+				a.header.slabID.address,
 			),
 		)
 	}
@@ -1722,12 +1722,12 @@ func (a *ArrayMetaDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 	}
 
 	// Construct right slab
-	sID, err := storage.GenerateSlabID(a.header.slabID.Address)
+	sID, err := storage.GenerateSlabID(a.header.slabID.address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
 		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(
 			err,
-			fmt.Sprintf("failed to generate slab ID for address 0x%x", a.header.slabID.Address))
+			fmt.Sprintf("failed to generate slab ID for address 0x%x", a.header.slabID.address))
 	}
 
 	rightSlab := &ArrayMetaDataSlab{
@@ -2377,8 +2377,8 @@ func (a *Array) ID() ID {
 	sid := a.SlabID()
 
 	var id ID
-	copy(id[:], sid.Address[:])
-	copy(id[8:], sid.Index[:])
+	copy(id[:], sid.address[:])
+	copy(id[8:], sid.index[:])
 
 	return id
 }

--- a/array_debug.go
+++ b/array_debug.go
@@ -167,7 +167,7 @@ func DumpArraySlabs(a *Array) ([]string, error) {
 		if !found {
 			return nil, NewSlabNotFoundErrorf(id, "slab not found during array slab dump")
 		}
-		dumps = append(dumps, fmt.Sprintf("overflow: %s", slab))
+		dumps = append(dumps, slab.String())
 	}
 
 	return dumps, nil

--- a/array_test.go
+++ b/array_test.go
@@ -2563,7 +2563,7 @@ func TestArraySlabDump(t *testing.T) {
 
 		want := []string{
 			"level 1, ArrayDataSlab id:0x102030405060708.1 size:24 count:1 elements: [SlabIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]})]",
-			"overflow: &{0x102030405060708.2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}",
+			"StorableSlab id:0x102030405060708.2 storable:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		}
 
 		dumps, err := DumpArraySlabs(array)
@@ -2599,7 +2599,7 @@ func TestArrayID(t *testing.T) {
 	require.NoError(t, err)
 
 	sid := array.SlabID()
-	id := array.ID()
+	id := array.ValueID()
 
 	require.Equal(t, sid.address[:], id[:8])
 	require.Equal(t, sid.index[:], id[8:])

--- a/array_test.go
+++ b/array_test.go
@@ -1639,10 +1639,10 @@ func TestArrayEncodeDecode(t *testing.T) {
 		require.Equal(t, uint64(arraySize), array.Count())
 		require.Equal(t, uint64(1), nestedArray.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
-		id4 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id4 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
 
 		// Expected serialized slab data with slab id
 		expected := map[SlabID][]byte{
@@ -2601,6 +2601,6 @@ func TestArrayID(t *testing.T) {
 	sid := array.SlabID()
 	id := array.ID()
 
-	require.Equal(t, sid.Address[:], id[:8])
-	require.Equal(t, sid.Index[:], id[8:])
+	require.Equal(t, sid.address[:], id[:8])
+	require.Equal(t, sid.index[:], id[8:])
 }

--- a/basicarray.go
+++ b/basicarray.go
@@ -279,7 +279,7 @@ func (a *BasicArray) SlabID() SlabID {
 }
 
 func (a *BasicArray) Address() Address {
-	return a.SlabID().Address
+	return a.SlabID().address
 }
 
 func NewBasicArrayWithRootID(storage SlabStorage, id SlabID) (*BasicArray, error) {

--- a/cmd/stress/array.go
+++ b/cmd/stress/array.go
@@ -396,7 +396,7 @@ func testArray(
 			ids := make([]atree.SlabID, 0, len(rootIDs))
 			for id := range rootIDs {
 				// filter out root ids with empty address
-				if id.Address != atree.AddressUndefined {
+				if !id.HasTempAddress() {
 					ids = append(ids, id)
 				}
 			}

--- a/cmd/stress/map.go
+++ b/cmd/stress/map.go
@@ -369,7 +369,7 @@ func testMap(
 			ids := make([]atree.SlabID, 0, len(rootIDs))
 			for id := range rootIDs {
 				// filter out root ids with empty address
-				if id.Address != atree.AddressUndefined {
+				if !id.HasTempAddress() {
 					ids = append(ids, id)
 				}
 			}

--- a/cmd/stress/storable.go
+++ b/cmd/stress/storable.go
@@ -348,30 +348,11 @@ func (v StringValue) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 }
 
 func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	if uint64(v.ByteSize()) > maxInlineSize {
-
-		// Create StorableSlab
-		id, err := storage.GenerateSlabID(address)
-		if err != nil {
-			return nil, err
-		}
-
-		slab := &atree.StorableSlab{
-			ID:       id,
-			Storable: v,
-		}
-
-		// Store StorableSlab in storage
-		err = storage.Store(id, slab)
-		if err != nil {
-			return nil, err
-		}
-
-		// Return slab id as storable
-		return atree.SlabIDStorable(id), nil
+	if uint64(v.ByteSize()) <= maxInlineSize {
+		return v, nil
 	}
 
-	return v, nil
+	return atree.NewStorableSlab(storage, address, v)
 }
 
 func (v StringValue) Encode(enc *atree.Encoder) error {

--- a/encode.go
+++ b/encode.go
@@ -100,9 +100,9 @@ func DecodeSlab(
 			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
 			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode slab storable")
 		}
-		return StorableSlab{
-			ID:       id,
-			Storable: storable,
+		return &StorableSlab{
+			slabID:   id,
+			storable: storable,
 		}, nil
 
 	default:

--- a/map.go
+++ b/map.go
@@ -2317,7 +2317,7 @@ func (m *MapDataSlab) StoredValue(storage SlabStorage) (Value, error) {
 
 func (m *MapDataSlab) Set(storage SlabStorage, b DigesterBuilder, digester Digester, level uint, hkey Digest, comparator ValueComparator, hip HashInputProvider, key Value, value Value) (MapValue, error) {
 
-	existingValue, err := m.elements.Set(storage, m.SlabID().Address, b, digester, level, hkey, comparator, hip, key, value)
+	existingValue, err := m.elements.Set(storage, m.SlabID().address, b, digester, level, hkey, comparator, hip, key, value)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by elements.Set().
 		return nil, err
@@ -2383,10 +2383,10 @@ func (m *MapDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 		return nil, nil, err
 	}
 
-	sID, err := storage.GenerateSlabID(m.SlabID().Address)
+	sID, err := storage.GenerateSlabID(m.SlabID().address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate slab ID for address 0x%x", m.SlabID().Address))
+		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate slab ID for address 0x%x", m.SlabID().address))
 	}
 
 	// Create new right slab
@@ -3348,10 +3348,10 @@ func (m *MapMetaDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 	leftChildrenCount := int(math.Ceil(float64(len(m.childrenHeaders)) / 2))
 	leftSize := leftChildrenCount * mapSlabHeaderSize
 
-	sID, err := storage.GenerateSlabID(m.SlabID().Address)
+	sID, err := storage.GenerateSlabID(m.SlabID().address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate slab ID for address 0x%x", m.SlabID().Address))
+		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate slab ID for address 0x%x", m.SlabID().address))
 	}
 
 	// Construct right slab
@@ -3545,8 +3545,8 @@ func NewMap(storage SlabStorage, address Address, digestBuilder DigesterBuilder,
 	// This is for creating the seed, so the seed used here is OK to be 0.
 	// LittleEndian is needed for compatibility (same digest from []byte and
 	// two uint64).
-	a := binary.LittleEndian.Uint64(sID.Address[:])
-	b := binary.LittleEndian.Uint64(sID.Index[:])
+	a := binary.LittleEndian.Uint64(sID.address[:])
+	b := binary.LittleEndian.Uint64(sID.index[:])
 	k0 := circlehash.Hash64Uint64x2(a, b, uint64(0))
 
 	// To save storage space, only store 64-bits of the seed.
@@ -3866,8 +3866,8 @@ func (m *OrderedMap) ID() ID {
 	sid := m.SlabID()
 
 	var id ID
-	copy(id[:], sid.Address[:])
-	copy(id[8:], sid.Index[:])
+	copy(id[:], sid.address[:])
+	copy(id[8:], sid.index[:])
 
 	return id
 }
@@ -3885,7 +3885,7 @@ func (m *OrderedMap) Count() uint64 {
 }
 
 func (m *OrderedMap) Address() Address {
-	return m.root.SlabID().Address
+	return m.root.SlabID().address
 }
 
 func (m *OrderedMap) Type() TypeInfo {

--- a/map.go
+++ b/map.go
@@ -263,7 +263,6 @@ var _ MapSlab = &MapMetaDataSlab{}
 
 type MapSlab interface {
 	Slab
-	fmt.Stringer
 
 	Get(storage SlabStorage, digester Digester, level uint, hkey Digest, comparator ValueComparator, key Value) (MapValue, error)
 	Set(storage SlabStorage, b DigesterBuilder, digester Digester, level uint, hkey Digest, comparator ValueComparator, hip HashInputProvider, key Value, value Value) (existingValue MapValue, err error)
@@ -3862,10 +3861,10 @@ func (m *OrderedMap) SlabID() SlabID {
 	return m.root.SlabID()
 }
 
-func (m *OrderedMap) ID() ID {
+func (m *OrderedMap) ValueID() ValueID {
 	sid := m.SlabID()
 
-	var id ID
+	var id ValueID
 	copy(id[:], sid.address[:])
 	copy(id[8:], sid.index[:])
 

--- a/map_debug.go
+++ b/map_debug.go
@@ -241,7 +241,7 @@ func DumpMapSlabs(m *OrderedMap) ([]string, error) {
 		if !found {
 			return nil, NewSlabNotFoundErrorf(id, "slab not found during map slab dump")
 		}
-		dumps = append(dumps, fmt.Sprintf("overflow: %s", slab))
+		dumps = append(dumps, slab.String())
 	}
 
 	return dumps, nil

--- a/map_test.go
+++ b/map_test.go
@@ -1537,7 +1537,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
 		expected := map[SlabID][]byte{
 			id1: {
@@ -1623,7 +1623,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
 		// Expected serialized slab data with slab id
 		expected := map[SlabID][]byte{
@@ -1742,10 +1742,10 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
-		id4 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id4 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
 
 		// Expected serialized slab data with slab id
 		expected := map[SlabID][]byte{
@@ -1961,7 +1961,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
 		// Expected serialized slab data with slab id
 		expected := map[SlabID][]byte{
@@ -2154,7 +2154,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
 		// Expected serialized slab data with slab id
 		expected := map[SlabID][]byte{
@@ -2397,9 +2397,9 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
 
 		// Expected serialized slab data with slab id
 		expected := map[SlabID][]byte{
@@ -2627,7 +2627,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		require.Equal(t, uint64(1), m.Count())
 
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
 
 		expectedNoPointer := []byte{
 
@@ -4229,6 +4229,6 @@ func TestMapID(t *testing.T) {
 	sid := m.SlabID()
 	id := m.ID()
 
-	require.Equal(t, sid.Address[:], id[:8])
-	require.Equal(t, sid.Index[:], id[8:])
+	require.Equal(t, sid.address[:], id[:8])
+	require.Equal(t, sid.index[:], id[8:])
 }

--- a/map_test.go
+++ b/map_test.go
@@ -3909,7 +3909,7 @@ func TestMapSlabDump(t *testing.T) {
 
 		want := []string{
 			"level 1, MapDataSlab id:0x102030405060708.1 size:102 firstkey:0 elements: [0:SlabIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]}):bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb]",
-			"overflow: &{0x102030405060708.2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}",
+			"StorableSlab id:0x102030405060708.2 storable:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		}
 		dumps, err := DumpMapSlabs(m)
 		require.NoError(t, err)
@@ -3936,7 +3936,7 @@ func TestMapSlabDump(t *testing.T) {
 
 		want := []string{
 			"level 1, MapDataSlab id:0x102030405060708.1 size:100 firstkey:0 elements: [0:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:SlabIDStorable({[1 2 3 4 5 6 7 8] [0 0 0 0 0 0 0 2]})]",
-			"overflow: &{0x102030405060708.2 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}",
+			"StorableSlab id:0x102030405060708.2 storable:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 		}
 		dumps, err := DumpMapSlabs(m)
 		require.NoError(t, err)
@@ -4227,7 +4227,7 @@ func TestMapID(t *testing.T) {
 	require.NoError(t, err)
 
 	sid := m.SlabID()
-	id := m.ID()
+	id := m.ValueID()
 
 	require.Equal(t, sid.address[:], id[:8])
 	require.Equal(t, sid.index[:], id[8:])

--- a/slab.go
+++ b/slab.go
@@ -18,8 +18,11 @@
 
 package atree
 
+import "fmt"
+
 type Slab interface {
 	Storable
+	fmt.Stringer
 
 	SlabID() SlabID
 	Split(SlabStorage) (Slab, Slab, error)

--- a/storable.go
+++ b/storable.go
@@ -90,8 +90,8 @@ func (v SlabIDStorable) Encode(enc *Encoder) error {
 		return NewEncodingError(err)
 	}
 
-	copy(enc.Scratch[:], v.Address[:])
-	copy(enc.Scratch[8:], v.Index[:])
+	copy(enc.Scratch[:], v.address[:])
+	copy(enc.Scratch[8:], v.index[:])
 
 	err = enc.CBOR.EncodeBytes(enc.Scratch[:slabIDSize])
 	if err != nil {

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -18,23 +18,56 @@
 
 package atree
 
+import "fmt"
+
 // StorableSlab allows storing storables (CBOR encoded data) directly in a slab.
 // Eventually we will only have a dictionary at the account storage root,
 // so this won't be needed, but during the refactor we have the need to store
 // other non-dictionary values (e.g. strings, integers, etc.) directly in accounts
 // (i.e. directly in slabs aka registers)
 type StorableSlab struct {
-	ID       SlabID
-	Storable Storable
+	slabID   SlabID
+	storable Storable
 }
 
-var _ Slab = StorableSlab{}
+var _ Slab = &StorableSlab{}
 
-func (s StorableSlab) ChildStorables() []Storable {
-	return []Storable{s.Storable}
+func NewStorableSlab(storage SlabStorage, address Address, storable Storable) (Storable, error) {
+	id, err := storage.GenerateSlabID(address)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(
+			err,
+			fmt.Sprintf(
+				"failed to generate slab ID for address 0x%x",
+				address,
+			),
+		)
+	}
+
+	slab := &StorableSlab{
+		slabID:   id,
+		storable: storable,
+	}
+
+	err = storage.Store(id, slab)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", id))
+	}
+
+	return SlabIDStorable(id), nil
 }
 
-func (s StorableSlab) Encode(enc *Encoder) error {
+func (s *StorableSlab) String() string {
+	return fmt.Sprintf("StorableSlab id:%s storable:%s", s.slabID, s.storable)
+}
+
+func (s *StorableSlab) ChildStorables() []Storable {
+	return []Storable{s.storable}
+}
+
+func (s *StorableSlab) Encode(enc *Encoder) error {
 	// Encode version
 	enc.Scratch[0] = 0
 
@@ -42,7 +75,7 @@ func (s StorableSlab) Encode(enc *Encoder) error {
 	flag := maskStorable
 	flag = setNoSizeLimit(flag)
 
-	if _, ok := s.Storable.(SlabIDStorable); ok {
+	if _, ok := s.storable.(SlabIDStorable); ok {
 		flag = setHasPointers(flag)
 	}
 
@@ -53,7 +86,7 @@ func (s StorableSlab) Encode(enc *Encoder) error {
 		return NewEncodingError(err)
 	}
 
-	err = s.Storable.Encode(enc)
+	err = s.storable.Encode(enc)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Storable interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode storable")
@@ -62,16 +95,16 @@ func (s StorableSlab) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (s StorableSlab) ByteSize() uint32 {
-	return versionAndFlagSize + s.Storable.ByteSize()
+func (s *StorableSlab) ByteSize() uint32 {
+	return versionAndFlagSize + s.storable.ByteSize()
 }
 
-func (s StorableSlab) SlabID() SlabID {
-	return s.ID
+func (s *StorableSlab) SlabID() SlabID {
+	return s.slabID
 }
 
-func (s StorableSlab) StoredValue(storage SlabStorage) (Value, error) {
-	value, err := s.Storable.StoredValue(storage)
+func (s *StorableSlab) StoredValue(storage SlabStorage) (Value, error) {
+	value, err := s.storable.StoredValue(storage)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Storable interface.
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get storable's stored value")
@@ -79,18 +112,18 @@ func (s StorableSlab) StoredValue(storage SlabStorage) (Value, error) {
 	return value, nil
 }
 
-func (StorableSlab) Split(_ SlabStorage) (Slab, Slab, error) {
+func (*StorableSlab) Split(_ SlabStorage) (Slab, Slab, error) {
 	return nil, nil, NewNotApplicableError("StorableSlab", "Slab", "Split")
 }
 
-func (StorableSlab) Merge(_ Slab) error {
+func (*StorableSlab) Merge(_ Slab) error {
 	return NewNotApplicableError("StorableSlab", "Slab", "Merge")
 }
 
-func (StorableSlab) LendToRight(_ Slab) error {
+func (*StorableSlab) LendToRight(_ Slab) error {
 	return NewNotApplicableError("StorableSlab", "Slab", "LendToRight")
 }
 
-func (StorableSlab) BorrowFromRight(_ Slab) error {
+func (*StorableSlab) BorrowFromRight(_ Slab) error {
 	return NewNotApplicableError("StorableSlab", "Slab", "BorrowFromRight")
 }

--- a/storable_test.go
+++ b/storable_test.go
@@ -355,8 +355,8 @@ func (v StringValue) Storable(storage SlabStorage, address Address, maxInlineSiz
 		}
 
 		slab := &StorableSlab{
-			ID:       id,
-			Storable: v,
+			slabID:   id,
+			storable: v,
 		}
 
 		// Store StorableSlab in storage

--- a/storage.go
+++ b/storage.go
@@ -38,8 +38,8 @@ type (
 	SlabIndex [8]byte
 
 	SlabID struct {
-		Address Address
-		Index   SlabIndex
+		address Address
+		index   SlabIndex
 	}
 )
 
@@ -84,41 +84,49 @@ func (id SlabID) ToRawBytes(b []byte) (int, error) {
 	if len(b) < slabIDSize {
 		return 0, NewSlabIDErrorf("incorrect slab ID buffer length %d", len(b))
 	}
-	copy(b, id.Address[:])
-	copy(b[8:], id.Index[:])
+	copy(b, id.address[:])
+	copy(b[8:], id.index[:])
 	return slabIDSize, nil
 }
 
 func (id SlabID) String() string {
 	return fmt.Sprintf(
 		"0x%x.%d",
-		binary.BigEndian.Uint64(id.Address[:]),
-		binary.BigEndian.Uint64(id.Index[:]),
+		binary.BigEndian.Uint64(id.address[:]),
+		binary.BigEndian.Uint64(id.index[:]),
 	)
 }
 
 func (id SlabID) AddressAsUint64() uint64 {
-	return binary.BigEndian.Uint64(id.Address[:])
+	return binary.BigEndian.Uint64(id.address[:])
 }
 
 func (id SlabID) IndexAsUint64() uint64 {
-	return binary.BigEndian.Uint64(id.Index[:])
+	return binary.BigEndian.Uint64(id.index[:])
+}
+
+func (id SlabID) HasTempAddress() bool {
+	return id.address == AddressUndefined
+}
+
+func (id SlabID) Index() SlabIndex {
+	return id.index
 }
 
 func (id SlabID) Valid() error {
 	if id == SlabIDUndefined {
 		return NewSlabIDError("undefined slab ID")
 	}
-	if id.Index == SlabIndexUndefined {
+	if id.index == SlabIndexUndefined {
 		return NewSlabIDError("undefined slab index")
 	}
 	return nil
 }
 
 func (id SlabID) Compare(other SlabID) int {
-	result := bytes.Compare(id.Address[:], other.Address[:])
+	result := bytes.Compare(id.address[:], other.address[:])
 	if result == 0 {
-		return bytes.Compare(id.Index[:], other.Index[:])
+		return bytes.Compare(id.index[:], other.index[:])
 	}
 	return result
 }
@@ -170,7 +178,7 @@ func NewLedgerBaseStorage(ledger Ledger) *LedgerBaseStorage {
 }
 
 func (s *LedgerBaseStorage) Retrieve(id SlabID) ([]byte, bool, error) {
-	v, err := s.ledger.GetValue(id.Address[:], SlabIndexToLedgerKey(id.Index))
+	v, err := s.ledger.GetValue(id.address[:], SlabIndexToLedgerKey(id.index))
 	s.bytesRetrieved += len(v)
 
 	if err != nil {
@@ -183,7 +191,7 @@ func (s *LedgerBaseStorage) Retrieve(id SlabID) ([]byte, bool, error) {
 
 func (s *LedgerBaseStorage) Store(id SlabID, data []byte) error {
 	s.bytesStored += len(data)
-	err := s.ledger.SetValue(id.Address[:], SlabIndexToLedgerKey(id.Index), data)
+	err := s.ledger.SetValue(id.address[:], SlabIndexToLedgerKey(id.index), data)
 
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Ledger interface.
@@ -194,7 +202,7 @@ func (s *LedgerBaseStorage) Store(id SlabID, data []byte) error {
 }
 
 func (s *LedgerBaseStorage) Remove(id SlabID) error {
-	err := s.ledger.SetValue(id.Address[:], SlabIndexToLedgerKey(id.Index), nil)
+	err := s.ledger.SetValue(id.address[:], SlabIndexToLedgerKey(id.index), nil)
 
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Ledger interface.
@@ -478,8 +486,8 @@ func CheckStorageHealth(storage SlabStorage, expectedNumberOfRootSlabs int) (map
 				return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to retrieve parent slab %s", parentID))
 			}
 
-			childOwner := childSlab.SlabID().Address
-			parentOwner := parentSlab.SlabID().Address
+			childOwner := childSlab.SlabID().address
+			parentOwner := parentSlab.SlabID().address
 
 			if childOwner != parentOwner {
 				return nil, NewFatalError(
@@ -705,7 +713,7 @@ func (s *PersistentSlabStorage) sortedOwnedDeltaKeys() []SlabID {
 	keysWithOwners := make([]SlabID, 0, len(s.deltas))
 	for k := range s.deltas {
 		// ignore the ones that are not owned by accounts
-		if k.Address != AddressUndefined {
+		if k.address != AddressUndefined {
 			keysWithOwners = append(keysWithOwners, k)
 		}
 	}
@@ -713,7 +721,7 @@ func (s *PersistentSlabStorage) sortedOwnedDeltaKeys() []SlabID {
 	sort.Slice(keysWithOwners, func(i, j int) bool {
 		a := keysWithOwners[i]
 		b := keysWithOwners[j]
-		if a.Address == b.Address {
+		if a.address == b.address {
 			return a.IndexAsUint64() < b.IndexAsUint64()
 		}
 		return a.AddressAsUint64() < b.AddressAsUint64()
@@ -983,7 +991,7 @@ func (s *PersistentSlabStorage) DeltasWithoutTempAddresses() uint {
 	deltas := uint(0)
 	for k := range s.deltas {
 		// exclude the ones that are not owned by accounts
-		if k.Address != AddressUndefined {
+		if k.address != AddressUndefined {
 			deltas++
 		}
 	}
@@ -995,7 +1003,7 @@ func (s *PersistentSlabStorage) DeltasSizeWithoutTempAddresses() uint64 {
 	size := uint64(0)
 	for k, slab := range s.deltas {
 		// Exclude slabs that are not owned by accounts.
-		if k.Address == AddressUndefined || slab == nil {
+		if k.address == AddressUndefined || slab == nil {
 			continue
 		}
 

--- a/storage.go
+++ b/storage.go
@@ -31,12 +31,16 @@ import (
 
 const LedgerBaseStorageSlabPrefix = "$"
 
-type ID [16]byte
+// ValueID identifies Array and OrderedMap.
+type ValueID [16]byte
 
 type (
 	Address   [8]byte
 	SlabIndex [8]byte
 
+	// SlabID identifies slab in storage.
+	// SlabID should only be used to retrieve,
+	// store, and remove slab in storage.
 	SlabID struct {
 		address Address
 		index   SlabIndex

--- a/storage_test.go
+++ b/storage_test.go
@@ -37,11 +37,11 @@ func TestStorageIndexNext(t *testing.T) {
 
 func TestNewSlabID(t *testing.T) {
 	t.Run("temp address", func(t *testing.T) {
-		want := SlabID{Address: Address{}, Index: SlabIndex{1}}
+		want := SlabID{address: Address{}, index: SlabIndex{1}}
 		require.Equal(t, want, NewSlabID(Address{}, SlabIndex{1}))
 	})
 	t.Run("perm address", func(t *testing.T) {
-		want := SlabID{Address: Address{1}, Index: SlabIndex{1}}
+		want := SlabID{address: Address{1}, index: SlabIndex{1}}
 		require.Equal(t, want, NewSlabID(Address{1}, SlabIndex{1}))
 	})
 }
@@ -70,8 +70,8 @@ func TestNewSlabIDFromRawBytes(t *testing.T) {
 		id, err := NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2})
 
 		want := SlabID{
-			Address: Address{0, 0, 0, 0, 0, 0, 0, 1},
-			Index:   SlabIndex{0, 0, 0, 0, 0, 0, 0, 2},
+			address: Address{0, 0, 0, 0, 0, 0, 0, 1},
+			index:   SlabIndex{0, 0, 0, 0, 0, 0, 0, 2},
 		}
 		require.Equal(t, want, id)
 		require.NoError(t, err)
@@ -80,8 +80,8 @@ func TestNewSlabIDFromRawBytes(t *testing.T) {
 		id, err := NewSlabIDFromRawBytes([]byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 1, 2, 3, 4, 5, 6, 7, 8})
 
 		want := SlabID{
-			Address: Address{0, 0, 0, 0, 0, 0, 0, 1},
-			Index:   SlabIndex{0, 0, 0, 0, 0, 0, 0, 2},
+			address: Address{0, 0, 0, 0, 0, 0, 0, 1},
+			index:   SlabIndex{0, 0, 0, 0, 0, 0, 0, 2},
 		}
 		require.Equal(t, want, id)
 		require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestSlabIDValid(t *testing.T) {
 	})
 
 	t.Run("temp index", func(t *testing.T) {
-		id := SlabID{Address: Address{1}, Index: SlabIndexUndefined}
+		id := SlabID{address: Address{1}, index: SlabIndexUndefined}
 		err := id.Valid()
 
 		var fatalError *FatalError
@@ -206,12 +206,12 @@ func TestSlabIDValid(t *testing.T) {
 	})
 
 	t.Run("temp address", func(t *testing.T) {
-		id := SlabID{Address: AddressUndefined, Index: SlabIndex{1}}
+		id := SlabID{address: AddressUndefined, index: SlabIndex{1}}
 		require.NoError(t, id.Valid())
 	})
 
 	t.Run("valid", func(t *testing.T) {
-		id := SlabID{Address: Address{1}, Index: SlabIndex{2}}
+		id := SlabID{address: Address{1}, index: SlabIndex{2}}
 		require.NoError(t, id.Valid())
 	})
 }
@@ -283,8 +283,8 @@ func TestLedgerBaseStorageStore(t *testing.T) {
 			break
 		}
 		var id SlabID
-		copy(id.Address[:], owner)
-		copy(id.Index[:], key[1:])
+		copy(id.address[:], owner)
+		copy(id.index[:], key[1:])
 
 		require.True(t, LedgerKeyIsSlabKey(string(key)))
 		require.Equal(t, values[id], value)
@@ -298,7 +298,7 @@ func TestLedgerBaseStorageRetrieve(t *testing.T) {
 	ledger := newTestLedger()
 	baseStorage := NewLedgerBaseStorage(ledger)
 
-	id := SlabID{Address: Address{1}, Index: SlabIndex{1}}
+	id := SlabID{address: Address{1}, index: SlabIndex{1}}
 	value := []byte{1, 2, 3}
 	bytesStored := 0
 	bytesRetrieved := 0
@@ -321,7 +321,7 @@ func TestLedgerBaseStorageRetrieve(t *testing.T) {
 	require.Equal(t, value, b)
 
 	// Retrieve non-existent value
-	id = SlabID{Address: Address{1}, Index: SlabIndex{2}}
+	id = SlabID{address: Address{1}, index: SlabIndex{2}}
 	b, found, err = baseStorage.Retrieve(id)
 	require.NoError(t, err)
 	require.False(t, found)
@@ -335,7 +335,7 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 	ledger := newTestLedger()
 	baseStorage := NewLedgerBaseStorage(ledger)
 
-	id := SlabID{Address: Address{1}, Index: SlabIndex{1}}
+	id := SlabID{address: Address{1}, index: SlabIndex{1}}
 	value := []byte{1, 2, 3}
 
 	// Remove value from empty storage
@@ -354,7 +354,7 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove non-existent value
-	err = baseStorage.Remove(SlabID{Address: id.Address, Index: id.Index.Next()})
+	err = baseStorage.Remove(SlabID{address: id.address, index: id.index.Next()})
 	require.NoError(t, err)
 
 	// Retrieve removed value
@@ -372,8 +372,8 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 			break
 		}
 		var id SlabID
-		copy(id.Address[:], owner)
-		copy(id.Index[:], key[1:])
+		copy(id.address[:], owner)
+		copy(id.index[:], key[1:])
 
 		require.True(t, LedgerKeyIsSlabKey(string(key)))
 		require.Nil(t, value)
@@ -392,18 +392,18 @@ func TestLedgerBaseStorageGenerateSlabID(t *testing.T) {
 
 	id, err := baseStorage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.Address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, address1, id.address)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
 
 	id, err = baseStorage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.Address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+	require.Equal(t, address1, id.address)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
 
 	id, err = baseStorage.GenerateSlabID(address2)
 	require.NoError(t, err)
-	require.Equal(t, address2, id.Address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, address2, id.address)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
 }
 
 func TestBasicSlabStorageStore(t *testing.T) {
@@ -424,7 +424,7 @@ func TestBasicSlabStorageStore(t *testing.T) {
 
 	// Overwrite stored values
 	for id := range slabs {
-		slab := generateRandomSlab(id.Address, r)
+		slab := generateRandomSlab(id.address, r)
 		slabs[id] = slab
 		err := storage.Store(id, slab)
 		require.NoError(t, err)
@@ -446,7 +446,7 @@ func TestBasicSlabStorageRetrieve(t *testing.T) {
 
 	r := newRand(t)
 	id := SlabID{Address{1}, SlabIndex{1}}
-	slab := generateRandomSlab(id.Address, r)
+	slab := generateRandomSlab(id.address, r)
 
 	// Retrieve value from empty storage
 	retrievedSlab, found, err := storage.Retrieve(id)
@@ -464,7 +464,7 @@ func TestBasicSlabStorageRetrieve(t *testing.T) {
 	require.Equal(t, slab, retrievedSlab)
 
 	// Retrieve non-existent value
-	id = SlabID{Address: Address{1}, Index: SlabIndex{2}}
+	id = SlabID{address: Address{1}, index: SlabIndex{2}}
 	retrievedSlab, found, err = storage.Retrieve(id)
 	require.NoError(t, err)
 	require.False(t, found)
@@ -476,7 +476,7 @@ func TestBasicSlabStorageRemove(t *testing.T) {
 
 	r := newRand(t)
 	id := SlabID{Address{1}, SlabIndex{1}}
-	slab := generateRandomSlab(id.Address, r)
+	slab := generateRandomSlab(id.address, r)
 
 	// Remove value from empty storage
 	err := storage.Remove(id)
@@ -494,7 +494,7 @@ func TestBasicSlabStorageRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove non-existent value
-	err = storage.Remove(SlabID{Address: id.Address, Index: id.Index.Next()})
+	err = storage.Remove(SlabID{address: id.address, index: id.index.Next()})
 	require.NoError(t, err)
 
 	// Retrieve removed value
@@ -514,18 +514,18 @@ func TestBasicSlabStorageGenerateSlabID(t *testing.T) {
 
 	id, err := storage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.Address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, address1, id.address)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
 
 	id, err = storage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.Address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+	require.Equal(t, address1, id.address)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
 
 	id, err = storage.GenerateSlabID(address2)
 	require.NoError(t, err)
-	require.Equal(t, address2, id.Address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+	require.Equal(t, address2, id.address)
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
 }
 
 func TestBasicSlabStorageSlabIDs(t *testing.T) {
@@ -533,9 +533,9 @@ func TestBasicSlabStorageSlabIDs(t *testing.T) {
 	address := Address{1}
 	index := SlabIndex{0, 0, 0, 0, 0, 0, 0, 0}
 	wantIDs := map[SlabID]bool{
-		{Address: address, Index: index.Next()}: true,
-		{Address: address, Index: index.Next()}: true,
-		{Address: address, Index: index.Next()}: true,
+		{address: address, index: index.Next()}: true,
+		{address: address, index: index.Next()}: true,
+		{address: address, index: index.Next()}: true,
 	}
 
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
@@ -546,7 +546,7 @@ func TestBasicSlabStorageSlabIDs(t *testing.T) {
 
 	// Store values
 	for id := range wantIDs {
-		err := storage.Store(id, generateRandomSlab(id.Address, r))
+		err := storage.Store(id, generateRandomSlab(id.address, r))
 		require.NoError(t, err)
 	}
 
@@ -564,14 +564,14 @@ func TestBasicSlabStorageSlabIterat(t *testing.T) {
 	address := Address{1}
 	index := SlabIndex{0, 0, 0, 0, 0, 0, 0, 0}
 
-	id1 := SlabID{Address: address, Index: index.Next()}
-	id2 := SlabID{Address: address, Index: index.Next()}
-	id3 := SlabID{Address: address, Index: index.Next()}
+	id1 := SlabID{address: address, index: index.Next()}
+	id2 := SlabID{address: address, index: index.Next()}
+	id3 := SlabID{address: address, index: index.Next()}
 
 	want := map[SlabID]Slab{
-		id1: generateRandomSlab(id1.Address, r),
-		id2: generateRandomSlab(id2.Address, r),
-		id3: generateRandomSlab(id3.Address, r),
+		id1: generateRandomSlab(id1.address, r),
+		id2: generateRandomSlab(id2.address, r),
+		id3: generateRandomSlab(id3.address, r),
 	}
 
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
@@ -642,8 +642,8 @@ func TestPersistentStorage(t *testing.T) {
 		permSlabID, err := NewSlabIDFromRawBytes([]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 		require.NoError(t, err)
 
-		slab1 := generateRandomSlab(tempSlabID.Address, r)
-		slab2 := generateRandomSlab(permSlabID.Address, r)
+		slab1 := generateRandomSlab(tempSlabID.address, r)
+		slab2 := generateRandomSlab(permSlabID.address, r)
 
 		// no temp ids should be in the base storage
 		err = storage.Store(tempSlabID, slab1)
@@ -892,10 +892,10 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 	t.Run("not-empty storage", func(t *testing.T) {
 
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
-		id1 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
-		id2 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
-		id3 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
-		id4 := SlabID{Address: address, Index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
+		id1 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}}
+		id2 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}}
+		id3 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 3}}
+		id4 := SlabID{address: address, index: SlabIndex{0, 0, 0, 0, 0, 0, 0, 4}}
 
 		data := map[SlabID][]byte{
 			// (metadata slab) headers: [{id:2 size:228 count:9} {id:3 size:270 count:11} ]
@@ -1029,26 +1029,26 @@ func TestPersistentStorageGenerateSlabID(t *testing.T) {
 
 		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.Address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+		require.Equal(t, address, id.address)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
 
 		id, err = storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.Address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+		require.Equal(t, address, id.address)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
 	})
 	t.Run("perm address", func(t *testing.T) {
 		address := Address{1}
 
 		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.Address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index)
+		require.Equal(t, address, id.address)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
 
 		id, err = storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.Address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index)
+		require.Equal(t, address, id.address)
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
 	})
 }
 


### PR DESCRIPTION
Updates #296 #292 https://github.com/onflow/flow-go/issues/1744
Updates https://github.com/onflow/cadence/pull/2622 and more context at https://github.com/onflow/cadence/pull/2622#issuecomment-1622232675.

## Description

Previously `SlabID` had two exported fields `Address` and `Index`.  `Address` field was used in Cadence repo to obtain storage address.  

We want clients to obtain storage address by calling `Array.Address()` or `OrderedMap.Address()`.  This PR unexports `Address` field to prevent misuse.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
