### PR TITLE
Reduce encoded size of map and bump version

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -1752,11 +1752,12 @@ func TestArrayEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedData := []byte{
-			// extra data
 			// version
 			0x01,
 			// flag
 			0x80,
+
+			// extra data
 			// array of extra data
 			0x81,
 			// type info
@@ -1795,11 +1796,12 @@ func TestArrayEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedData := []byte{
-			// extra data
 			// version
 			0x01,
 			// flag
 			0x80,
+
+			// extra data
 			// array of extra data
 			0x81,
 			// type info
@@ -1869,11 +1871,12 @@ func TestArrayEncodeDecode(t *testing.T) {
 
 			// (metadata slab) headers: [{id:2 size:228 count:9} {id:3 size:270 count:11} ]
 			id1: {
-				// extra data
 				// version
 				0x01,
 				// flag
 				0x81,
+
+				// extra data
 				// array of extra data
 				0x81,
 				// type info
@@ -1941,11 +1944,12 @@ func TestArrayEncodeDecode(t *testing.T) {
 
 			// (data slab) next: 0, data: [0]
 			id4: {
-				// extra data
 				// version
 				0x01,
 				// extra data flag
 				0x80,
+
+				// extra data
 				// array of extra data
 				0x81,
 				// type info

--- a/map.go
+++ b/map.go
@@ -1153,7 +1153,8 @@ func (e *hkeyElements) Encode(enc *Encoder) error {
 	}
 
 	// Encode CBOR array head of 3 elements (level, hkeys, elements)
-	enc.Scratch[0] = 0x83
+	const cborArrayHeadOfThreeElements = 0x83
+	enc.Scratch[0] = cborArrayHeadOfThreeElements
 
 	// Encode hash level
 	enc.Scratch[1] = byte(e.level)
@@ -1162,7 +1163,9 @@ func (e *hkeyElements) Encode(enc *Encoder) error {
 
 	// Encode hkeys bytes header manually for fix-sized encoding
 	// TODO: maybe make this header dynamic to reduce size
-	enc.Scratch[2] = 0x59
+	// CBOR byte string head 0x59 indicates that the number of bytes in byte string are encoded in the next 2 bytes.
+	const cborByteStringHead = 0x59
+	enc.Scratch[2] = cborByteStringHead
 
 	binary.BigEndian.PutUint16(enc.Scratch[3:], uint16(len(e.hkeys)*8))
 
@@ -1186,7 +1189,9 @@ func (e *hkeyElements) Encode(enc *Encoder) error {
 
 	// Encode elements array header manually for fix-sized encoding
 	// TODO: maybe make this header dynamic to reduce size
-	enc.Scratch[0] = 0x99
+	// CBOR array head 0x99 indicating that the number of array elements are encoded in the next 2 bytes.
+	const cborArrayHead = 0x99
+	enc.Scratch[0] = cborArrayHead
 	binary.BigEndian.PutUint16(enc.Scratch[1:], uint16(len(e.elems)))
 	err = enc.CBOR.EncodeRawBytes(enc.Scratch[:3])
 	if err != nil {

--- a/map_debug.go
+++ b/map_debug.go
@@ -1366,7 +1366,7 @@ func getEncodedMapExtraDataSize(extraData *MapExtraData, cborEncMode cbor.EncMod
 	var buf bytes.Buffer
 	enc := NewEncoder(&buf, cborEncMode)
 
-	err := extraData.Encode(enc, byte(0), byte(0))
+	err := extraData.Encode(enc)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by MapExtraData.Encode().
 		return 0, err


### PR DESCRIPTION
Updates #292
Updates https://github.com/onflow/flow-go/issues/1744

Changes:
- bump Atree format version to 1 (was 0) for maps
- remove redundant version and flag data from root slabs (2 bytes per root slab)
- remove redundant slab address from children headers in metadata slab since all child slabs have the same address (8 bytes per child header per metadata slab)
- reduce encoded child slab size in children headers in metadata slab from 4 bytes to 2 bytes (2 bytes per child header per metadata slab)
- reduce encoded number of digests from 8 bytes to 2 bytes (6 bytes per data slab)
- reduce encoded number of map elements from 8 bytes to 2 bytes (6 bytes per data slab)
- decode version 0 and 1
- encode only version 1
- add tests to decode map slabs data in version 0

⚠️ This change requires data migration and data format version was bumped from 0 to 1.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
