### PR TITLE
Make smoke tests check recently added data deduplication feature

### DIFF
--- a/cmd/stress/typeinfo.go
+++ b/cmd/stress/typeinfo.go
@@ -53,7 +53,7 @@ func (i arrayTypeInfo) IsComposite() bool {
 	return false
 }
 
-func (i arrayTypeInfo) ID() string {
+func (i arrayTypeInfo) Identifier() string {
 	return fmt.Sprintf("array(%d)", i)
 }
 
@@ -88,7 +88,7 @@ func (i mapTypeInfo) IsComposite() bool {
 	return false
 }
 
-func (i mapTypeInfo) ID() string {
+func (i mapTypeInfo) Identifier() string {
 	return fmt.Sprintf("map(%d)", i)
 }
 
@@ -153,7 +153,7 @@ func (i compositeTypeInfo) IsComposite() bool {
 	return true
 }
 
-func (i compositeTypeInfo) ID() string {
+func (i compositeTypeInfo) Identifier() string {
 	return fmt.Sprintf("composite(%d_%d)", i.fieldStartIndex, i.fieldEndIndex)
 }
 

--- a/cmd/stress/utils.go
+++ b/cmd/stress/utils.go
@@ -47,6 +47,7 @@ const (
 const (
 	arrayType int = iota
 	mapType
+	compositeType
 	maxContainerValueType
 )
 
@@ -122,6 +123,9 @@ func generateContainerValue(
 	case mapType:
 		length := r.Intn(maxNestedMapSize)
 		return newMap(storage, address, length, nestedLevels)
+
+	case compositeType:
+		return newComposite(storage, address, nestedLevels)
 
 	default:
 		return nil, nil, fmt.Errorf("unexpected randome container value type %d", valueType)
@@ -374,6 +378,50 @@ func newMap(
 			if err != nil {
 				return nil, nil, fmt.Errorf("failed to remove storable element %s: %w", existingStorable, err)
 			}
+		}
+	}
+
+	err = checkMapDataLoss(expectedValues, m)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return expectedValues, m, nil
+}
+
+// newComposite creates atree.OrderedMap with elements of random composite type and nested level
+func newComposite(
+	storage atree.SlabStorage,
+	address atree.Address,
+	nestedLevel int,
+) (mapValue, *atree.OrderedMap, error) {
+
+	compositeType := newCompositeTypeInfo()
+
+	m, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), compositeType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create new map: %w", err)
+	}
+
+	expectedValues := make(mapValue)
+
+	for _, name := range compositeType.getFieldNames() {
+
+		expectedKey, key := NewStringValue(name), NewStringValue(name)
+
+		expectedValue, value, err := randomValue(storage, address, nestedLevel-1)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		expectedValues[expectedKey] = expectedValue
+
+		existingStorable, err := m.Set(compare, hashInputProvider, key, value)
+		if err != nil {
+			return nil, nil, err
+		}
+		if existingStorable != nil {
+			return nil, nil, fmt.Errorf("failed to create new map of composite type: found duplicate field name %s", name)
 		}
 	}
 

--- a/cmd/stress/utils.go
+++ b/cmd/stress/utils.go
@@ -540,5 +540,5 @@ func (v mapValue) Storable(atree.SlabStorage, atree.Address, uint64) (atree.Stor
 }
 
 var typeInfoComparator = func(a atree.TypeInfo, b atree.TypeInfo) bool {
-	return a.ID() == b.ID()
+	return a.Identifier() == b.Identifier()
 }

--- a/map_debug.go
+++ b/map_debug.go
@@ -1351,8 +1351,18 @@ func mapExtraDataEqual(expected, actual *MapExtraData) error {
 		return NewFatalError(fmt.Errorf("has extra data is %t, want %t", actual == nil, expected == nil))
 	}
 
-	if !reflect.DeepEqual(*expected, *actual) {
-		return NewFatalError(fmt.Errorf("extra data %+v is wrong, want %+v", *actual, *expected))
+	if !reflect.DeepEqual(expected.TypeInfo, actual.TypeInfo) {
+		return NewFatalError(fmt.Errorf("map extra data type %+v is wrong, want %+v", actual.TypeInfo, expected.TypeInfo))
+	}
+
+	if expected.Count != actual.Count {
+		return NewFatalError(fmt.Errorf("map extra data count %d is wrong, want %d", actual.Count, expected.Count))
+	}
+
+	if !expected.TypeInfo.IsComposite() {
+		if expected.Seed != actual.Seed {
+			return NewFatalError(fmt.Errorf("map extra data seed %d is wrong, want %d", actual.Seed, expected.Seed))
+		}
 	}
 
 	return nil

--- a/map_debug.go
+++ b/map_debug.go
@@ -470,8 +470,16 @@ func (v *mapVerifier) verifyDataSlab(
 	}
 
 	// Verify that only root slab can be inlined
-	if level > 0 && dataSlab.Inlined() {
-		return 0, nil, nil, nil, NewFatalError(fmt.Errorf("non-root slab %s is inlined", id))
+	if dataSlab.Inlined() {
+		if level > 0 {
+			return 0, nil, nil, nil, NewFatalError(fmt.Errorf("non-root slab %s is inlined", id))
+		}
+		if dataSlab.extraData == nil {
+			return 0, nil, nil, nil, NewFatalError(fmt.Errorf("inlined slab %s doesn't have extra data", id))
+		}
+		if dataSlab.next != SlabIDUndefined {
+			return 0, nil, nil, nil, NewFatalError(fmt.Errorf("inlined slab %s has next slab ID", id))
+		}
 	}
 
 	// Verify that aggregated element size + slab prefix is the same as header.size
@@ -846,12 +854,6 @@ func (v *mapVerifier) verifySingleElement(
 		return 0, 0, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("element %s key can't be converted to value", e))
 	}
 
-	switch e.key.(type) {
-	case *ArrayDataSlab, *MapDataSlab:
-		// Verify key can't be inlined array or map
-		return 0, 0, NewFatalError(fmt.Errorf("element %s key shouldn't be inlined array or map", e))
-	}
-
 	err = verifyValue(kv, v.address, nil, v.tic, v.hip, v.inlineEnabled, slabIDs)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by verifyValue().
@@ -942,6 +944,11 @@ func VerifyMapSerialization(
 	decodeTypeInfo TypeInfoDecoder,
 	compare StorableComparator,
 ) error {
+	// Skip verification of inlined map serialization.
+	if m.Inlined() {
+		return nil
+	}
+
 	v := &serializationVerifier{
 		storage:        m.Storage,
 		cborDecMode:    cborDecMode,
@@ -958,7 +965,7 @@ func (v *serializationVerifier) verifyMapSlab(slab MapSlab) error {
 	id := slab.SlabID()
 
 	// Encode slab
-	data, err := Encode(slab, v.cborEncMode)
+	data, err := EncodeSlab(slab, v.cborEncMode)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Encode().
 		return err
@@ -972,7 +979,7 @@ func (v *serializationVerifier) verifyMapSlab(slab MapSlab) error {
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, v.cborEncMode)
+	dataFromDecodedSlab, err := EncodeSlab(decodedSlab, v.cborEncMode)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Encode().
 		return err
@@ -1065,8 +1072,10 @@ func (v *serializationVerifier) verifyMapSlab(slab MapSlab) error {
 
 func (v *serializationVerifier) mapDataSlabEqual(expected, actual *MapDataSlab) error {
 
+	_, _, _, actualDecodedFromCompactMap := expected.canBeEncodedAsCompactMap()
+
 	// Compare extra data
-	err := mapExtraDataEqual(expected.extraData, actual.extraData)
+	err := mapExtraDataEqual(expected.extraData, actual.extraData, actualDecodedFromCompactMap)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by mapExtraDataEqual().
 		return err
@@ -1093,12 +1102,19 @@ func (v *serializationVerifier) mapDataSlabEqual(expected, actual *MapDataSlab) 
 	}
 
 	// Compare header
-	if !reflect.DeepEqual(expected.header, actual.header) {
+	if actualDecodedFromCompactMap {
+		if expected.header.slabID != actual.header.slabID {
+			return NewFatalError(fmt.Errorf("header.slabID %s is wrong, want %s", actual.header.slabID, expected.header.slabID))
+		}
+		if expected.header.size != actual.header.size {
+			return NewFatalError(fmt.Errorf("header.size %d is wrong, want %d", actual.header.size, expected.header.size))
+		}
+	} else if !reflect.DeepEqual(expected.header, actual.header) {
 		return NewFatalError(fmt.Errorf("header %+v is wrong, want %+v", actual.header, expected.header))
 	}
 
 	// Compare elements
-	err = v.mapElementsEqual(expected.elements, actual.elements)
+	err = v.mapElementsEqual(expected.elements, actual.elements, actualDecodedFromCompactMap)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by mapElementsEqual().
 		return err
@@ -1107,7 +1123,7 @@ func (v *serializationVerifier) mapDataSlabEqual(expected, actual *MapDataSlab) 
 	return nil
 }
 
-func (v *serializationVerifier) mapElementsEqual(expected, actual elements) error {
+func (v *serializationVerifier) mapElementsEqual(expected, actual elements, actualDecodedFromCompactMap bool) error {
 	switch expectedElems := expected.(type) {
 
 	case *hkeyElements:
@@ -1115,7 +1131,7 @@ func (v *serializationVerifier) mapElementsEqual(expected, actual elements) erro
 		if !ok {
 			return NewFatalError(fmt.Errorf("elements type %T is wrong, want %T", actual, expected))
 		}
-		return v.mapHkeyElementsEqual(expectedElems, actualElems)
+		return v.mapHkeyElementsEqual(expectedElems, actualElems, actualDecodedFromCompactMap)
 
 	case *singleElements:
 		actualElems, ok := actual.(*singleElements)
@@ -1129,7 +1145,7 @@ func (v *serializationVerifier) mapElementsEqual(expected, actual elements) erro
 	return nil
 }
 
-func (v *serializationVerifier) mapHkeyElementsEqual(expected, actual *hkeyElements) error {
+func (v *serializationVerifier) mapHkeyElementsEqual(expected, actual *hkeyElements, actualDecodedFromCompactMap bool) error {
 
 	if expected.level != actual.level {
 		return NewFatalError(fmt.Errorf("hkeyElements level %d is wrong, want %d", actual.level, expected.level))
@@ -1139,12 +1155,12 @@ func (v *serializationVerifier) mapHkeyElementsEqual(expected, actual *hkeyEleme
 		return NewFatalError(fmt.Errorf("hkeyElements size %d is wrong, want %d", actual.size, expected.size))
 	}
 
-	if len(expected.hkeys) == 0 {
-		if len(actual.hkeys) != 0 {
-			return NewFatalError(fmt.Errorf("hkeyElements hkeys %v is wrong, want %v", actual.hkeys, expected.hkeys))
-		}
-	} else {
-		if !reflect.DeepEqual(expected.hkeys, actual.hkeys) {
+	if len(expected.hkeys) != len(actual.hkeys) {
+		return NewFatalError(fmt.Errorf("hkeyElements hkeys len %d is wrong, want %d", len(actual.hkeys), len(expected.hkeys)))
+	}
+
+	if !actualDecodedFromCompactMap {
+		if len(expected.hkeys) > 0 && !reflect.DeepEqual(expected.hkeys, actual.hkeys) {
 			return NewFatalError(fmt.Errorf("hkeyElements hkeys %v is wrong, want %v", actual.hkeys, expected.hkeys))
 		}
 	}
@@ -1153,14 +1169,30 @@ func (v *serializationVerifier) mapHkeyElementsEqual(expected, actual *hkeyEleme
 		return NewFatalError(fmt.Errorf("hkeyElements elems len %d is wrong, want %d", len(actual.elems), len(expected.elems)))
 	}
 
-	for i := 0; i < len(expected.elems); i++ {
-		expectedEle := expected.elems[i]
-		actualEle := actual.elems[i]
+	if actualDecodedFromCompactMap {
+		for _, expectedEle := range expected.elems {
+			found := false
+			for _, actualEle := range actual.elems {
+				err := v.mapElementEqual(expectedEle, actualEle, actualDecodedFromCompactMap)
+				if err == nil {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return NewFatalError(fmt.Errorf("hkeyElements elem %v is not found", expectedEle))
+			}
+		}
+	} else {
+		for i := 0; i < len(expected.elems); i++ {
+			expectedEle := expected.elems[i]
+			actualEle := actual.elems[i]
 
-		err := v.mapElementEqual(expectedEle, actualEle)
-		if err != nil {
-			// Don't need to wrap error as external error because err is already categorized by mapElementEqual().
-			return err
+			err := v.mapElementEqual(expectedEle, actualEle, actualDecodedFromCompactMap)
+			if err != nil {
+				// Don't need to wrap error as external error because err is already categorized by mapElementEqual().
+				return err
+			}
 		}
 	}
 
@@ -1195,7 +1227,7 @@ func (v *serializationVerifier) mapSingleElementsEqual(expected, actual *singleE
 	return nil
 }
 
-func (v *serializationVerifier) mapElementEqual(expected, actual element) error {
+func (v *serializationVerifier) mapElementEqual(expected, actual element, actualDecodedFromCompactMap bool) error {
 	switch expectedElem := expected.(type) {
 
 	case *singleElement:
@@ -1210,7 +1242,7 @@ func (v *serializationVerifier) mapElementEqual(expected, actual element) error 
 		if !ok {
 			return NewFatalError(fmt.Errorf("elements type %T is wrong, want %T", actual, expected))
 		}
-		return v.mapElementsEqual(expectedElem.elements, actualElem.elements)
+		return v.mapElementsEqual(expectedElem.elements, actualElem.elements, actualDecodedFromCompactMap)
 
 	case *externalCollisionGroup:
 		actualElem, ok := actual.(*externalCollisionGroup)
@@ -1322,7 +1354,7 @@ func (v *serializationVerifier) mapSingleElementEqual(expected, actual *singleEl
 func (v *serializationVerifier) mapMetaDataSlabEqual(expected, actual *MapMetaDataSlab) error {
 
 	// Compare extra data
-	err := mapExtraDataEqual(expected.extraData, actual.extraData)
+	err := mapExtraDataEqual(expected.extraData, actual.extraData, false)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by mapExtraDataEqual().
 		return err
@@ -1341,7 +1373,7 @@ func (v *serializationVerifier) mapMetaDataSlabEqual(expected, actual *MapMetaDa
 	return nil
 }
 
-func mapExtraDataEqual(expected, actual *MapExtraData) error {
+func mapExtraDataEqual(expected, actual *MapExtraData, actualDecodedFromCompactMap bool) error {
 
 	if (expected == nil) && (actual == nil) {
 		return nil
@@ -1359,7 +1391,7 @@ func mapExtraDataEqual(expected, actual *MapExtraData) error {
 		return NewFatalError(fmt.Errorf("map extra data count %d is wrong, want %d", actual.Count, expected.Count))
 	}
 
-	if !expected.TypeInfo.IsComposite() {
+	if !actualDecodedFromCompactMap {
 		if expected.Seed != actual.Seed {
 			return NewFatalError(fmt.Errorf("map extra data seed %d is wrong, want %d", actual.Seed, expected.Seed))
 		}

--- a/storable_test.go
+++ b/storable_test.go
@@ -698,11 +698,11 @@ type SomeStorable struct {
 	Storable Storable
 }
 
-var _ Storable = SomeStorable{}
+var _ ContainerStorable = SomeStorable{}
 
-func (v SomeStorable) hasPointer() bool {
-	if ms, ok := v.Storable.(containerStorable); ok {
-		return ms.hasPointer()
+func (v SomeStorable) HasPointer() bool {
+	if ms, ok := v.Storable.(ContainerStorable); ok {
+		return ms.HasPointer()
 	}
 	return false
 }
@@ -721,6 +721,17 @@ func (v SomeStorable) Encode(enc *Encoder) error {
 		return err
 	}
 	return v.Storable.Encode(enc)
+}
+
+func (v SomeStorable) EncodeAsElement(enc *Encoder, inlinedExtraData *InlinedExtraData) error {
+	err := enc.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagSomeValue,
+	})
+	if err != nil {
+		return err
+	}
+	return EncodeStorableAsElement(enc, v.Storable, inlinedExtraData)
 }
 
 func (v SomeStorable) ChildStorables() []Storable {

--- a/storage.go
+++ b/storage.go
@@ -390,7 +390,7 @@ func (s *BasicSlabStorage) SlabIDs() []SlabID {
 func (s *BasicSlabStorage) Encode() (map[SlabID][]byte, error) {
 	m := make(map[SlabID][]byte)
 	for id, slab := range s.Slabs {
-		b, err := Encode(slab, s.cborEncMode)
+		b, err := EncodeSlab(slab, s.cborEncMode)
 		if err != nil {
 			// err is already categorized by Encode().
 			return nil, err
@@ -800,7 +800,7 @@ func (s *PersistentSlabStorage) Commit() error {
 		}
 
 		// serialize
-		data, err := Encode(slab, s.cborEncMode)
+		data, err := EncodeSlab(slab, s.cborEncMode)
 		if err != nil {
 			// err is categorized already by Encode()
 			return err
@@ -879,7 +879,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 				continue
 			}
 			// serialize
-			data, err := Encode(slab, s.cborEncMode)
+			data, err := EncodeSlab(slab, s.cborEncMode)
 			results <- &encodedSlabs{
 				slabID: id,
 				data:   data,

--- a/storage_test.go
+++ b/storage_test.go
@@ -749,7 +749,7 @@ func TestPersistentStorage(t *testing.T) {
 				require.NoError(t, err)
 
 				// capture data for accuracy testing
-				simpleMap[slabID], err = Encode(slab, encMode)
+				simpleMap[slabID], err = EncodeSlab(slab, encMode)
 				require.NoError(t, err)
 			}
 		}
@@ -1000,7 +1000,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				break
 			}
 
-			encodedSlab, err := Encode(slab, storage.cborEncMode)
+			encodedSlab, err := EncodeSlab(slab, storage.cborEncMode)
 			require.NoError(t, err)
 
 			require.Equal(t, encodedSlab, data[id])

--- a/utils_test.go
+++ b/utils_test.go
@@ -100,7 +100,7 @@ func (i testTypeInfo) IsComposite() bool {
 	return false
 }
 
-func (i testTypeInfo) ID() string {
+func (i testTypeInfo) Identifier() string {
 	return fmt.Sprintf("uint64(%d)", i)
 }
 
@@ -129,7 +129,7 @@ func (i testCompositeTypeInfo) IsComposite() bool {
 	return true
 }
 
-func (i testCompositeTypeInfo) ID() string {
+func (i testCompositeTypeInfo) Identifier() string {
 	return fmt.Sprintf("composite(%d)", i)
 }
 
@@ -198,6 +198,15 @@ func newTestPersistentStorageWithBaseStorage(t testing.TB, baseStorage BaseStora
 		decodeStorable,
 		decodeTypeInfo,
 	)
+}
+
+func newTestPersistentStorageWithBaseStorageAndDeltas(t testing.TB, baseStorage BaseStorage, data map[SlabID][]byte) *PersistentSlabStorage {
+	storage := newTestPersistentStorageWithBaseStorage(t, baseStorage)
+	for id, b := range data {
+		err := storage.baseStorage.Store(id, b)
+		require.NoError(t, err)
+	}
+	return storage
 }
 
 func newTestBasicStorage(t testing.TB) *BasicSlabStorage {


### PR DESCRIPTION
Closes #349
Updates epic #292 and issue #296

Currently, the data deduplication feature added by PR https://github.com/onflow/atree/pull/342 is not being checked by smoke tests.  We need to smoke test encoding/decoding to the new compact map format (which deduplicates nested Cadence composite types).

This PR adds nested composite types to smoke tests and checks encoding/decoding with the new compact map format to test data deduplication.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
