### PR TITLE
Add `OrderedMap.SetType()` to allow updating TypeInfo

### DIFF
--- a/map.go
+++ b/map.go
@@ -3817,6 +3817,22 @@ func (m *OrderedMap) Type() TypeInfo {
 	return nil
 }
 
+func (m *OrderedMap) SetType(typeInfo TypeInfo) error {
+	extraData := m.root.ExtraData()
+	extraData.TypeInfo = typeInfo
+
+	m.root.SetExtraData(extraData)
+
+	// Store modified root slab in storage since typeInfo is part of extraData stored in root slab.
+	err := m.Storage.Store(m.root.Header().id, m.root)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.root.Header().id))
+	}
+
+	return nil
+}
+
 func (m *OrderedMap) String() string {
 	iterator, err := m.Iterator()
 	if err != nil {

--- a/map.go
+++ b/map.go
@@ -3824,13 +3824,7 @@ func (m *OrderedMap) SetType(typeInfo TypeInfo) error {
 	m.root.SetExtraData(extraData)
 
 	// Store modified root slab in storage since typeInfo is part of extraData stored in root slab.
-	err := m.Storage.Store(m.root.Header().id, m.root)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.root.Header().id))
-	}
-
-	return nil
+	return storeSlab(m.Storage, m.root)
 }
 
 func (m *OrderedMap) String() string {


### PR DESCRIPTION
Closes #373 

This feature is needed by Cadence migrations to update static types.  For more details, see
- https://github.com/onflow/cadence/issues/3096#issuecomment-1977580596.

This PR allows updating static types of `OrderedMap` container.
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
