### PR TITLE
Add readonly iterators and support value mutations only from non-readonly iterators

### DIFF
--- a/array.go
+++ b/array.go
@@ -3117,6 +3117,7 @@ type ArrayIterator struct {
 	dataSlab       *ArrayDataSlab
 	index          int
 	remainingCount int
+	readOnly       bool
 }
 
 func (i *ArrayIterator) Next() (Value, error) {
@@ -3179,6 +3180,19 @@ func (a *Array) Iterator() (*ArrayIterator, error) {
 	}, nil
 }
 
+// ReadOnlyIterator returns readonly iterator for array elements.
+// If elements of child containers are mutated, those changes
+// are not guaranteed to persist.
+func (a *Array) ReadOnlyIterator() (*ArrayIterator, error) {
+	iterator, err := a.Iterator()
+	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by Iterator().
+		return nil, err
+	}
+	iterator.readOnly = true
+	return iterator, nil
+}
+
 func (a *Array) RangeIterator(startIndex uint64, endIndex uint64) (*ArrayIterator, error) {
 	count := a.Count()
 
@@ -3229,63 +3243,74 @@ func (a *Array) RangeIterator(startIndex uint64, endIndex uint64) (*ArrayIterato
 	}, nil
 }
 
+func (a *Array) ReadOnlyRangeIterator(startIndex uint64, endIndex uint64) (*ArrayIterator, error) {
+	iterator, err := a.RangeIterator(startIndex, endIndex)
+	if err != nil {
+		return nil, err
+	}
+	iterator.readOnly = true
+	return iterator, nil
+}
+
 type ArrayIterationFunc func(element Value) (resume bool, err error)
 
-func (a *Array) Iterate(fn ArrayIterationFunc) error {
+func iterate(iterator *ArrayIterator, fn ArrayIterationFunc) error {
+	for {
+		value, err := iterator.Next()
+		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by ArrayIterator.Next().
+			return err
+		}
+		if value == nil {
+			return nil
+		}
+		resume, err := fn(value)
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by ArrayIterationFunc callback.
+			return wrapErrorAsExternalErrorIfNeeded(err)
+		}
+		if !resume {
+			return nil
+		}
+	}
+}
 
+func (a *Array) Iterate(fn ArrayIterationFunc) error {
 	iterator, err := a.Iterator()
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Array.Iterator().
 		return err
 	}
+	return iterate(iterator, fn)
+}
 
-	for {
-		value, err := iterator.Next()
-		if err != nil {
-			// Don't need to wrap error as external error because err is already categorized by ArrayIterator.Next().
-			return err
-		}
-		if value == nil {
-			return nil
-		}
-		resume, err := fn(value)
-		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by ArrayIterationFunc callback.
-			return wrapErrorAsExternalErrorIfNeeded(err)
-		}
-		if !resume {
-			return nil
-		}
+func (a *Array) IterateReadOnly(fn ArrayIterationFunc) error {
+	iterator, err := a.ReadOnlyIterator()
+	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by Array.ReadOnlyIterator().
+		return err
 	}
+	return iterate(iterator, fn)
 }
 
 func (a *Array) IterateRange(startIndex uint64, endIndex uint64, fn ArrayIterationFunc) error {
-
 	iterator, err := a.RangeIterator(startIndex, endIndex)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Array.RangeIterator().
 		return err
 	}
-
-	for {
-		value, err := iterator.Next()
-		if err != nil {
-			// Don't need to wrap error as external error because err is already categorized by ArrayIterator.Next().
-			return err
-		}
-		if value == nil {
-			return nil
-		}
-		resume, err := fn(value)
-		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by ArrayIterationFunc callback.
-			return wrapErrorAsExternalErrorIfNeeded(err)
-		}
-		if !resume {
-			return nil
-		}
-	}
+	return iterate(iterator, fn)
 }
+
+func (a *Array) IterateReadOnlyRange(startIndex uint64, endIndex uint64, fn ArrayIterationFunc) error {
+	iterator, err := a.ReadOnlyRangeIterator(startIndex, endIndex)
+	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by Array.ReadOnlyRangeIterator().
+		return err
+	}
+	return iterate(iterator, fn)
+}
+
 func (a *Array) Count() uint64 {
 	return uint64(a.root.Header().count)
 }
@@ -3309,7 +3334,7 @@ func (a *Array) Type() TypeInfo {
 }
 
 func (a *Array) String() string {
-	iterator, err := a.Iterator()
+	iterator, err := a.ReadOnlyIterator()
 	if err != nil {
 		return err.Error()
 	}
@@ -3793,8 +3818,8 @@ func (i *ArrayLoadedValueIterator) Next() (Value, error) {
 	return nil, nil
 }
 
-// LoadedValueIterator returns iterator to iterate loaded array elements.
-func (a *Array) LoadedValueIterator() (*ArrayLoadedValueIterator, error) {
+// ReadOnlyLoadedValueIterator returns iterator to iterate loaded array elements.
+func (a *Array) ReadOnlyLoadedValueIterator() (*ArrayLoadedValueIterator, error) {
 	switch slab := a.root.(type) {
 
 	case *ArrayDataSlab:
@@ -3832,9 +3857,9 @@ func (a *Array) LoadedValueIterator() (*ArrayLoadedValueIterator, error) {
 	}
 }
 
-// IterateLoadedValues iterates loaded array values.
-func (a *Array) IterateLoadedValues(fn ArrayIterationFunc) error {
-	iterator, err := a.LoadedValueIterator()
+// IterateReadOnlyLoadedValues iterates loaded array values.
+func (a *Array) IterateReadOnlyLoadedValues(fn ArrayIterationFunc) error {
+	iterator, err := a.ReadOnlyLoadedValueIterator()
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Array.LoadedValueIterator().
 		return err

--- a/array.go
+++ b/array.go
@@ -3359,6 +3359,10 @@ type ArrayIterator struct {
 	readOnly        bool
 }
 
+func (i *ArrayIterator) CanMutate() bool {
+	return !i.readOnly
+}
+
 func (i *ArrayIterator) Next() (Value, error) {
 	if i.remainingCount == 0 {
 		return nil, nil
@@ -3391,7 +3395,7 @@ func (i *ArrayIterator) Next() (Value, error) {
 			return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get storable's stored value")
 		}
 
-		if !i.readOnly {
+		if i.CanMutate() {
 			// Set up notification callback in child value so
 			// when child value is modified parent a is notified.
 			i.array.setCallbackWithChild(uint64(i.indexInArray), element, maxInlineArrayElementSize)

--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -355,7 +355,7 @@ func benchmarkNewArrayFromAppend(b *testing.B, initialArraySize int) {
 	for i := 0; i < b.N; i++ {
 		copied, _ := NewArray(storage, array.Address(), array.Type())
 
-		_ = array.Iterate(func(value Value) (bool, error) {
+		_ = array.IterateReadOnly(func(value Value) (bool, error) {
 			_ = copied.Append(value)
 			return true, nil
 		})
@@ -379,7 +379,7 @@ func benchmarkNewArrayFromBatchData(b *testing.B, initialArraySize int) {
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(b, err)
 
 		copied, _ := NewArrayFromBatchData(storage, array.Address(), array.Type(), func() (Value, error) {

--- a/array_test.go
+++ b/array_test.go
@@ -100,7 +100,7 @@ func _verifyArray(
 
 	// Verify array elements by iterator
 	i := 0
-	err = array.Iterate(func(v Value) (bool, error) {
+	err = array.IterateReadOnly(func(v Value) (bool, error) {
 		valueEqual(t, expectedValues[i], v)
 		i++
 		return true, nil
@@ -679,7 +679,7 @@ func TestArrayIterate(t *testing.T) {
 		require.NoError(t, err)
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -706,7 +706,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(i), v)
 			i++
 			return true, nil
@@ -743,7 +743,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(i), v)
 			i++
 			return true, nil
@@ -776,7 +776,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := uint64(0)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(i), v)
 			i++
 			return true, nil
@@ -812,7 +812,7 @@ func TestArrayIterate(t *testing.T) {
 
 		i := uint64(0)
 		j := uint64(1)
-		err = array.Iterate(func(v Value) (bool, error) {
+		err = array.IterateReadOnly(func(v Value) (bool, error) {
 			require.Equal(t, Uint64Value(j), v)
 			i++
 			j += 2
@@ -838,7 +838,7 @@ func TestArrayIterate(t *testing.T) {
 		}
 
 		i := 0
-		err = array.Iterate(func(_ Value) (bool, error) {
+		err = array.IterateReadOnly(func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, nil
 			}
@@ -867,7 +867,7 @@ func TestArrayIterate(t *testing.T) {
 		testErr := errors.New("test")
 
 		i := 0
-		err = array.Iterate(func(_ Value) (bool, error) {
+		err = array.IterateReadOnly(func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, testErr
 			}
@@ -893,7 +893,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 	count := array.Count()
 
 	// If startIndex > count, IterateRange returns SliceOutOfBoundsError
-	err = array.IterateRange(count+1, count+1, func(v Value) (bool, error) {
+	err = array.IterateReadOnlyRange(count+1, count+1, func(v Value) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -906,7 +906,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 	require.Equal(t, uint64(0), i)
 
 	// If endIndex > count, IterateRange returns SliceOutOfBoundsError
-	err = array.IterateRange(0, count+1, func(v Value) (bool, error) {
+	err = array.IterateReadOnlyRange(0, count+1, func(v Value) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -918,7 +918,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 
 	// If startIndex > endIndex, IterateRange returns InvalidSliceIndexError
 	if count > 0 {
-		err = array.IterateRange(1, 0, func(v Value) (bool, error) {
+		err = array.IterateReadOnlyRange(1, 0, func(v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -933,7 +933,7 @@ func testArrayIterateRange(t *testing.T, array *Array, values []Value) {
 	for startIndex := uint64(0); startIndex <= count; startIndex++ {
 		for endIndex := startIndex; endIndex <= count; endIndex++ {
 			i = uint64(0)
-			err = array.IterateRange(startIndex, endIndex, func(v Value) (bool, error) {
+			err = array.IterateReadOnlyRange(startIndex, endIndex, func(v Value) (bool, error) {
 				valueEqual(t, v, values[int(startIndex+i)])
 				i++
 				return true, nil
@@ -1015,7 +1015,7 @@ func TestArrayIterateRange(t *testing.T) {
 		startIndex := uint64(1)
 		endIndex := uint64(5)
 		count := endIndex - startIndex
-		err = array.IterateRange(startIndex, endIndex, func(_ Value) (bool, error) {
+		err = array.IterateReadOnlyRange(startIndex, endIndex, func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, nil
 			}
@@ -1044,7 +1044,7 @@ func TestArrayIterateRange(t *testing.T) {
 		startIndex := uint64(1)
 		endIndex := uint64(5)
 		count := endIndex - startIndex
-		err = array.IterateRange(startIndex, endIndex, func(_ Value) (bool, error) {
+		err = array.IterateReadOnlyRange(startIndex, endIndex, func(_ Value) (bool, error) {
 			if i == count/2 {
 				return false, testErr
 			}
@@ -3059,7 +3059,7 @@ func TestEmptyArray(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		i := uint64(0)
-		err := array.Iterate(func(v Value) (bool, error) {
+		err := array.IterateReadOnly(func(v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -3301,7 +3301,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		// Create a new array with new storage, new address, and original array's elements.
@@ -3341,7 +3341,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		// Create a new array with new storage, new address, and original array's elements.
@@ -3385,7 +3385,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		address := Address{2, 3, 4, 5, 6, 7, 8, 9}
@@ -3435,7 +3435,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(36), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -3485,7 +3485,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(36), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -3531,7 +3531,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -3586,7 +3586,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		iter, err := array.Iterator()
+		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -3942,7 +3942,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		verifyArrayLoadedElements(t, array, values)
 
 		i := 0
-		err := array.IterateLoadedValues(func(v Value) (bool, error) {
+		err := array.IterateReadOnlyLoadedValues(func(v Value) (bool, error) {
 			// At this point, iterator returned first element (v).
 
 			// Remove all other nested composite elements (except first element) from storage.
@@ -4627,7 +4627,7 @@ func createArrayWithSimpleAndChildArrayValues(
 
 func verifyArrayLoadedElements(t *testing.T, array *Array, expectedValues []Value) {
 	i := 0
-	err := array.IterateLoadedValues(func(v Value) (bool, error) {
+	err := array.IterateReadOnlyLoadedValues(func(v Value) (bool, error) {
 		require.True(t, i < len(expectedValues))
 		valueEqual(t, expectedValues[i], v)
 		i++

--- a/cmd/stress/utils.go
+++ b/cmd/stress/utils.go
@@ -132,7 +132,7 @@ func copyValue(storage *atree.PersistentSlabStorage, address atree.Address, valu
 }
 
 func copyArray(storage *atree.PersistentSlabStorage, address atree.Address, array *atree.Array) (*atree.Array, error) {
-	iterator, err := array.Iterator()
+	iterator, err := array.ReadOnlyIterator()
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func copyArray(storage *atree.PersistentSlabStorage, address atree.Address, arra
 }
 
 func copyMap(storage *atree.PersistentSlabStorage, address atree.Address, m *atree.OrderedMap) (*atree.OrderedMap, error) {
-	iterator, err := m.Iterator()
+	iterator, err := m.ReadOnlyIterator()
 	if err != nil {
 		return nil, err
 	}
@@ -260,12 +260,12 @@ func arrayEqual(a atree.Value, b atree.Value) error {
 		return fmt.Errorf("array %s count %d != array %s count %d", array1, array1.Count(), array2, array2.Count())
 	}
 
-	iterator1, err := array1.Iterator()
+	iterator1, err := array1.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get array1 iterator: %w", err)
 	}
 
-	iterator2, err := array2.Iterator()
+	iterator2, err := array2.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get array2 iterator: %w", err)
 	}
@@ -309,12 +309,12 @@ func mapEqual(a atree.Value, b atree.Value) error {
 		return fmt.Errorf("map %s count %d != map %s count %d", m1, m1.Count(), m2, m2.Count())
 	}
 
-	iterator1, err := m1.Iterator()
+	iterator1, err := m1.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get m1 iterator: %w", err)
 	}
 
-	iterator2, err := m2.Iterator()
+	iterator2, err := m2.ReadOnlyIterator()
 	if err != nil {
 		return fmt.Errorf("failed to get m2 iterator: %w", err)
 	}

--- a/map_test.go
+++ b/map_test.go
@@ -167,7 +167,7 @@ func _verifyMap(
 		require.Equal(t, len(expectedKeyValues), len(sortedKeys))
 
 		i := 0
-		err = m.Iterate(func(k, v Value) (bool, error) {
+		err = m.IterateReadOnly(func(k, v Value) (bool, error) {
 			expectedKey := sortedKeys[i]
 			expectedValue := expectedKeyValues[expectedKey]
 
@@ -1123,7 +1123,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate key value pairs
 		i = uint64(0)
-		err = m.Iterate(func(k Value, v Value) (resume bool, err error) {
+		err = m.IterateReadOnly(func(k Value, v Value) (resume bool, err error) {
 			valueEqual(t, sortedKeys[i], k)
 			valueEqual(t, keyValues[k], v)
 			i++
@@ -1135,7 +1135,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate keys
 		i = uint64(0)
-		err = m.IterateKeys(func(k Value) (resume bool, err error) {
+		err = m.IterateReadOnlyKeys(func(k Value) (resume bool, err error) {
 			valueEqual(t, sortedKeys[i], k)
 			i++
 			return true, nil
@@ -1146,7 +1146,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate values
 		i = uint64(0)
-		err = m.IterateValues(func(v Value) (resume bool, err error) {
+		err = m.IterateReadOnlyValues(func(v Value) (resume bool, err error) {
 			k := sortedKeys[i]
 			valueEqual(t, keyValues[k], v)
 			i++
@@ -1209,7 +1209,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate key value pairs
 		i := uint64(0)
-		err = m.Iterate(func(k Value, v Value) (resume bool, err error) {
+		err = m.IterateReadOnly(func(k Value, v Value) (resume bool, err error) {
 			valueEqual(t, sortedKeys[i], k)
 			valueEqual(t, keyValues[k], v)
 			i++
@@ -1222,7 +1222,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate keys
 		i = uint64(0)
-		err = m.IterateKeys(func(k Value) (resume bool, err error) {
+		err = m.IterateReadOnlyKeys(func(k Value) (resume bool, err error) {
 			valueEqual(t, sortedKeys[i], k)
 			i++
 			return true, nil
@@ -1234,7 +1234,7 @@ func TestMapIterate(t *testing.T) {
 
 		// Iterate values
 		i = uint64(0)
-		err = m.IterateValues(func(v Value) (resume bool, err error) {
+		err = m.IterateReadOnlyValues(func(v Value) (resume bool, err error) {
 			valueEqual(t, keyValues[sortedKeys[i]], v)
 			i++
 			return true, nil
@@ -7895,7 +7895,7 @@ func TestEmptyMap(t *testing.T) {
 
 	t.Run("iterate", func(t *testing.T) {
 		i := 0
-		err := m.Iterate(func(k Value, v Value) (bool, error) {
+		err := m.IterateReadOnly(func(k Value, v Value) (bool, error) {
 			i++
 			return true, nil
 		})
@@ -7933,7 +7933,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -7980,7 +7980,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -8042,7 +8042,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -8107,7 +8107,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize+1), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -8176,7 +8176,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.Equal(t, uint64(mapSize+1), m.Count())
 		require.Equal(t, typeInfo, m.Type())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -8239,7 +8239,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		storage := newTestPersistentStorage(t)
@@ -8320,7 +8320,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -8404,7 +8404,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, storable)
 
-		iter, err := m.Iterator()
+		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
 
 		var sortedKeys []Value
@@ -9637,7 +9637,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		verifyMapLoadedElements(t, m, values)
 
 		i := 0
-		err := m.IterateLoadedValues(func(k Value, v Value) (bool, error) {
+		err := m.IterateReadOnlyLoadedValues(func(k Value, v Value) (bool, error) {
 			// At this point, iterator returned first element (v).
 
 			// Remove all other nested composite elements (except first element) from storage.
@@ -10541,7 +10541,7 @@ func createMapWithSimpleAndChildArrayValues(
 
 func verifyMapLoadedElements(t *testing.T, m *OrderedMap, expectedValues [][2]Value) {
 	i := 0
-	err := m.IterateLoadedValues(func(k Value, v Value) (bool, error) {
+	err := m.IterateReadOnlyLoadedValues(func(k Value, v Value) (bool, error) {
 		require.True(t, i < len(expectedValues))
 		valueEqual(t, expectedValues[i][0], k)
 		valueEqual(t, expectedValues[i][1], v)
@@ -12814,7 +12814,7 @@ func getInlinedChildMapsFromParentMap(t *testing.T, address Address, parentMap *
 
 	children := make(map[Value]*mapInfo)
 
-	err := parentMap.IterateKeys(func(k Value) (bool, error) {
+	err := parentMap.IterateReadOnlyKeys(func(k Value) (bool, error) {
 		if k == nil {
 			return false, nil
 		}

--- a/utils_test.go
+++ b/utils_test.go
@@ -342,7 +342,7 @@ func valueEqual(t *testing.T, expected Value, actual Value) {
 func arrayEqual(t *testing.T, expected arrayValue, actual *Array) {
 	require.Equal(t, uint64(len(expected)), actual.Count())
 
-	iterator, err := actual.Iterator()
+	iterator, err := actual.ReadOnlyIterator()
 	require.NoError(t, err)
 
 	i := 0
@@ -363,7 +363,7 @@ func arrayEqual(t *testing.T, expected arrayValue, actual *Array) {
 func mapEqual(t *testing.T, expected mapValue, actual *OrderedMap) {
 	require.Equal(t, uint64(len(expected)), actual.Count())
 
-	iterator, err := actual.Iterator()
+	iterator, err := actual.ReadOnlyIterator()
 	require.NoError(t, err)
 
 	i := 0


### PR DESCRIPTION
Updates #292 

Changes:
- Adds readonly iterators that match current iterator API (except for the "ReadOnly" suffix added to some function names).
- Refactors API of non-readonly iterators because register inlining will require more parameters for MapIterator.
- Support mutations of values returned from non-readonly iterators

For readonly iterators, the caller is responsible for preventing changes to child containers during iteration because mutations of child containers are not guaranteed to persist.

For non-readonly iterators, two additional parameters are needed to update child container in parent map when child container is modified.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
