### PR TITLE
Reduce RAM and persistent storage by deduplicating inlined dict type info

### DIFF
--- a/array.go
+++ b/array.go
@@ -301,13 +301,13 @@ func (a *ArrayExtraData) isExtraData() bool {
 // Encode encodes extra data as CBOR array:
 //
 //	[type info]
-func (a *ArrayExtraData) Encode(enc *Encoder) error {
+func (a *ArrayExtraData) Encode(enc *Encoder, encodeTypeInfo encodeTypeInfo) error {
 	err := enc.CBOR.EncodeArrayHead(arrayExtraDataLength)
 	if err != nil {
 		return NewEncodingError(err)
 	}
 
-	err = a.TypeInfo.Encode(enc.CBOR)
+	err = encodeTypeInfo(enc, a.TypeInfo)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by TypeInfo interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode type info")
@@ -840,7 +840,8 @@ func (a *ArrayDataSlab) Encode(enc *Encoder) error {
 
 	// Encode extra data
 	if a.extraData != nil {
-		err = a.extraData.Encode(enc)
+		// Use defaultEncodeTypeInfo to encode root level TypeInfo as is.
+		err = a.extraData.Encode(enc, defaultEncodeTypeInfo)
 		if err != nil {
 			// err is already categorized by ArrayExtraData.Encode().
 			return err
@@ -1738,7 +1739,8 @@ func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 
 	// Encode extra data if present
 	if a.extraData != nil {
-		err = a.extraData.Encode(enc)
+		// Use defaultEncodeTypeInfo to encode root level TypeInfo as is.
+		err = a.extraData.Encode(enc, defaultEncodeTypeInfo)
 		if err != nil {
 			// Don't need to wrap because err is already categorized by ArrayExtraData.Encode().
 			return err

--- a/array.go
+++ b/array.go
@@ -298,6 +298,10 @@ func (a *ArrayExtraData) isExtraData() bool {
 	return true
 }
 
+func (a *ArrayExtraData) Type() TypeInfo {
+	return a.TypeInfo
+}
+
 // Encode encodes extra data as CBOR array:
 //
 //	[type info]

--- a/array_test.go
+++ b/array_test.go
@@ -3186,17 +3186,14 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of type info
-				0x81,
-				// type info
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of extra data
 				0x81,
 				// array extra data
 				0xd8, 0xf7,
 				0x81,
 				// array type info ref
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3275,21 +3272,17 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x82,
-				0x18, 0x2c,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x82,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2b,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3372,20 +3365,16 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x82,
-				0x18, 0x2c,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x82,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2b,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3480,33 +3469,25 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x84,
-				0x18, 0x2c,
-				0x18, 0x2b,
-				0x18, 0x2e,
-				0x18, 0x2d,
+				0x80,
 				// element 1: array of inlined extra data
 				0x84,
 				// typeInfo3
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 				// typeInfo2
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2b,
 				// typeInfo5
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x02,
+				0x18, 0x2e,
 				// typeInfo4
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x03,
+				0x18, 0x2d,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3633,15 +3614,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
 				// CBOR encoded array elements
@@ -3787,20 +3766,16 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined extra data
-				0x82,
-				0x18, 0x2c,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x82,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2b,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
 				// CBOR encoded array elements
@@ -4117,15 +4092,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of type info
-				0x81,
-				0x18, 0x2c,
+				0x80,
 				// element 1: array of extra data
 				0x81,
 				// type info
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,

--- a/array_test.go
+++ b/array_test.go
@@ -3184,11 +3184,19 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x18, 0x2a,
 
 				// inlined extra data
+				0x82,
+				// element 0: array of type info
 				0x81,
-				// inlined array extra data
+				// type info
+				0x18, 0x2b,
+				// element 1: array of extra data
+				0x81,
+				// array extra data
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				// array type info ref
+				0xd8, 0xf6,
+				0x00,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3266,14 +3274,22 @@ func TestArrayEncodeDecode(t *testing.T) {
 
 				// inlined extra data
 				0x82,
-				// inlined array extra data
-				0xd8, 0xf7,
-				0x81,
+				// element 0: array of inlined type info
+				0x82,
 				0x18, 0x2c,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
+				0x82,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
+				// inlined array extra data
+				0xd8, 0xf7,
+				0x81,
+				0xd8, 0xf6,
+				0x01,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3355,13 +3371,21 @@ func TestArrayEncodeDecode(t *testing.T) {
 
 				// inlined extra data
 				0x82,
+				// element 0: array of inlined type info
+				0x82,
+				0x18, 0x2c,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
+				0x82,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x00,
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x01,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3454,23 +3478,35 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x18, 0x2a,
 
 				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x84,
+				0x18, 0x2c,
+				0x18, 0x2b,
+				0x18, 0x2e,
+				0x18, 0x2d,
+				// element 1: array of inlined extra data
 				0x84,
 				// typeInfo3
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x00,
 				// typeInfo2
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x01,
 				// typeInfo5
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2e,
+				0xd8, 0xf6,
+				0x02,
 				// typeInfo4
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2d,
+				0xd8, 0xf6,
+				0x03,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x02,
@@ -3595,11 +3631,17 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// array data slab flag
 				0x00,
 				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
 				// CBOR encoded array elements
@@ -3744,13 +3786,21 @@ func TestArrayEncodeDecode(t *testing.T) {
 				0x00,
 				// inlined extra data
 				0x82,
+				// element 0: array of inlined extra data
+				0x82,
+				0x18, 0x2c,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
+				0x82,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x00,
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x01,
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,
 				// CBOR encoded array elements
@@ -4064,12 +4114,18 @@ func TestArrayEncodeDecode(t *testing.T) {
 				// array data slab flag (has pointer)
 				0x40,
 
-				// inlined array of extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of type info
+				0x81,
+				0x18, 0x2c,
+				// element 1: array of extra data
 				0x81,
 				// type info
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x00,
 
 				// CBOR encoded array head (fixed size 3 byte)
 				0x99, 0x00, 0x0b,

--- a/map.go
+++ b/map.go
@@ -494,6 +494,10 @@ func (m *MapExtraData) isExtraData() bool {
 	return true
 }
 
+func (m *MapExtraData) Type() TypeInfo {
+	return m.TypeInfo
+}
+
 // Encode encodes extra data as CBOR array:
 //
 //	[type info, count, seed]

--- a/map.go
+++ b/map.go
@@ -497,14 +497,14 @@ func (m *MapExtraData) isExtraData() bool {
 // Encode encodes extra data as CBOR array:
 //
 //	[type info, count, seed]
-func (m *MapExtraData) Encode(enc *Encoder) error {
+func (m *MapExtraData) Encode(enc *Encoder, encodeTypeInfo encodeTypeInfo) error {
 
 	err := enc.CBOR.EncodeArrayHead(mapExtraDataLength)
 	if err != nil {
 		return NewEncodingError(err)
 	}
 
-	err = m.TypeInfo.Encode(enc.CBOR)
+	err = encodeTypeInfo(enc, m.TypeInfo)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by TypeInfo interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, "failed to encode type info")
@@ -2917,7 +2917,8 @@ func (m *MapDataSlab) Encode(enc *Encoder) error {
 
 	// Encode extra data
 	if m.extraData != nil {
-		err = m.extraData.Encode(enc)
+		// Use defaultEncodeTypeInfo to encode root level TypeInfo as is.
+		err = m.extraData.Encode(enc, defaultEncodeTypeInfo)
 		if err != nil {
 			// Don't need to wrap error as external error because err is already categorized by MapExtraData.Encode().
 			return err
@@ -3918,7 +3919,8 @@ func (m *MapMetaDataSlab) Encode(enc *Encoder) error {
 
 	// Encode extra data if present
 	if m.extraData != nil {
-		err = m.extraData.Encode(enc)
+		// Use defaultEncodeTypeInfo to encode root level TypeInfo as is.
+		err = m.extraData.Encode(enc, defaultEncodeTypeInfo)
 		if err != nil {
 			// Don't need to wrap error as external error because err is already categorized by MapExtraData.Encode().
 			return err

--- a/map_test.go
+++ b/map_test.go
@@ -7663,15 +7663,13 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 
 				// the following encoded data is valid CBOR
 
@@ -7729,7 +7727,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.Equal(t, 2, len(meta.childrenHeaders))
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
 
-		const inlinedExtraDataSize = 11
+		const inlinedExtraDataSize = 8
 		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+slabIDSize), meta.childrenHeaders[1].size)
 
 		// Decode data to new storage
@@ -7827,7 +7825,6 @@ func TestMapEncodeDecode(t *testing.T) {
 				0x01,
 				// seed
 				0x1b, 0xa9, 0x3a, 0x2d, 0x6f, 0x53, 0x49, 0xaa, 0xdd,
-				// element 1
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
@@ -8008,18 +8005,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x82,
-				0x18, 0x2c,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x82,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 				// count: 1
 				0x01,
 				// seed
@@ -8028,9 +8021,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2b,
 				// count: 1
 				0x01,
 				// seed
@@ -8486,20 +8477,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of type info
-				0x84,
-				0x18, 0x2c,
-				0x18, 0x2e,
-				0x18, 0x2b,
-				0x18, 0x2d,
+				0x80,
 				// element 1: array of extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info: 44
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2c,
 				// count: 1
 				0x01,
 				// seed
@@ -8509,9 +8494,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info: 46
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2e,
 				// count: 1
 				0x01,
 				// seed
@@ -8521,9 +8504,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info: 43
-				0xd8, 0xf6,
-				0x02,
+				0x18, 0x2b,
 				// count: 1
 				0x01,
 				// seed
@@ -8533,9 +8514,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info: 45
-				0xd8, 0xf6,
-				0x03,
+				0x18, 0x2d,
 				// count: 1
 				0x01,
 				// seed
@@ -9264,20 +9243,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x84,
-				0x18, 0x2b,
-				0x18, 0x2c,
-				0x18, 0x2d,
-				0x18, 0x2e,
+				0x80,
 				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 				// count: 1
 				0x01,
 				// seed
@@ -9286,9 +9259,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2c,
 				// count: 1
 				0x01,
 				// seed
@@ -9297,9 +9268,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x02,
+				0x18, 0x2d,
 				// count: 1
 				0x01,
 				// seed
@@ -9307,9 +9276,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x03,
+				0x18, 0x2e,
 				// count: 1
 				0x01,
 				// seed
@@ -9459,20 +9426,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x84,
-				0x18, 0x2b,
-				0x18, 0x2c,
-				0x18, 0x2d,
-				0x18, 0x2e,
+				0x80,
 				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 				// count: 1
 				0x01,
 				// seed
@@ -9481,9 +9442,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x01,
+				0x18, 0x2c,
 				// count: 1
 				0x01,
 				// seed
@@ -9492,9 +9451,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x02,
+				0x18, 0x2d,
 				// count: 1
 				0x01,
 				// seed
@@ -9502,9 +9459,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x03,
+				0x18, 0x2e,
 				// count: 1
 				0x01,
 				// seed
@@ -10597,17 +10552,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
-				// type info
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 				// count: 1
 				0x01,
 				// seed
@@ -11078,17 +11030,14 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				// type info
-				0xd8, 0xf6,
-				0x00,
+				0x18, 0x2b,
 
 				// the following encoded data is valid CBOR
 
@@ -11379,8 +11328,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0xd8, 0xf6, 0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// element 0
@@ -11390,8 +11338,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6,
-				0x00,
+				0xd8, 0xf6, 0x18, 0x2b,
 				// count
 				0x01,
 				// seed
@@ -11553,8 +11500,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0xd8, 0xf6, 0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// element 0
@@ -11564,8 +11510,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6,
-				0x00,
+				0xd8, 0xf6, 0x18, 0x2b,
 				// count: 2
 				0x02,
 				// seed
@@ -11734,8 +11679,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x81,
-				0xd8, 0xf6, 0x18, 0x2b,
+				0x80,
 				// element 1: array of inlined extra data
 				0x81,
 				// element 0
@@ -11745,8 +11689,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6,
-				0x00,
+				0xd8, 0xf6, 0x18, 0x2b,
 				// count: 2
 				0x02,
 				// seed
@@ -12379,9 +12322,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// inlined extra data
 				0x82,
 				// element 0: array of inlined type info
-				0x82,
-				0xd8, 0xf6, 0x18, 0x2b,
-				0xd8, 0xf6, 0x18, 0x2c,
+				0x80,
 				// element 1: array of inlined extra data
 				0x82,
 				// element 0
@@ -12391,8 +12332,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6,
-				0x00,
+				0xd8, 0xf6, 0x18, 0x2b,
 				// count: 2
 				0x02,
 				// seed
@@ -12410,8 +12350,7 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6,
-				0x01,
+				0xd8, 0xf6, 0x18, 0x2c,
 				// count: 2
 				0x02,
 				// seed

--- a/map_test.go
+++ b/map_test.go
@@ -7660,12 +7660,18 @@ func TestMapEncodeDecode(t *testing.T) {
 				// flag: has inlined slab + map data
 				0x08,
 
-				// inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 
 				// the following encoded data is valid CBOR
 
@@ -7723,7 +7729,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.Equal(t, 2, len(meta.childrenHeaders))
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
 
-		const inlinedExtraDataSize = 6
+		const inlinedExtraDataSize = 11
 		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+slabIDSize), meta.childrenHeaders[1].size)
 
 		// Decode data to new storage
@@ -7803,14 +7809,20 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 2 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x82,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -7820,7 +7832,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -7992,14 +8005,21 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 2 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x82,
+				0x18, 0x2c,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x82,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8009,7 +8029,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x01,
 				// count: 1
 				0x01,
 				// seed
@@ -8183,14 +8204,20 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 4 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8200,7 +8227,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8210,7 +8238,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8220,7 +8249,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8453,14 +8483,23 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 4 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of type info
+				0x84,
+				0x18, 0x2c,
+				0x18, 0x2e,
+				0x18, 0x2b,
+				0x18, 0x2d,
+				// element 1: array of extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info: 44
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8471,7 +8510,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info: 46
-				0x18, 0x2e,
+				0xd8, 0xf6,
+				0x01,
 				// count: 1
 				0x01,
 				// seed
@@ -8482,7 +8522,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info: 43
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x02,
 				// count: 1
 				0x01,
 				// seed
@@ -8493,7 +8534,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info: 45
-				0x18, 0x2d,
+				0xd8, 0xf6,
+				0x03,
 				// count: 1
 				0x01,
 				// seed
@@ -8720,14 +8762,20 @@ func TestMapEncodeDecode(t *testing.T) {
 				// flag: map data
 				0x08,
 
-				// 4 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8737,7 +8785,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8747,7 +8796,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8756,7 +8806,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8903,14 +8954,20 @@ func TestMapEncodeDecode(t *testing.T) {
 				// flag: map data
 				0x08,
 
-				// 4 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8920,7 +8977,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8930,7 +8988,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -8939,7 +8998,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -9201,14 +9261,23 @@ func TestMapEncodeDecode(t *testing.T) {
 				// flag: map data
 				0x08,
 
-				// 4 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x84,
+				0x18, 0x2b,
+				0x18, 0x2c,
+				0x18, 0x2d,
+				0x18, 0x2e,
+				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -9218,7 +9287,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x01,
 				// count: 1
 				0x01,
 				// seed
@@ -9228,7 +9298,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2d,
+				0xd8, 0xf6,
+				0x02,
 				// count: 1
 				0x01,
 				// seed
@@ -9237,7 +9308,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2e,
+				0xd8, 0xf6,
+				0x03,
 				// count: 1
 				0x01,
 				// seed
@@ -9384,14 +9456,23 @@ func TestMapEncodeDecode(t *testing.T) {
 				// flag: map data
 				0x08,
 
-				// 4 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x84,
+				0x18, 0x2b,
+				0x18, 0x2c,
+				0x18, 0x2d,
+				0x18, 0x2e,
+				// element 1: array of inlined extra data
 				0x84,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -9401,7 +9482,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2c,
+				0xd8, 0xf6,
+				0x01,
 				// count: 1
 				0x01,
 				// seed
@@ -9411,7 +9493,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2d,
+				0xd8, 0xf6,
+				0x02,
 				// count: 1
 				0x01,
 				// seed
@@ -9420,7 +9503,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2e,
+				0xd8, 0xf6,
+				0x03,
 				// count: 1
 				0x01,
 				// seed
@@ -10510,14 +10594,20 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// array of inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined map extra data
 				0xd8, 0xf8,
 				0x83,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -10985,14 +11075,20 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// array of inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined array extra data
 				0xd8, 0xf7,
 				0x81,
 				// type info
-				0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 
 				// the following encoded data is valid CBOR
 
@@ -11280,7 +11376,12 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 1 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0xd8, 0xf6, 0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined composite extra data
@@ -11289,7 +11390,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count
 				0x01,
 				// seed
@@ -11448,7 +11550,12 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 1 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0xd8, 0xf6, 0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined composite extra data
@@ -11457,7 +11564,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -11623,7 +11731,12 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 1 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0xd8, 0xf6, 0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x81,
 				// element 0
 				// inlined composite extra data
@@ -11632,7 +11745,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -11813,7 +11927,12 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 3 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0xd8, 0xf6, 0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x83,
 				// element 0
 				// inlined composite extra data
@@ -11822,7 +11941,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -11841,7 +11961,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -11860,7 +11981,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -12049,7 +12171,12 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 2 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x81,
+				0xd8, 0xf6, 0x18, 0x2b,
+				// element 1: array of inlined extra data
 				0x82,
 				// element 0
 				// inlined map extra data
@@ -12058,7 +12185,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -12076,7 +12204,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 1
 				0x01,
 				// seed
@@ -12247,7 +12376,13 @@ func TestMapEncodeDecode(t *testing.T) {
 				// seed
 				0x1b, 0x52, 0xa8, 0x78, 0x3, 0x85, 0x2c, 0xaa, 0x49,
 
-				// 2 inlined slab extra data
+				// inlined extra data
+				0x82,
+				// element 0: array of inlined type info
+				0x82,
+				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6, 0x18, 0x2c,
+				// element 1: array of inlined extra data
 				0x82,
 				// element 0
 				// inlined composite extra data
@@ -12256,7 +12391,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2b,
+				0xd8, 0xf6,
+				0x00,
 				// count: 2
 				0x02,
 				// seed
@@ -12274,7 +12410,8 @@ func TestMapEncodeDecode(t *testing.T) {
 				// map extra data
 				0x83,
 				// type info
-				0xd8, 0xf6, 0x18, 0x2c,
+				0xd8, 0xf6,
+				0x01,
 				// count: 2
 				0x02,
 				// seed

--- a/storable.go
+++ b/storable.go
@@ -76,6 +76,8 @@ const (
 	// As of Oct. 2, 2023, Cadence uses tag numbers from 128 to 224.
 	// See runtime/interpreter/encode.go at github.com/onflow/cadence.
 
+	CBORTagTypeInfoRef = 246
+
 	CBORTagInlinedArrayExtraData      = 247
 	CBORTagInlinedMapExtraData        = 248
 	CBORTagInlinedCompactMapExtraData = 249

--- a/storage.go
+++ b/storage.go
@@ -910,7 +910,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 	// process the results while encoders are working
 	// we need to capture them inside a map
 	// again so we can apply them in order of keys
-	encSlabByID := make(map[SlabID][]byte)
+	encSlabByID := make(map[SlabID][]byte, len(keysWithOwners))
 	for i := 0; i < len(keysWithOwners); i++ {
 		result := <-results
 		// if any error return


### PR DESCRIPTION
Closes #358 Updates epic #292

This PR deduplicates Cadence dictionary type resulting in reduced memory and persistent storage.

More specifically, this encodes inlined atree slab extra data section as two-element array:
- array of deduplicated type info
- array of deduplicated extra data with type info index

TODO (est. 1.5 - 2 days effort total):
[x] - initial deduplication of dict type info
[x] - build, run, and pass migration with validation enabled for all accounts and all payloads from mainnet snapshot
[x] - improve deduplication (1/2 day effort to wrap up + rerun test using mainnet snapshot)

UPDATE (Feb 29, 2024):  :stop_sign:  Work on this PR is paused to work on urgent request to create tooling for Cadence 1.0 migration.
- https://discord.com/channels/613813861610684416/1212814563385413682/1212814774723805194
- https://github.com/onflow/flow-go/issues/5483
- also several PRs for https://github.com/onflow/cadence/issues/3096#issuecomment-1979583162

NOTE: This PR is expected to produce small improvements to [atree inlining & deduplication results :bar_chart:](https://github.com/onflow/atree/issues/292).

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
