### PR TITLE
Add ByteSize() to TypeInfo interface

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -77,6 +77,10 @@ type testTypeInfo struct{}
 
 var _ atree.TypeInfo = testTypeInfo{}
 
+func (i testTypeInfo) ByteSize() uint32 {
+	return atree.GetUintCBORSize(42)
+}
+
 func (testTypeInfo) Encode(e *cbor.StreamEncoder) error {
 	return e.EncodeUint8(42)
 }

--- a/cmd/stress/typeinfo.go
+++ b/cmd/stress/typeinfo.go
@@ -30,6 +30,10 @@ type testTypeInfo struct {
 
 var _ atree.TypeInfo = testTypeInfo{}
 
+func (i testTypeInfo) ByteSize() uint32 {
+	return atree.GetUintCBORSize(i.value)
+}
+
 func (i testTypeInfo) Encode(e *cbor.StreamEncoder) error {
 	return e.EncodeUint64(i.value)
 }

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -24,6 +24,7 @@ import (
 
 type TypeInfo interface {
 	Encode(*cbor.StreamEncoder) error
+	ByteSize() uint32
 }
 
 type TypeInfoDecoder func(

--- a/utils_test.go
+++ b/utils_test.go
@@ -91,6 +91,10 @@ type testTypeInfo struct {
 
 var _ TypeInfo = testTypeInfo{}
 
+func (i testTypeInfo) ByteSize() uint32 {
+	return GetUintCBORSize(i.value)
+}
+
 func (i testTypeInfo) Encode(enc *cbor.StreamEncoder) error {
 	return enc.EncodeUint64(i.value)
 }


### PR DESCRIPTION
Updates #292 

## Description

This PR adds `ByteSize()` function in `TypeInfo` interface, which is used to compute extra data size of inlined registers.

### Context

Inlined registers are treated as element and its encoded size must be known at runtime to enforce slab size limits.  Since inlined registers are root slabs with extra data, encoded extra data size needs to be computed. 

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
