### PR TITLE
Update for Cadence integration for atree inlining and deduplication

### DIFF
--- a/array.go
+++ b/array.go
@@ -704,7 +704,7 @@ func DecodeInlinedArrayStorable(
 //	+------------------+----------------+----------+
 //	| extra data index | value ID index | elements |
 //	+------------------+----------------+----------+
-func (a *ArrayDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (a *ArrayDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 	if a.extraData == nil {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode non-root array data slab as inlined"))
@@ -886,7 +886,7 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (a *ArrayDataSlab) encodeElements(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (a *ArrayDataSlab) encodeElements(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 	// Encode CBOR array size manually for fix-sized encoding
 
 	enc.Scratch[0] = 0x80 | 25

--- a/array.go
+++ b/array.go
@@ -132,6 +132,7 @@ func (a *ArrayDataSlab) StoredValue(storage SlabStorage) (Value, error) {
 }
 
 var _ ArraySlab = &ArrayDataSlab{}
+var _ ContainerStorable = &ArrayDataSlab{}
 
 // ArrayMetaDataSlab is internal node, implementing ArraySlab.
 type ArrayMetaDataSlab struct {
@@ -697,14 +698,14 @@ func DecodeInlinedArrayStorable(
 	}, nil
 }
 
-// encodeAsInlined encodes inlined array data slab. Encoding is
+// EncodeAsElement encodes inlined array data slab. Encoding is
 // version 1 with CBOR tag having tag number CBORTagInlinedArray,
 // and tag contant as 3-element array:
 //
 //	+------------------+----------------+----------+
 //	| extra data index | value ID index | elements |
 //	+------------------+----------------+----------+
-func (a *ArrayDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (a *ArrayDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 	if a.extraData == nil {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode non-root array data slab as inlined"))

--- a/array.go
+++ b/array.go
@@ -754,7 +754,8 @@ func (a *ArrayDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo *inlinedEx
 	// element 2: array elements
 	err = a.encodeElements(enc, inlinedTypeInfo)
 	if err != nil {
-		return NewEncodingError(err)
+		// err is already categorized by ArrayDataSlab.encodeElements().
+		return err
 	}
 
 	err = enc.CBOR.Flush()
@@ -908,8 +909,8 @@ func (a *ArrayDataSlab) encodeElements(enc *Encoder, inlinedTypeInfo *inlinedExt
 	for _, e := range a.elements {
 		err = encodeStorableAsElement(enc, e, inlinedTypeInfo)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by Storable interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode array element")
+			// err is already categorized by encodeStorableAsElement().
+			return err
 		}
 	}
 

--- a/array.go
+++ b/array.go
@@ -908,7 +908,7 @@ func (a *ArrayDataSlab) encodeElements(enc *Encoder, inlinedTypeInfo InlinedExtr
 
 	// Encode data slab content (array of elements)
 	for _, e := range a.elements {
-		err = encodeStorableAsElement(enc, e, inlinedTypeInfo)
+		err = EncodeStorableAsElement(enc, e, inlinedTypeInfo)
 		if err != nil {
 			// err is already categorized by encodeStorableAsElement().
 			return err

--- a/array.go
+++ b/array.go
@@ -819,7 +819,7 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 		return NewEncodingError(err)
 	}
 
-	if a.hasPointer() {
+	if a.HasPointer() {
 		h.setHasPointers()
 	}
 
@@ -1002,7 +1002,7 @@ func (a *ArrayDataSlab) Uninline(storage SlabStorage) error {
 	return nil
 }
 
-func (a *ArrayDataSlab) hasPointer() bool {
+func (a *ArrayDataSlab) HasPointer() bool {
 	for _, e := range a.elements {
 		if hasPointer(e) {
 			return true

--- a/array.go
+++ b/array.go
@@ -705,7 +705,7 @@ func DecodeInlinedArrayStorable(
 //	+------------------+----------------+----------+
 //	| extra data index | value ID index | elements |
 //	+------------------+----------------+----------+
-func (a *ArrayDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (a *ArrayDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 	if a.extraData == nil {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode non-root array data slab as inlined"))
@@ -887,7 +887,7 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (a *ArrayDataSlab) encodeElements(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (a *ArrayDataSlab) encodeElements(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 	// Encode CBOR array size manually for fix-sized encoding
 
 	enc.Scratch[0] = 0x80 | 25

--- a/array_debug.go
+++ b/array_debug.go
@@ -272,8 +272,12 @@ func (v *arrayVerifier) verifySlab(
 
 	// Verify that inlined slab is not in storage
 	if slab.Inlined() {
-		slab := v.storage.RetrieveIfLoaded(id)
-		if slab != nil {
+		_, exist, err := v.storage.Retrieve(id)
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by Storage interface.
+			return 0, nil, nil, wrapErrorAsExternalErrorIfNeeded(err)
+		}
+		if exist {
 			return 0, nil, nil, NewFatalError(fmt.Errorf("inlined slab %s is in storage", id))
 		}
 	}

--- a/array_debug.go
+++ b/array_debug.go
@@ -550,7 +550,7 @@ func (v *serializationVerifier) verifyArraySlab(slab ArraySlab) error {
 	id := slab.SlabID()
 
 	// Encode slab
-	data, err := Encode(slab, v.cborEncMode)
+	data, err := EncodeSlab(slab, v.cborEncMode)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Encode().
 		return err
@@ -564,7 +564,7 @@ func (v *serializationVerifier) verifyArraySlab(slab ArraySlab) error {
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, v.cborEncMode)
+	dataFromDecodedSlab, err := EncodeSlab(decodedSlab, v.cborEncMode)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Encode().
 		return err

--- a/cmd/stress/typeinfo.go
+++ b/cmd/stress/typeinfo.go
@@ -53,7 +53,7 @@ func (i arrayTypeInfo) IsComposite() bool {
 	return false
 }
 
-func (i arrayTypeInfo) ID() string {
+func (i arrayTypeInfo) Identifier() string {
 	return fmt.Sprintf("array(%d)", i)
 }
 
@@ -88,7 +88,7 @@ func (i mapTypeInfo) IsComposite() bool {
 	return false
 }
 
-func (i mapTypeInfo) ID() string {
+func (i mapTypeInfo) Identifier() string {
 	return fmt.Sprintf("map(%d)", i)
 }
 
@@ -153,7 +153,7 @@ func (i compositeTypeInfo) IsComposite() bool {
 	return true
 }
 
-func (i compositeTypeInfo) ID() string {
+func (i compositeTypeInfo) Identifier() string {
 	return fmt.Sprintf("composite(%d_%d)", i.fieldStartIndex, i.fieldEndIndex)
 }
 

--- a/cmd/stress/utils.go
+++ b/cmd/stress/utils.go
@@ -540,5 +540,5 @@ func (v mapValue) Storable(atree.SlabStorage, atree.Address, uint64) (atree.Stor
 }
 
 var typeInfoComparator = func(a atree.TypeInfo, b atree.TypeInfo) bool {
-	return a.ID() == b.ID()
+	return a.Identifier() == b.Identifier()
 }

--- a/encode.go
+++ b/encode.go
@@ -42,9 +42,9 @@ func NewEncoder(w io.Writer, encMode cbor.EncMode) *Encoder {
 	}
 }
 
-// encodeStorableAsElement encodes storable as Array or OrderedMap element.
+// EncodeStorableAsElement encodes storable as Array or OrderedMap element.
 // Storable is encode as an inlined ArrayDataSlab or MapDataSlab if it is ArrayDataSlab or MapDataSlab.
-func encodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo InlinedExtraData) error {
+func EncodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo InlinedExtraData) error {
 
 	switch storable := storable.(type) {
 

--- a/encode.go
+++ b/encode.go
@@ -48,11 +48,12 @@ func encodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo In
 
 	switch storable := storable.(type) {
 
-	case *ArrayDataSlab:
-		return storable.encodeAsInlined(enc, inlinedTypeInfo)
-
-	case *MapDataSlab:
-		return storable.encodeAsInlined(enc, inlinedTypeInfo)
+	case ContainerStorable:
+		err := storable.EncodeAsElement(enc, inlinedTypeInfo)
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by ContainerStorable interface.
+			return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode container storable as element")
+		}
 
 	default:
 		err := storable.Encode(enc)

--- a/encode.go
+++ b/encode.go
@@ -44,7 +44,7 @@ func NewEncoder(w io.Writer, encMode cbor.EncMode) *Encoder {
 
 // encodeStorableAsElement encodes storable as Array or OrderedMap element.
 // Storable is encode as an inlined ArrayDataSlab or MapDataSlab if it is ArrayDataSlab or MapDataSlab.
-func encodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo *inlinedExtraData) error {
+func encodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo InlinedExtraData) error {
 
 	switch storable := storable.(type) {
 

--- a/encode.go
+++ b/encode.go
@@ -44,7 +44,7 @@ func NewEncoder(w io.Writer, encMode cbor.EncMode) *Encoder {
 
 // EncodeStorableAsElement encodes storable as Array or OrderedMap element.
 // Storable is encode as an inlined ArrayDataSlab or MapDataSlab if it is ArrayDataSlab or MapDataSlab.
-func EncodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo InlinedExtraData) error {
+func EncodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo *InlinedExtraData) error {
 
 	switch storable := storable.(type) {
 

--- a/encode.go
+++ b/encode.go
@@ -58,7 +58,7 @@ func encodeStorableAsElement(enc *Encoder, storable Storable, inlinedTypeInfo *i
 		err := storable.Encode(enc)
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by Storable interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode map value")
+			return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode storable as element")
 		}
 	}
 

--- a/map.go
+++ b/map.go
@@ -148,7 +148,7 @@ type element interface {
 		key Value,
 	) (MapKey, MapValue, element, error)
 
-	Encode(*Encoder, *inlinedExtraData) error
+	Encode(*Encoder, InlinedExtraData) error
 
 	hasPointer() bool
 
@@ -215,7 +215,7 @@ type elements interface {
 
 	Element(int) (element, error)
 
-	Encode(*Encoder, *inlinedExtraData) error
+	Encode(*Encoder, InlinedExtraData) error
 
 	hasPointer() bool
 
@@ -586,7 +586,7 @@ func newSingleElementFromData(cborDec *cbor.StreamDecoder, decodeStorable Storab
 // Encode encodes singleElement to the given encoder.
 //
 //	CBOR encoded array of 2 elements (key, value).
-func (e *singleElement) Encode(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (e *singleElement) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 
 	// Encode CBOR array head for 2 elements
 	err := enc.CBOR.EncodeRawBytes([]byte{0x82})
@@ -763,7 +763,7 @@ func newInlineCollisionGroupFromData(cborDec *cbor.StreamDecoder, decodeStorable
 // Encode encodes inlineCollisionGroup to the given encoder.
 //
 //	CBOR tag (number: CBORTagInlineCollisionGroup, content: elements)
-func (e *inlineCollisionGroup) Encode(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (e *inlineCollisionGroup) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number CBORTagInlineCollisionGroup
@@ -953,7 +953,7 @@ func newExternalCollisionGroupFromData(cborDec *cbor.StreamDecoder, decodeStorab
 // Encode encodes externalCollisionGroup to the given encoder.
 //
 //	CBOR tag (number: CBORTagExternalCollisionGroup, content: slab ID)
-func (e *externalCollisionGroup) Encode(enc *Encoder, _ *inlinedExtraData) error {
+func (e *externalCollisionGroup) Encode(enc *Encoder, _ InlinedExtraData) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number CBORTagExternalCollisionGroup
 		0xd8, CBORTagExternalCollisionGroup,
@@ -1259,7 +1259,7 @@ func newHkeyElementsWithElement(level uint, hkey Digest, elem element) *hkeyElem
 //	    1: hkeys (byte string)
 //	    2: elements (array)
 //	]
-func (e *hkeyElements) Encode(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (e *hkeyElements) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 
 	if e.level > maxDigestLevel {
 		return NewFatalError(fmt.Errorf("hash level %d exceeds max digest level %d", e.level, maxDigestLevel))
@@ -1921,7 +1921,7 @@ func newSingleElementsWithElement(level uint, elem *singleElement) *singleElemen
 //	    1: hkeys (0 length byte string)
 //	    2: elements (array)
 //	]
-func (e *singleElements) Encode(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (e *singleElements) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 
 	if e.level > maxDigestLevel {
 		return NewFatalError(fmt.Errorf("digest level %d exceeds max digest level %d", e.level, maxDigestLevel))
@@ -2777,7 +2777,7 @@ func (m *MapDataSlab) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes *inlinedExtraData) error {
+func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes InlinedExtraData) error {
 	err := m.elements.Encode(enc, inlinedTypes)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by elements.Encode().
@@ -2799,7 +2799,7 @@ func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes *inlinedExtraDat
 //	+------------------+----------------+----------+
 //	| extra data index | value ID index | elements |
 //	+------------------+----------------+----------+
-func (m *MapDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (m *MapDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 	if m.extraData == nil {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode non-root map data slab as inlined"))
@@ -2817,7 +2817,7 @@ func (m *MapDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo *inlinedExtr
 	return m.encodeAsInlinedMap(enc, inlinedTypeInfo)
 }
 
-func (m *MapDataSlab) encodeAsInlinedMap(enc *Encoder, inlinedTypeInfo *inlinedExtraData) error {
+func (m *MapDataSlab) encodeAsInlinedMap(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 
 	extraDataIndex := inlinedTypeInfo.addMapExtraData(m.extraData)
 
@@ -2877,7 +2877,7 @@ func encodeAsInlinedCompactMap(
 	hkeys []Digest,
 	keys []ComparableStorable,
 	values []Storable,
-	inlinedTypeInfo *inlinedExtraData,
+	inlinedTypeInfo InlinedExtraData,
 ) error {
 
 	extraDataIndex, cachedKeys := inlinedTypeInfo.addCompactMapExtraData(extraData, hkeys, keys)
@@ -2941,7 +2941,7 @@ func encodeCompactMapValues(
 	cachedKeys []ComparableStorable,
 	keys []ComparableStorable,
 	values []Storable,
-	inlinedTypeInfo *inlinedExtraData,
+	inlinedTypeInfo InlinedExtraData,
 ) error {
 
 	var err error

--- a/map.go
+++ b/map.go
@@ -2705,7 +2705,7 @@ func (m *MapDataSlab) Encode(enc *Encoder) error {
 		return NewEncodingError(err)
 	}
 
-	if m.hasPointer() {
+	if m.HasPointer() {
 		h.setHasPointers()
 	}
 
@@ -3031,7 +3031,7 @@ func (m *MapDataSlab) canBeEncodedAsCompactMap() ([]Digest, []ComparableStorable
 	return elements.hkeys, keys, values, true
 }
 
-func (m *MapDataSlab) hasPointer() bool {
+func (m *MapDataSlab) HasPointer() bool {
 	return m.elements.hasPointer()
 }
 

--- a/map.go
+++ b/map.go
@@ -2923,7 +2923,8 @@ func encodeAsInlinedCompactMap(
 	// element 2: compact map values in the order of cachedKeys
 	err = encodeCompactMapValues(enc, cachedKeys, keys, values, inlinedTypeInfo)
 	if err != nil {
-		return NewEncodingError(err)
+		// err is already categorized by encodeCompactMapValues().
+		return err
 	}
 
 	err = enc.CBOR.Flush()
@@ -2968,7 +2969,7 @@ func encodeCompactMapValues(
 
 				err = encodeStorableAsElement(enc, values[index], inlinedTypeInfo)
 				if err != nil {
-					// Don't need to wrap error as external error because err is already categorized by encodeStorable().
+					// Don't need to wrap error as external error because err is already categorized by encodeStorableAsElement().
 					return err
 				}
 

--- a/map.go
+++ b/map.go
@@ -595,17 +595,17 @@ func (e *singleElement) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) e
 	}
 
 	// Encode key
-	err = e.key.Encode(enc)
+	err = encodeStorableAsElement(enc, e.key, inlinedTypeInfo)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by Storable interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode map key")
+		// Don't need to wrap error as external error because err is already categorized by encodeStorableAsElement().
+		return err
 	}
 
 	// Encode value
 	err = encodeStorableAsElement(enc, e.value, inlinedTypeInfo)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by Storable interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode map value")
+		// Don't need to wrap error as external error because err is already categorized by encodeStorableAsElement().
+		return err
 	}
 
 	err = enc.CBOR.Flush()

--- a/map.go
+++ b/map.go
@@ -148,7 +148,7 @@ type element interface {
 		key Value,
 	) (MapKey, MapValue, element, error)
 
-	Encode(*Encoder, InlinedExtraData) error
+	Encode(*Encoder, *InlinedExtraData) error
 
 	hasPointer() bool
 
@@ -215,7 +215,7 @@ type elements interface {
 
 	Element(int) (element, error)
 
-	Encode(*Encoder, InlinedExtraData) error
+	Encode(*Encoder, *InlinedExtraData) error
 
 	hasPointer() bool
 
@@ -586,7 +586,7 @@ func newSingleElementFromData(cborDec *cbor.StreamDecoder, decodeStorable Storab
 // Encode encodes singleElement to the given encoder.
 //
 //	CBOR encoded array of 2 elements (key, value).
-func (e *singleElement) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (e *singleElement) Encode(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 
 	// Encode CBOR array head for 2 elements
 	err := enc.CBOR.EncodeRawBytes([]byte{0x82})
@@ -763,7 +763,7 @@ func newInlineCollisionGroupFromData(cborDec *cbor.StreamDecoder, decodeStorable
 // Encode encodes inlineCollisionGroup to the given encoder.
 //
 //	CBOR tag (number: CBORTagInlineCollisionGroup, content: elements)
-func (e *inlineCollisionGroup) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (e *inlineCollisionGroup) Encode(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number CBORTagInlineCollisionGroup
@@ -953,7 +953,7 @@ func newExternalCollisionGroupFromData(cborDec *cbor.StreamDecoder, decodeStorab
 // Encode encodes externalCollisionGroup to the given encoder.
 //
 //	CBOR tag (number: CBORTagExternalCollisionGroup, content: slab ID)
-func (e *externalCollisionGroup) Encode(enc *Encoder, _ InlinedExtraData) error {
+func (e *externalCollisionGroup) Encode(enc *Encoder, _ *InlinedExtraData) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number CBORTagExternalCollisionGroup
 		0xd8, CBORTagExternalCollisionGroup,
@@ -1259,7 +1259,7 @@ func newHkeyElementsWithElement(level uint, hkey Digest, elem element) *hkeyElem
 //	    1: hkeys (byte string)
 //	    2: elements (array)
 //	]
-func (e *hkeyElements) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (e *hkeyElements) Encode(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 
 	if e.level > maxDigestLevel {
 		return NewFatalError(fmt.Errorf("hash level %d exceeds max digest level %d", e.level, maxDigestLevel))
@@ -1921,7 +1921,7 @@ func newSingleElementsWithElement(level uint, elem *singleElement) *singleElemen
 //	    1: hkeys (0 length byte string)
 //	    2: elements (array)
 //	]
-func (e *singleElements) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (e *singleElements) Encode(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 
 	if e.level > maxDigestLevel {
 		return NewFatalError(fmt.Errorf("digest level %d exceeds max digest level %d", e.level, maxDigestLevel))
@@ -2777,7 +2777,7 @@ func (m *MapDataSlab) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes InlinedExtraData) error {
+func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes *InlinedExtraData) error {
 	err := m.elements.Encode(enc, inlinedTypes)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by elements.Encode().
@@ -2799,7 +2799,7 @@ func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes InlinedExtraData
 //	+------------------+----------------+----------+
 //	| extra data index | value ID index | elements |
 //	+------------------+----------------+----------+
-func (m *MapDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (m *MapDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 	if m.extraData == nil {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode non-root map data slab as inlined"))
@@ -2817,7 +2817,7 @@ func (m *MapDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo InlinedExtra
 	return m.encodeAsInlinedMap(enc, inlinedTypeInfo)
 }
 
-func (m *MapDataSlab) encodeAsInlinedMap(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (m *MapDataSlab) encodeAsInlinedMap(enc *Encoder, inlinedTypeInfo *InlinedExtraData) error {
 
 	extraDataIndex := inlinedTypeInfo.addMapExtraData(m.extraData)
 
@@ -2877,7 +2877,7 @@ func encodeAsInlinedCompactMap(
 	hkeys []Digest,
 	keys []ComparableStorable,
 	values []Storable,
-	inlinedTypeInfo InlinedExtraData,
+	inlinedTypeInfo *InlinedExtraData,
 ) error {
 
 	extraDataIndex, cachedKeys := inlinedTypeInfo.addCompactMapExtraData(extraData, hkeys, keys)
@@ -2941,7 +2941,7 @@ func encodeCompactMapValues(
 	cachedKeys []ComparableStorable,
 	keys []ComparableStorable,
 	values []Storable,
-	inlinedTypeInfo InlinedExtraData,
+	inlinedTypeInfo *InlinedExtraData,
 ) error {
 
 	var err error

--- a/map.go
+++ b/map.go
@@ -595,14 +595,14 @@ func (e *singleElement) Encode(enc *Encoder, inlinedTypeInfo InlinedExtraData) e
 	}
 
 	// Encode key
-	err = encodeStorableAsElement(enc, e.key, inlinedTypeInfo)
+	err = EncodeStorableAsElement(enc, e.key, inlinedTypeInfo)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by encodeStorableAsElement().
 		return err
 	}
 
 	// Encode value
-	err = encodeStorableAsElement(enc, e.value, inlinedTypeInfo)
+	err = EncodeStorableAsElement(enc, e.value, inlinedTypeInfo)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by encodeStorableAsElement().
 		return err
@@ -2967,7 +2967,7 @@ func encodeCompactMapValues(
 				found = true
 				keyIndexes[i], keyIndexes[j] = keyIndexes[j], keyIndexes[i]
 
-				err = encodeStorableAsElement(enc, values[index], inlinedTypeInfo)
+				err = EncodeStorableAsElement(enc, values[index], inlinedTypeInfo)
 				if err != nil {
 					// Don't need to wrap error as external error because err is already categorized by encodeStorableAsElement().
 					return err

--- a/map.go
+++ b/map.go
@@ -300,7 +300,7 @@ type MapDataSlab struct {
 }
 
 var _ MapSlab = &MapDataSlab{}
-var _ Storable = &MapDataSlab{}
+var _ ContainerStorable = &MapDataSlab{}
 
 // MapMetaDataSlab is internal node, implementing MapSlab.
 type MapMetaDataSlab struct {
@@ -2792,14 +2792,14 @@ func (m *MapDataSlab) encodeElements(enc *Encoder, inlinedTypes InlinedExtraData
 	return nil
 }
 
-// encodeAsInlined encodes inlined map data slab. Encoding is
+// EncodeAsElement encodes inlined map data slab. Encoding is
 // version 1 with CBOR tag having tag number CBORTagInlinedMap,
 // and tag contant as 3-element array:
 //
 //	+------------------+----------------+----------+
 //	| extra data index | value ID index | elements |
 //	+------------------+----------------+----------+
-func (m *MapDataSlab) encodeAsInlined(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
+func (m *MapDataSlab) EncodeAsElement(enc *Encoder, inlinedTypeInfo InlinedExtraData) error {
 	if m.extraData == nil {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode non-root map data slab as inlined"))

--- a/map_debug.go
+++ b/map_debug.go
@@ -958,7 +958,7 @@ func (v *serializationVerifier) verifyMapSlab(slab MapSlab) error {
 	id := slab.SlabID()
 
 	// Encode slab
-	data, err := Encode(slab, v.cborEncMode)
+	data, err := EncodeSlab(slab, v.cborEncMode)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Encode().
 		return err
@@ -972,7 +972,7 @@ func (v *serializationVerifier) verifyMapSlab(slab MapSlab) error {
 	}
 
 	// Re-encode decoded slab
-	dataFromDecodedSlab, err := Encode(decodedSlab, v.cborEncMode)
+	dataFromDecodedSlab, err := EncodeSlab(decodedSlab, v.cborEncMode)
 	if err != nil {
 		// Don't need to wrap error as external error because err is already categorized by Encode().
 		return err

--- a/map_debug.go
+++ b/map_debug.go
@@ -386,8 +386,12 @@ func (v *mapVerifier) verifySlab(
 
 	// Verify that inlined slab is not in storage
 	if slab.Inlined() {
-		slab := v.storage.RetrieveIfLoaded(id)
-		if slab != nil {
+		_, exist, err := v.storage.Retrieve(id)
+		if err != nil {
+			// Wrap err as external error (if needed) because err is returned by Storage interface.
+			return 0, nil, nil, nil, wrapErrorAsExternalErrorIfNeeded(err)
+		}
+		if exist {
 			return 0, nil, nil, nil, NewFatalError(fmt.Errorf("inlined slab %s is in storage", id))
 		}
 	}

--- a/map_debug.go
+++ b/map_debug.go
@@ -1105,10 +1105,8 @@ func (v *serializationVerifier) mapDataSlabEqual(expected, actual *MapDataSlab) 
 		if expected.header.size != actual.header.size {
 			return NewFatalError(fmt.Errorf("header.size %d is wrong, want %d", actual.header.size, expected.header.size))
 		}
-	} else {
-		if !reflect.DeepEqual(expected.header, actual.header) {
-			return NewFatalError(fmt.Errorf("header %+v is wrong, want %+v", actual.header, expected.header))
-		}
+	} else if !reflect.DeepEqual(expected.header, actual.header) {
+		return NewFatalError(fmt.Errorf("header %+v is wrong, want %+v", actual.header, expected.header))
 	}
 
 	// Compare elements

--- a/storable.go
+++ b/storable.go
@@ -59,16 +59,12 @@ type ContainerStorable interface {
 	Storable
 
 	EncodeAsElement(*Encoder, InlinedExtraData) error
-}
-
-type containerStorable interface {
-	Storable
-	hasPointer() bool
+	HasPointer() bool
 }
 
 func hasPointer(storable Storable) bool {
-	if cs, ok := storable.(containerStorable); ok {
-		return cs.hasPointer()
+	if cs, ok := storable.(ContainerStorable); ok {
+		return cs.HasPointer()
 	}
 	return false
 }
@@ -95,10 +91,9 @@ const (
 
 type SlabIDStorable SlabID
 
-var _ Storable = SlabIDStorable{}
-var _ containerStorable = SlabIDStorable{}
+var _ ContainerStorable = SlabIDStorable{}
 
-func (v SlabIDStorable) hasPointer() bool {
+func (v SlabIDStorable) HasPointer() bool {
 	return true
 }
 
@@ -153,6 +148,10 @@ func (v SlabIDStorable) Encode(enc *Encoder) error {
 	}
 
 	return nil
+}
+
+func (v SlabIDStorable) EncodeAsElement(enc *Encoder, _ InlinedExtraData) error {
+	return v.Encode(enc)
 }
 
 func (v SlabIDStorable) ByteSize() uint32 {

--- a/storable.go
+++ b/storable.go
@@ -58,7 +58,13 @@ type ComparableStorable interface {
 type ContainerStorable interface {
 	Storable
 
+	// EncodeAsElement encodes ContainerStorable and its child storables as an element
+	// of parent array/map.  Since child storable can be inlined array or map,
+	// encoding inlined array or map requires extra parameter InlinedExtraData.
 	EncodeAsElement(*Encoder, InlinedExtraData) error
+
+	// HasPointer returns true if any of its child storables is SlabIDStorable
+	// (references to another slab).  This function is used during encoding.
 	HasPointer() bool
 }
 

--- a/storable.go
+++ b/storable.go
@@ -61,7 +61,7 @@ type ContainerStorable interface {
 	// EncodeAsElement encodes ContainerStorable and its child storables as an element
 	// of parent array/map.  Since child storable can be inlined array or map,
 	// encoding inlined array or map requires extra parameter InlinedExtraData.
-	EncodeAsElement(*Encoder, InlinedExtraData) error
+	EncodeAsElement(*Encoder, *InlinedExtraData) error
 
 	// HasPointer returns true if any of its child storables is SlabIDStorable
 	// (references to another slab).  This function is used during encoding.
@@ -156,7 +156,7 @@ func (v SlabIDStorable) Encode(enc *Encoder) error {
 	return nil
 }
 
-func (v SlabIDStorable) EncodeAsElement(enc *Encoder, _ InlinedExtraData) error {
+func (v SlabIDStorable) EncodeAsElement(enc *Encoder, _ *InlinedExtraData) error {
 	return v.Encode(enc)
 }
 

--- a/storable.go
+++ b/storable.go
@@ -54,6 +54,13 @@ type ComparableStorable interface {
 	Copy() Storable
 }
 
+// ContainerStorable is an interface that supports Storable containing other storables.
+type ContainerStorable interface {
+	Storable
+
+	EncodeAsElement(*Encoder, InlinedExtraData) error
+}
+
 type containerStorable interface {
 	Storable
 	hasPointer() bool

--- a/storable.go
+++ b/storable.go
@@ -164,12 +164,11 @@ func (v SlabIDStorable) String() string {
 	return fmt.Sprintf("SlabIDStorable(%d)", v)
 }
 
-// Encode is a wrapper for Storable.Encode()
-func Encode(storable Storable, encMode cbor.EncMode) ([]byte, error) {
+func EncodeSlab(slab Slab, encMode cbor.EncMode) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := NewEncoder(&buf, encMode)
 
-	err := storable.Encode(enc)
+	err := slab.Encode(enc)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Storable interface.
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode storable")

--- a/storable_test.go
+++ b/storable_test.go
@@ -723,7 +723,7 @@ func (v SomeStorable) Encode(enc *Encoder) error {
 	return v.Storable.Encode(enc)
 }
 
-func (v SomeStorable) EncodeAsElement(enc *Encoder, inlinedExtraData InlinedExtraData) error {
+func (v SomeStorable) EncodeAsElement(enc *Encoder, inlinedExtraData *InlinedExtraData) error {
 	err := enc.CBOR.EncodeRawBytes([]byte{
 		// tag number
 		0xd8, cborTagSomeValue,

--- a/storable_test.go
+++ b/storable_test.go
@@ -698,11 +698,11 @@ type SomeStorable struct {
 	Storable Storable
 }
 
-var _ Storable = SomeStorable{}
+var _ ContainerStorable = SomeStorable{}
 
-func (v SomeStorable) hasPointer() bool {
-	if ms, ok := v.Storable.(containerStorable); ok {
-		return ms.hasPointer()
+func (v SomeStorable) HasPointer() bool {
+	if ms, ok := v.Storable.(ContainerStorable); ok {
+		return ms.HasPointer()
 	}
 	return false
 }
@@ -721,6 +721,17 @@ func (v SomeStorable) Encode(enc *Encoder) error {
 		return err
 	}
 	return v.Storable.Encode(enc)
+}
+
+func (v SomeStorable) EncodeAsElement(enc *Encoder, inlinedExtraData InlinedExtraData) error {
+	err := enc.CBOR.EncodeRawBytes([]byte{
+		// tag number
+		0xd8, cborTagSomeValue,
+	})
+	if err != nil {
+		return err
+	}
+	return EncodeStorableAsElement(enc, v.Storable, inlinedExtraData)
 }
 
 func (v SomeStorable) ChildStorables() []Storable {

--- a/storage.go
+++ b/storage.go
@@ -390,7 +390,7 @@ func (s *BasicSlabStorage) SlabIDs() []SlabID {
 func (s *BasicSlabStorage) Encode() (map[SlabID][]byte, error) {
 	m := make(map[SlabID][]byte)
 	for id, slab := range s.Slabs {
-		b, err := Encode(slab, s.cborEncMode)
+		b, err := EncodeSlab(slab, s.cborEncMode)
 		if err != nil {
 			// err is already categorized by Encode().
 			return nil, err
@@ -800,7 +800,7 @@ func (s *PersistentSlabStorage) Commit() error {
 		}
 
 		// serialize
-		data, err := Encode(slab, s.cborEncMode)
+		data, err := EncodeSlab(slab, s.cborEncMode)
 		if err != nil {
 			// err is categorized already by Encode()
 			return err
@@ -879,7 +879,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 				continue
 			}
 			// serialize
-			data, err := Encode(slab, s.cborEncMode)
+			data, err := EncodeSlab(slab, s.cborEncMode)
 			results <- &encodedSlabs{
 				slabID: id,
 				data:   data,

--- a/storage_test.go
+++ b/storage_test.go
@@ -749,7 +749,7 @@ func TestPersistentStorage(t *testing.T) {
 				require.NoError(t, err)
 
 				// capture data for accuracy testing
-				simpleMap[slabID], err = Encode(slab, encMode)
+				simpleMap[slabID], err = EncodeSlab(slab, encMode)
 				require.NoError(t, err)
 			}
 		}
@@ -1000,7 +1000,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				break
 			}
 
-			encodedSlab, err := Encode(slab, storage.cborEncMode)
+			encodedSlab, err := EncodeSlab(slab, storage.cborEncMode)
 			require.NoError(t, err)
 
 			require.Equal(t, encodedSlab, data[id])

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -199,11 +199,25 @@ type compactMapTypeInfo struct {
 	keys  []ComparableStorable
 }
 
+type InlinedExtraData interface {
+	Encode(*Encoder) error
+
+	addArrayExtraData(data *ArrayExtraData) int
+	addMapExtraData(data *MapExtraData) int
+	addCompactMapExtraData(
+		data *MapExtraData,
+		digests []Digest,
+		keys []ComparableStorable,
+	) (int, []ComparableStorable)
+}
+
 type inlinedExtraData struct {
 	extraData       []ExtraData
 	compactMapTypes map[string]compactMapTypeInfo
 	arrayTypes      map[string]int
 }
+
+var _ InlinedExtraData = &inlinedExtraData{}
 
 func newInlinedExtraData() *inlinedExtraData {
 	return &inlinedExtraData{}

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -29,7 +29,7 @@ import (
 type TypeInfo interface {
 	Encode(*cbor.StreamEncoder) error
 	IsComposite() bool
-	ID() string
+	Identifier() string
 	Copy() TypeInfo
 }
 
@@ -312,7 +312,7 @@ func (ied *inlinedExtraData) addArrayExtraData(data *ArrayExtraData) int {
 		ied.arrayTypes = make(map[string]int)
 	}
 
-	id := data.TypeInfo.ID()
+	id := data.TypeInfo.Identifier()
 	index, exist := ied.arrayTypes[id]
 	if exist {
 		return index
@@ -376,14 +376,14 @@ func makeCompactMapTypeID(t TypeInfo, names []ComparableStorable) string {
 	const separator = ","
 
 	if len(names) == 1 {
-		return t.ID() + separator + names[0].ID()
+		return t.Identifier() + separator + names[0].ID()
 	}
 
 	sorter := newFieldNameSorter(names)
 
 	sort.Sort(sorter)
 
-	return t.ID() + separator + sorter.join(separator)
+	return t.Identifier() + separator + sorter.join(separator)
 }
 
 // fieldNameSorter sorts names by index (not in place sort).

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/fxamacker/cbor/v2"
 )
@@ -418,9 +419,12 @@ func (fn *fieldNameSorter) Swap(i, j int) {
 }
 
 func (fn *fieldNameSorter) join(sep string) string {
-	var s string
-	for _, i := range fn.index {
-		s += sep + fn.names[i].ID()
+	var sb strings.Builder
+	for i, index := range fn.index {
+		if i > 0 {
+			sb.WriteString(sep)
+		}
+		sb.WriteString(fn.names[index].ID())
 	}
-	return s
+	return sb.String()
 }

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -199,32 +199,18 @@ type compactMapTypeInfo struct {
 	keys  []ComparableStorable
 }
 
-type InlinedExtraData interface {
-	Encode(*Encoder) error
-
-	addArrayExtraData(data *ArrayExtraData) int
-	addMapExtraData(data *MapExtraData) int
-	addCompactMapExtraData(
-		data *MapExtraData,
-		digests []Digest,
-		keys []ComparableStorable,
-	) (int, []ComparableStorable)
-}
-
-type inlinedExtraData struct {
+type InlinedExtraData struct {
 	extraData       []ExtraData
 	compactMapTypes map[string]compactMapTypeInfo
 	arrayTypes      map[string]int
 }
 
-var _ InlinedExtraData = &inlinedExtraData{}
-
-func newInlinedExtraData() *inlinedExtraData {
-	return &inlinedExtraData{}
+func newInlinedExtraData() *InlinedExtraData {
+	return &InlinedExtraData{}
 }
 
 // Encode encodes inlined extra data as CBOR array.
-func (ied *inlinedExtraData) Encode(enc *Encoder) error {
+func (ied *InlinedExtraData) Encode(enc *Encoder) error {
 	err := enc.CBOR.EncodeArrayHead(uint64(len(ied.extraData)))
 	if err != nil {
 		return NewEncodingError(err)
@@ -321,7 +307,7 @@ func newInlinedExtraDataFromData(
 // addArrayExtraData returns index of deduplicated array extra data.
 // Array extra data is deduplicated by array type info ID because array
 // extra data only contains type info.
-func (ied *inlinedExtraData) addArrayExtraData(data *ArrayExtraData) int {
+func (ied *InlinedExtraData) addArrayExtraData(data *ArrayExtraData) int {
 	if ied.arrayTypes == nil {
 		ied.arrayTypes = make(map[string]int)
 	}
@@ -340,7 +326,7 @@ func (ied *inlinedExtraData) addArrayExtraData(data *ArrayExtraData) int {
 
 // addMapExtraData returns index of map extra data.
 // Map extra data is not deduplicated because it also contains count and seed.
-func (ied *inlinedExtraData) addMapExtraData(data *MapExtraData) int {
+func (ied *InlinedExtraData) addMapExtraData(data *MapExtraData) int {
 	index := len(ied.extraData)
 	ied.extraData = append(ied.extraData, data)
 	return index
@@ -348,7 +334,7 @@ func (ied *inlinedExtraData) addMapExtraData(data *MapExtraData) int {
 
 // addCompactMapExtraData returns index of deduplicated compact map extra data.
 // Compact map extra data is deduplicated by TypeInfo.ID() with sorted field names.
-func (ied *inlinedExtraData) addCompactMapExtraData(
+func (ied *InlinedExtraData) addCompactMapExtraData(
 	data *MapExtraData,
 	digests []Digest,
 	keys []ComparableStorable,
@@ -381,7 +367,7 @@ func (ied *inlinedExtraData) addCompactMapExtraData(
 	return index, keys
 }
 
-func (ied *inlinedExtraData) empty() bool {
+func (ied *InlinedExtraData) empty() bool {
 	return len(ied.extraData) == 0
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -100,7 +100,7 @@ func (i testTypeInfo) IsComposite() bool {
 	return false
 }
 
-func (i testTypeInfo) ID() string {
+func (i testTypeInfo) Identifier() string {
 	return fmt.Sprintf("uint64(%d)", i)
 }
 
@@ -129,7 +129,7 @@ func (i testCompositeTypeInfo) IsComposite() bool {
 	return true
 }
 
-func (i testCompositeTypeInfo) ID() string {
+func (i testCompositeTypeInfo) Identifier() string {
 	return fmt.Sprintf("composite(%d)", i)
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -200,6 +200,15 @@ func newTestPersistentStorageWithBaseStorage(t testing.TB, baseStorage BaseStora
 	)
 }
 
+func newTestPersistentStorageWithBaseStorageAndDeltas(t testing.TB, baseStorage BaseStorage, data map[SlabID][]byte) *PersistentSlabStorage {
+	storage := newTestPersistentStorageWithBaseStorage(t, baseStorage)
+	for id, b := range data {
+		err := storage.baseStorage.Store(id, b)
+		require.NoError(t, err)
+	}
+	return storage
+}
+
 func newTestBasicStorage(t testing.TB) *BasicSlabStorage {
 	encMode, err := cbor.EncOptions{}.EncMode()
 	require.NoError(t, err)


### PR DESCRIPTION
Closes #351
Updates #292 https://github.com/onflow/cadence/issues/2809 https://github.com/onflow/flow-go/issues/1744

This PR adds new interfaces, changes error types, exports new functions, etc.  This is to resolve all the integration issues integration issues I ran into while updating [onflow/cadence](github.com/onflow/cadence) to use Atree PR #342 and #345.

Changes:

- [x] Rename `TypeInfo.ID()` to `TypeInfo.Identifier()`
- [x] Change array encoding error type
- [x] Change map encoding error type
- [x] Add `InlinedExtraData` interface
- [x] Add `ContainerStorable` interface
- [x] Rename `Encode` to `EncodeSlab`
- [x] Encode inlined map as map key
- [x] Add test verification for compact map serialization
- [x] Add more tests for decoded array/map
- [x] Export `EncodeStorableAsElement()`
- [x] Add `ContainerStorable.HasPointer()`

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
