### PR TITLE
Omit empty next slab ID in encoded map data slab

### DIFF
--- a/map_test.go
+++ b/map_test.go
@@ -2737,7 +2737,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			// data slab
 			id2: {
 				// version
-				0x10,
+				0x12,
 				// flag: map data
 				0x08,
 				// next slab id
@@ -2789,8 +2789,6 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x10,
 				// flag: has pointer + map data
 				0x48,
-				// next slab id
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 				// the following encoded data is valid CBOR
 
@@ -2864,7 +2862,8 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, 2, len(meta.childrenHeaders))
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
-		require.Equal(t, uint32(len(stored[id3])), meta.childrenHeaders[1].size)
+		// Need to add slabIDSize to encoded data slab here because empty slab ID is omitted during encoding.
+		require.Equal(t, uint32(len(stored[id3])+slabIDSize), meta.childrenHeaders[1].size)
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -3392,8 +3391,6 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x10,
 				// flag: any size + collision group
 				0x2b,
-				// next slab id
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 				// the following encoded data is valid CBOR
 
@@ -3457,8 +3454,6 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x10,
 				// flag: any size + collision group
 				0x2b,
-				// next slab id
-				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 
 				// the following encoded data is valid CBOR
 


### PR DESCRIPTION
Updates #292 

Changes:

Currently, we omit empty next slab ID in encoded root data slabs because next slab ID is always empty in root data slabs.

However, next slab ID is also empty for non-root data slabs if the non-root data slab is the last data slab.

This commit sets hasNextSlabID flag during encoding and only encodes non-empty next slab ID for map data slab.

This change saves 16 bytes for the last non-root data slabs.  Also, we don't special case the omission of next slab ID in root slabs.

NOTE: omission of empty next slab ID doesn't affect slab size computation which is used for slab operations, such as splitting and merging.  This commit is a size optimization during slab encoding.


<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
