### PR TITLE
Rename ID to ValueID

### DIFF
--- a/array.go
+++ b/array.go
@@ -2372,10 +2372,10 @@ func (a *Array) SlabID() SlabID {
 	return a.root.SlabID()
 }
 
-func (a *Array) ID() ID {
+func (a *Array) ValueID() ValueID {
 	sid := a.SlabID()
 
-	var id ID
+	var id ValueID
 	copy(id[:], sid.address[:])
 	copy(id[8:], sid.index[:])
 

--- a/array_test.go
+++ b/array_test.go
@@ -2599,7 +2599,7 @@ func TestArrayID(t *testing.T) {
 	require.NoError(t, err)
 
 	sid := array.SlabID()
-	id := array.ID()
+	id := array.ValueID()
 
 	require.Equal(t, sid.address[:], id[:8])
 	require.Equal(t, sid.index[:], id[8:])

--- a/map.go
+++ b/map.go
@@ -3861,10 +3861,10 @@ func (m *OrderedMap) SlabID() SlabID {
 	return m.root.SlabID()
 }
 
-func (m *OrderedMap) ID() ID {
+func (m *OrderedMap) ValueID() ValueID {
 	sid := m.SlabID()
 
-	var id ID
+	var id ValueID
 	copy(id[:], sid.address[:])
 	copy(id[8:], sid.index[:])
 

--- a/map_test.go
+++ b/map_test.go
@@ -4227,7 +4227,7 @@ func TestMapID(t *testing.T) {
 	require.NoError(t, err)
 
 	sid := m.SlabID()
-	id := m.ID()
+	id := m.ValueID()
 
 	require.Equal(t, sid.address[:], id[:8])
 	require.Equal(t, sid.index[:], id[8:])

--- a/storage.go
+++ b/storage.go
@@ -31,12 +31,16 @@ import (
 
 const LedgerBaseStorageSlabPrefix = "$"
 
-type ID [16]byte
+// ValueID identifies Array and OrderedMap.
+type ValueID [16]byte
 
 type (
 	Address   [8]byte
 	SlabIndex [8]byte
 
+	// SlabID identifies slab in storage.
+	// SlabID should only be used to retrieve,
+	// store, and remove slab in storage.
 	SlabID struct {
 		address Address
 		index   SlabIndex


### PR DESCRIPTION
Updates #296 #292 https://github.com/onflow/flow-go/issues/1744
Updates PR #321 and more context at https://github.com/onflow/atree/pull/321#discussion_r1254622587


## Description

`ValueID` identifies atree `Array` and `OrderedMap` while `SlabID` identifies slab in storage.  `SlabID` should only be used to retrieve, store, and remove slab in storage.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
