### PR TITLE
Add ReadOnly iterators and refactor other iterators

### DIFF
--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -355,7 +355,7 @@ func benchmarkNewArrayFromAppend(b *testing.B, initialArraySize int) {
 	for i := 0; i < b.N; i++ {
 		copied, _ := NewArray(storage, array.Address(), array.Type())
 
-		_ = array.Iterate(func(value Value) (bool, error) {
+		_ = array.IterateReadOnly(func(value Value) (bool, error) {
 			_ = copied.Append(value)
 			return true, nil
 		})
@@ -379,7 +379,7 @@ func benchmarkNewArrayFromBatchData(b *testing.B, initialArraySize int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(b, err)
 
 		copied, _ := NewArrayFromBatchData(storage, array.Address(), array.Type(), func() (Value, error) {

--- a/array_test.go
+++ b/array_test.go
@@ -65,7 +65,7 @@ func verifyArray(
 
 	// Verify array elements by iterator
 	i := 0
-	err = array.Iterate(func(v Value) (bool, error) {
+	err = array.IterateReadOnly(func(v Value) (bool, error) {
 		valueEqual(t, typeInfoComparator, values[i], v)
 		i++
 		return true, nil
@@ -644,7 +644,7 @@ func TestArrayIterate(t *testing.T) {
 		require.NoError(t, err)
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -671,7 +671,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(i), v)
 			i++
 			return true, nil
@@ -708,7 +708,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(i), v)
 			i++
 			return true, nil
@@ -741,7 +741,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(i), v)
 			i++
 			return true, nil
@@ -777,7 +777,7 @@ func TestArrayIterate(t *testing.T) {
 
 		i := uint64(0)
 		j := uint64(1)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(j), v)
 			i++
 			j += 2
@@ -803,7 +803,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := 0
-		err = array.Iterate(func(_ Value) (bool, error) {
+		err = array.IterateReadOnly(func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, nil
 			}
@@ -832,7 +832,7 @@ func TestArrayIterate(t *testing.T) {
 		testErr := errors.New("test")
 
 		i := 0
-		err = array.Iterate(func(_ Value) (bool, error) {
+		err = array.IterateReadOnly(func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, testErr
 			}
@@ -858,7 +858,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 	count := array.Count()
 
 	// If startIndex > count, IterateRange returns SliceOutOfBoundsError
-	err = array.IterateRange(count+1, count+1, func(v Value) (bool, error) {
+	err = array.IterateReadOnlyRange(count+1, count+1, func(v Value) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -871,7 +871,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 	require.Equal(t, uint64(0), i)
 
 	// If endIndex > count, IterateRange returns SliceOutOfBoundsError
-	err = array.IterateRange(0, count+1, func(v Value) (bool, error) {
+	err = array.IterateReadOnlyRange(0, count+1, func(v Value) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -883,7 +883,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 
 	// If startIndex > endIndex, IterateRange returns InvalidSliceIndexError
 	if count > 0 {
-		err = array.IterateRange(1, 0, func(v Value) (bool, error) {
+		err = array.IterateReadOnlyRange(1, 0, func(v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -898,7 +898,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 	for startIndex := uint64(0); startIndex <= count; startIndex++ {
 		for endIndex := startIndex; endIndex <= count; endIndex++ {
 			i = uint64(0)
-			err = array.IterateRange(startIndex, endIndex, func(v Value) (bool, error) {
+			err = array.IterateReadOnlyRange(startIndex, endIndex, func(v Value) (bool, error) {
 				valueEqual(t, typeInfoComparator, v, values[int(startIndex+i)])
 				i++
 				return true, nil
@@ -980,7 +980,7 @@ func TestArrayIterateRange(t *testing.T) {
 		startIndex := uint64(1)
 		endIndex := uint64(5)
 		count := endIndex - startIndex
-		err = array.IterateRange(startIndex, endIndex, func(_ Value) (bool, error) {
+		err = array.IterateReadOnlyRange(startIndex, endIndex, func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, nil
 			}
@@ -1009,7 +1009,7 @@ func TestArrayIterateRange(t *testing.T) {
 		startIndex := uint64(1)
 		endIndex := uint64(5)
 		count := endIndex - startIndex
-		err = array.IterateRange(startIndex, endIndex, func(_ Value) (bool, error) {
+		err = array.IterateReadOnlyRange(startIndex, endIndex, func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, testErr
 			}
@@ -1846,7 +1846,7 @@ func TestEmptyArray(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		i := uint64(0)
-		err := array.Iterate(func(v Value) (bool, error) {
+		err := array.IterateReadOnly(func(v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -2088,7 +2088,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		// Create a new array with new storage, new address, and original array's elements.
@@ -2128,7 +2128,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		// Create a new array with new storage, new address, and original array's elements.
@@ -2172,7 +2172,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		address := Address{2, 3, 4, 5, 6, 7, 8, 9}
@@ -2222,7 +2222,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(36), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -2272,7 +2272,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(36), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -2318,7 +2318,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -2373,7 +2373,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -2738,7 +2738,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		verifyArrayLoadedElements(t, array, values)
 
 		i := 0
-		err := array.IterateLoadedValues(func(v Value) (bool, error) {
+		err := array.IterateReadOnlyLoadedValues(func(v Value) (bool, error) {
 			// At this point, iterator returned first element (v).
 
 			// Remove all other nested composite elements (except first element) from storage.
@@ -3414,7 +3414,7 @@ func createArrayWithSimpleAndCompositeValues(
 
 func verifyArrayLoadedElements(t *testing.T, array *Array, expectedValues []Value) {
 	i := 0
-	err := array.IterateLoadedValues(func(v Value) (bool, error) {
+	err := array.IterateReadOnlyLoadedValues(func(v Value) (bool, error) {
 		require.True(t, i < len(expectedValues))
 		valueEqual(t, typeInfoComparator, expectedValues[i], v)
 		i++

--- a/cmd/stress/utils.go
+++ b/cmd/stress/utils.go
@@ -132,7 +132,7 @@ func copyValue(storage *atree.PersistentSlabStorage, address atree.Address, valu
 }
 
 func copyArray(storage *atree.PersistentSlabStorage, address atree.Address, array *atree.Array) (*atree.Array, error) {
-	iterator, err := array.Iterator()
+	iterator, err := array.ReadOnlyIterator()
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func copyArray(storage *atree.PersistentSlabStorage, address atree.Address, arra
 }
 
 func copyMap(storage *atree.PersistentSlabStorage, address atree.Address, m *atree.OrderedMap) (*atree.OrderedMap, error) {
-	iterator, err := m.Iterator()
+	iterator, err := m.ReadOnlyIterator()
 	if err != nil {
 		return nil, err
 	}
@@ -260,12 +260,12 @@ func arrayEqual(a atree.Value, b atree.Value) error {
 		return fmt.Errorf("array %s count %d != array %s count %d", array1, array1.Count(), array2, array2.Count())
 	}
 
-	iterator1, err := array1.Iterator()
+	iterator1, err := array1.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get array1 iterator: %w", err)
 	}
 
-	iterator2, err := array2.Iterator()
+	iterator2, err := array2.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get array2 iterator: %w", err)
 	}
@@ -309,12 +309,12 @@ func mapEqual(a atree.Value, b atree.Value) error {
 		return fmt.Errorf("map %s count %d != map %s count %d", m1, m1.Count(), m2, m2.Count())
 	}
 
-	iterator1, err := m1.Iterator()
+	iterator1, err := m1.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get m1 iterator: %w", err)
 	}
 
-	iterator2, err := m2.Iterator()
+	iterator2, err := m2.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get m2 iterator: %w", err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -130,7 +130,7 @@ func verifyMap(
 		require.Equal(t, len(keyValues), len(sortedKeys))
 
 		i := 0
-		err = m.Iterate(func(k, v Value) (bool, error) {
+		err = m.IterateReadOnly(func(k, v Value) (bool, error) {
 			expectedKey := sortedKeys[i]
 			expectedValue := keyValues[expectedKey]
 
@@ -1086,7 +1086,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate key value pairs
 		i = uint64(0)
-		err = m.Iterate(func(k Value, v Value) (resume bool, err error) {
+		err = m.IterateReadOnly(func(k Value, v Value) (resume bool, err error) {
 			valueEqual(t, typeInfoComparator, sortedKeys[i], k)
 			valueEqual(t, typeInfoComparator, keyValues[k], v)
 			i++
@@ -1098,7 +1098,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate keys
 		i = uint64(0)
-		err = m.IterateKeys(func(k Value) (resume bool, err error) {
+		err = m.IterateReadOnlyKeys(func(k Value) (resume bool, err error) {
 			valueEqual(t, typeInfoComparator, sortedKeys[i], k)
 			i++
 			return true, nil
@@ -1109,7 +1109,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate values
 		i = uint64(0)
-		err = m.IterateValues(func(v Value) (resume bool, err error) {
+		err = m.IterateReadOnlyValues(func(v Value) (resume bool, err error) {
 			k := sortedKeys[i]
 			valueEqual(t, typeInfoComparator, keyValues[k], v)
 			i++
@@ -1172,7 +1172,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate key value pairs
 		i := uint64(0)
-		err = m.Iterate(func(k Value, v Value) (resume bool, err error) {
+		err = m.IterateReadOnly(func(k Value, v Value) (resume bool, err error) {
 			valueEqual(t, typeInfoComparator, sortedKeys[i], k)
 			valueEqual(t, typeInfoComparator, keyValues[k], v)
 			i++
@@ -1185,7 +1185,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate keys
 		i = uint64(0)
-		err = m.IterateKeys(func(k Value) (resume bool, err error) {
+		err = m.IterateReadOnlyKeys(func(k Value) (resume bool, err error) {
 			valueEqual(t, typeInfoComparator, sortedKeys[i], k)
 			i++
 			return true, nil
@@ -1197,7 +1197,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate values
 		i = uint64(0)
-		err = m.IterateValues(func(v Value) (resume bool, err error) {
+		err = m.IterateReadOnlyValues(func(v Value) (resume bool, err error) {
 			valueEqual(t, typeInfoComparator, keyValues[sortedKeys[i]], v)
 			i++
 			return true, nil
@@ -3058,7 +3058,7 @@ func TestEmptyMap(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		i := 0
-		err := m.Iterate(func(k Value, v Value) (bool, error) {
+		err := m.IterateReadOnly(func(k Value, v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -3096,7 +3096,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -3143,7 +3143,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -3205,7 +3205,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -3270,7 +3270,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize+1), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -3339,7 +3339,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.Equal(t, uint64(mapSize+1), m.Count())
 		require.Equal(t, typeInfo, m.Type())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -3402,7 +3402,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -3483,7 +3483,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -3567,7 +3567,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, storable)
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -4844,7 +4844,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		verifyMapLoadedElements(t, m, values)
 
 		i := 0
-		err := m.IterateLoadedValues(func(k Value, v Value) (bool, error) {
+		err := m.IterateReadOnlyLoadedValues(func(k Value, v Value) (bool, error) {
 			// At this point, iterator returned first element (v).
 
 			// Remove all other nested composite elements (except first element) from storage.
@@ -5746,7 +5746,7 @@ func createMapWithSimpleAndCompositeValues(
 
 func verifyMapLoadedElements(t *testing.T, m *OrderedMap, expectedValues [][2]Value) {
 	i := 0
-	err := m.IterateLoadedValues(func(k Value, v Value) (bool, error) {
+	err := m.IterateReadOnlyLoadedValues(func(k Value, v Value) (bool, error) {
 		require.True(t, i < len(expectedValues))
 		valueEqual(t, typeInfoComparator, expectedValues[i][0], k)
 		valueEqual(t, typeInfoComparator, expectedValues[i][1], v)

--- a/utils_test.go
+++ b/utils_test.go
@@ -287,10 +287,10 @@ func arrayEqual(t *testing.T, tic TypeInfoComparator, a Value, b Value) {
 	require.Equal(t, array1.Count(), array2.Count())
 	require.Equal(t, array1.SlabID(), array2.SlabID())
 
-	iterator1, err := array1.Iterator()
+	iterator1, err := array1.ReadOnlyIterator()
 	require.NoError(t, err)
 
-	iterator2, err := array2.Iterator()
+	iterator2, err := array2.ReadOnlyIterator()
 	require.NoError(t, err)
 
 	for {
@@ -320,10 +320,10 @@ func mapEqual(t *testing.T, tic TypeInfoComparator, a Value, b Value) {
 	require.Equal(t, m1.Count(), m2.Count())
 	require.Equal(t, m1.SlabID(), m2.SlabID())
 
-	iterator1, err := m1.Iterator()
+	iterator1, err := m1.ReadOnlyIterator()
 	require.NoError(t, err)
 
-	iterator2, err := m2.Iterator()
+	iterator2, err := m2.ReadOnlyIterator()
 	require.NoError(t, err)
 
 	for {


### PR DESCRIPTION
Updates #292 

## Description

This change:
- Adds ReadOnly iterators that match current iterator API (except for the "ReadOnly" suffix added to some function names).
- Refactors API of non-Readonly iterators because register inlining will require more parameters for MapIterator.

For ReadOnly iterators, the caller is responsible for preventing changes to child containers during iteration because mutations of child containers are not guaranteed to persist.

For non-ReadOnly iterators, two additional parameters are needed to update child container in parent map when child container is modified.



______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
