### PR TITLE
Omit empty next slab ID in encoded array data slab

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -1899,7 +1899,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			// (data slab) next: 3, data: [aaaaaaaaaaaaaaaaaaaaaa ... aaaaaaaaaaaaaaaaaaaaaa]
 			id2: {
 				// version
-				0x10,
+				0x12,
 				// array data slab flag
 				0x00,
 				// next slab id
@@ -1924,8 +1924,6 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x10,
 				// array data slab flag
 				0x40,
-				// next slab id
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
 				// CBOR encoded array elements

--- a/storage_test.go
+++ b/storage_test.go
@@ -927,7 +927,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 			// (data slab) next: 3, data: [aaaaaaaaaaaaaaaaaaaaaa ... aaaaaaaaaaaaaaaaaaaaaa]
 			id2: {
 				// version
-				0x10,
+				0x12,
 				// array data slab flag
 				0x00,
 				// next slab id
@@ -952,8 +952,6 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				0x10,
 				// array data slab flag
 				0x40,
-				// next slab id
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
 				// CBOR encoded array elements


### PR DESCRIPTION
## Description

Currently, we omit empty next slab ID in encoded root data slabs because next slab ID is always empty in root data slabs.

However, next slab ID is also empty for non-root data slabs if the non-root data slab is the last data slab.

This commit sets hasNextSlabID flag during encoding and only encodes non-empty next slab ID for array data slab.

This change saves 16 bytes for the last non-root data slabs.  Also, we don't special case the omission of next slab ID in root slabs.

NOTE: omission of empty next slab ID doesn't affect slab size computation which is used for slab operations, such as splitting and merging.  This commit is a size optimization during slab encoding.




<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
