### PR TITLE
Fix slab size when resetting mutable storable in Array

### DIFF
--- a/storable_test.go
+++ b/storable_test.go
@@ -676,3 +676,48 @@ func (v SomeStorable) StoredValue(storage SlabStorage) (Value, error) {
 func (v SomeStorable) String() string {
 	return fmt.Sprintf("%s", v.Storable)
 }
+
+type mutableValue struct {
+	storable *mutableStorable
+}
+
+var _ Value = &mutableValue{}
+
+func newMutableValue(storableSize uint32) *mutableValue {
+	return &mutableValue{
+		storable: &mutableStorable{
+			size: storableSize,
+		},
+	}
+}
+
+func (v *mutableValue) Storable(SlabStorage, Address, uint64) (Storable, error) {
+	return v.storable, nil
+}
+
+func (v *mutableValue) updateStorableSize(n uint32) {
+	v.storable.size = n
+}
+
+type mutableStorable struct {
+	size uint32
+}
+
+var _ Storable = &mutableStorable{}
+
+func (s *mutableStorable) ByteSize() uint32 {
+	return s.size
+}
+
+func (s *mutableStorable) StoredValue(SlabStorage) (Value, error) {
+	return &mutableValue{s}, nil
+}
+
+func (*mutableStorable) ChildStorables() []Storable {
+	return nil
+}
+
+func (*mutableStorable) Encode(*Encoder) error {
+	// no-op for testing
+	return nil
+}


### PR DESCRIPTION
Updates #292  #335 

## Changes

Recompute slab size by adding all element sizes instead of using the size diff of old 
and new element because oldElem can be the same storable when the same value is reset
and oldElem.ByteSize() can equal storable.ByteSize().

Given this, size diff of the old and new element can be 0 even when its actual size changed.

This is prep work for atree inlining to prevent a bug from surfacing.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
