### PR TITLE
Add `Array.SetType()` to allow updating TypeInfo

### DIFF
--- a/array.go
+++ b/array.go
@@ -2371,6 +2371,22 @@ func (a *Array) Type() TypeInfo {
 	return nil
 }
 
+func (a *Array) SetType(typeInfo TypeInfo) error {
+	extraData := a.root.ExtraData()
+	extraData.TypeInfo = typeInfo
+
+	a.root.SetExtraData(extraData)
+
+	// Store modified root slab in storage since typeInfo is part of extraData stored in root slab.
+	err := a.Storage.Store(a.root.Header().id, a.root)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.root.Header().id))
+	}
+
+	return nil
+}
+
 func (a *Array) String() string {
 	iterator, err := a.Iterator()
 	if err != nil {

--- a/basicarray.go
+++ b/basicarray.go
@@ -155,13 +155,7 @@ func (a *BasicArrayDataSlab) Set(storage SlabStorage, index uint64, v Storable) 
 		oldElem.ByteSize() +
 		v.ByteSize()
 
-	err := storage.Store(a.header.id, a)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
-	}
-
-	return nil
+	return storeSlab(storage, a)
 }
 
 func (a *BasicArrayDataSlab) Insert(storage SlabStorage, index uint64, v Storable) error {
@@ -180,13 +174,7 @@ func (a *BasicArrayDataSlab) Insert(storage SlabStorage, index uint64, v Storabl
 	a.header.count++
 	a.header.size += v.ByteSize()
 
-	err := storage.Store(a.header.id, a)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
-	}
-
-	return nil
+	return storeSlab(storage, a)
 }
 
 func (a *BasicArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable, error) {
@@ -209,10 +197,9 @@ func (a *BasicArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable
 	a.header.count--
 	a.header.size -= v.ByteSize()
 
-	err := storage.Store(a.header.id, a)
+	err := storeSlab(storage, a)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.id))
+		return nil, err
 	}
 
 	return v, nil

--- a/storable_test.go
+++ b/storable_test.go
@@ -360,7 +360,7 @@ func (v StringValue) Storable(storage SlabStorage, address Address, maxInlineSiz
 		}
 
 		// Store StorableSlab in storage
-		err = storage.Store(id, slab)
+		err = storeSlab(storage, slab)
 		if err != nil {
 			return nil, err
 		}

--- a/storage.go
+++ b/storage.go
@@ -1017,3 +1017,13 @@ func (s *PersistentSlabStorage) DeltasSizeWithoutTempAddresses() uint64 {
 	}
 	return size
 }
+
+func storeSlab(storage SlabStorage, slab Slab) error {
+	id := slab.ID()
+	err := storage.Store(id, slab)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", id))
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #372

This feature is needed by Cadence migrations to update static types.  For more details, see
- https://github.com/onflow/cadence/issues/3096#issuecomment-1977580596.

This PR allows updating static types of `Array` container.
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
