### PR TITLE
Pin dependencies in coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,13 +16,12 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: '1.19'
           check-latest: true
 
       - name: Get dependencies
@@ -35,7 +34,7 @@ jobs:
         run: go test -timeout 60m -race -coverprofile=coverage.txt -covermode=atomic
 
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v3.1.4  
+        uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1  
         with:
             files: ./coverage.txt
             fail_ci_if_error: false # we can set this to true after "Could not find a repository" upload error is fixed


### PR DESCRIPTION
This replaces PR #365.

### Changes

- Pin dependencies:
  - actions/checkout
  - actions/setup-go
  - codecov/codecov-action

- Use default Go version instead of go-1.19.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
