### PR TITLE
Refactor `hasPointer` for register inlining

### DIFF
--- a/array.go
+++ b/array.go
@@ -451,7 +451,7 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 
 func (a *ArrayDataSlab) hasPointer() bool {
 	for _, e := range a.elements {
-		if _, ok := e.(SlabIDStorable); ok {
+		if hasPointer(e) {
 			return true
 		}
 	}

--- a/map_debug.go
+++ b/map_debug.go
@@ -726,11 +726,6 @@ func validSingleElement(
 	err error,
 ) {
 
-	// Verify key pointer
-	if _, keyPointer := e.key.(SlabIDStorable); e.keyPointer != keyPointer {
-		return 0, 0, NewFatalError(fmt.Errorf("element %s keyPointer %t is wrong, want %t", e, e.keyPointer, keyPointer))
-	}
-
 	// Verify key
 	kv, err := e.key.StoredValue(storage)
 	if err != nil {
@@ -742,11 +737,6 @@ func validSingleElement(
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by ValidValue().
 		return 0, 0, fmt.Errorf("element %s key isn't valid: %w", e, err)
-	}
-
-	// Verify value pointer
-	if _, valuePointer := e.value.(SlabIDStorable); e.valuePointer != valuePointer {
-		return 0, 0, NewFatalError(fmt.Errorf("element %s valuePointer %t is wrong, want %t", e, e.valuePointer, valuePointer))
 	}
 
 	// Verify value
@@ -1270,14 +1260,6 @@ func mapSingleElementEqual(
 
 	if expected.size != actual.size {
 		return NewFatalError(fmt.Errorf("singleElement size %d is wrong, want %d", actual.size, expected.size))
-	}
-
-	if expected.keyPointer != actual.keyPointer {
-		return NewFatalError(fmt.Errorf("singleElement keyPointer %t is wrong, want %t", actual.keyPointer, expected.keyPointer))
-	}
-
-	if expected.valuePointer != actual.valuePointer {
-		return NewFatalError(fmt.Errorf("singleElement valuePointer %t is wrong, want %t", actual.valuePointer, expected.valuePointer))
 	}
 
 	if !compare(expected.key, actual.key) {

--- a/storable.go
+++ b/storable.go
@@ -37,6 +37,18 @@ type Storable interface {
 	ChildStorables() []Storable
 }
 
+type containerStorable interface {
+	Storable
+	hasPointer() bool
+}
+
+func hasPointer(storable Storable) bool {
+	if cs, ok := storable.(containerStorable); ok {
+		return cs.hasPointer()
+	}
+	return false
+}
+
 const (
 	CBORTagInlineCollisionGroup   = 253
 	CBORTagExternalCollisionGroup = 254
@@ -47,6 +59,10 @@ const (
 type SlabIDStorable SlabID
 
 var _ Storable = SlabIDStorable{}
+
+func (v SlabIDStorable) hasPointer() bool {
+	return true
+}
 
 func (v SlabIDStorable) ChildStorables() []Storable {
 	return nil

--- a/storable_test.go
+++ b/storable_test.go
@@ -637,6 +637,13 @@ type SomeStorable struct {
 
 var _ Storable = SomeStorable{}
 
+func (v SomeStorable) hasPointer() bool {
+	if ms, ok := v.Storable.(containerStorable); ok {
+		return ms.hasPointer()
+	}
+	return false
+}
+
 func (v SomeStorable) ByteSize() uint32 {
 	// tag number (2 bytes) + encoded content
 	return 2 + v.Storable.ByteSize()


### PR DESCRIPTION
Updates #292 

## Description

Currently, slab has pointer if any of its element is `SlabIDStorable`. This will become an issue with register inlining because even though inlined slab is not `SlabIDStorable`, it can contain `SlabIDStorable`.

This PR:
- adds `containerStorable` interface with `hasPointer` function
- delegates each storable to check itself recursively
- removes `keyPointer` and `valuePointer` fields from `singleElement` struct to simplify code.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
