### PR TITLE
Add support for changing type info of atree arrays (atree inlining branch)

### DIFF
--- a/array.go
+++ b/array.go
@@ -3600,16 +3600,9 @@ func (a *Array) SetType(typeInfo TypeInfo) error {
 
 	if a.Inlined() {
 		// Array is inlined.
-		// Notify parent container so parent slab is saved in storage with updated TypeInfo of inlined array.
-		found, err := a.parentUpdater()
-		if err != nil {
-			return err
-		}
-		if !found {
-			a.parentUpdater = nil
-		}
 
-		return nil
+		// Notify parent container so parent slab is saved in storage with updated TypeInfo of inlined array.
+		return a.notifyParentIfNeeded()
 	}
 
 	// Array is standalone.

--- a/basicarray.go
+++ b/basicarray.go
@@ -167,13 +167,7 @@ func (a *BasicArrayDataSlab) Set(storage SlabStorage, index uint64, v Storable) 
 		oldElem.ByteSize() +
 		v.ByteSize()
 
-	err := storage.Store(a.header.slabID, a)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.slabID))
-	}
-
-	return nil
+	return storeSlab(storage, a)
 }
 
 func (a *BasicArrayDataSlab) Insert(storage SlabStorage, index uint64, v Storable) error {
@@ -192,13 +186,7 @@ func (a *BasicArrayDataSlab) Insert(storage SlabStorage, index uint64, v Storabl
 	a.header.count++
 	a.header.size += v.ByteSize()
 
-	err := storage.Store(a.header.slabID, a)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.slabID))
-	}
-
-	return nil
+	return storeSlab(storage, a)
 }
 
 func (a *BasicArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable, error) {
@@ -221,10 +209,9 @@ func (a *BasicArrayDataSlab) Remove(storage SlabStorage, index uint64) (Storable
 	a.header.count--
 	a.header.size -= v.ByteSize()
 
-	err := storage.Store(a.header.slabID, a)
+	err := storeSlab(storage, a)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", a.header.slabID))
+		return nil, err
 	}
 
 	return v, nil

--- a/map.go
+++ b/map.go
@@ -915,10 +915,9 @@ func (e *inlineCollisionGroup) Set(
 				collisionGroup: true,
 			}
 
-			err = storage.Store(id, slab)
+			err = storeSlab(storage, slab)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return nil, nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", id))
+				return nil, nil, nil, err
 			}
 
 			// Create and return externalCollisionGroup (wrapper of newly created MapDataSlab)
@@ -3287,13 +3286,7 @@ func (m *MapDataSlab) Uninline(storage SlabStorage) error {
 	m.inlined = false
 
 	// Store slab in storage
-	err := storage.Store(m.header.slabID, m)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
-	}
-
-	return nil
+	return storeSlab(storage, m)
 }
 
 func elementsStorables(elems elements, childStorables []Storable) []Storable {
@@ -3374,10 +3367,9 @@ func (m *MapDataSlab) Set(
 
 	// Store modified slab
 	if !m.inlined {
-		err := storage.Store(m.header.slabID, m)
+		err := storeSlab(storage, m)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+			return nil, nil, err
 		}
 	}
 
@@ -3400,10 +3392,9 @@ func (m *MapDataSlab) Remove(storage SlabStorage, digester Digester, level uint,
 
 	// Store modified slab
 	if !m.inlined {
-		err := storage.Store(m.header.slabID, m)
+		err := storeSlab(storage, m)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+			return nil, nil, err
 		}
 	}
 
@@ -4164,10 +4155,9 @@ func (m *MapMetaDataSlab) Set(
 		return keyStorable, existingMapValueStorable, nil
 	}
 
-	err = storage.Store(m.header.slabID, m)
+	err = storeSlab(storage, m)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+		return nil, nil, err
 	}
 	return keyStorable, existingMapValueStorable, nil
 }
@@ -4231,10 +4221,9 @@ func (m *MapMetaDataSlab) Remove(storage SlabStorage, digester Digester, level u
 		return k, v, nil
 	}
 
-	err = storage.Store(m.header.slabID, m)
+	err = storeSlab(storage, m)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+		return nil, nil, err
 	}
 	return k, v, nil
 }
@@ -4261,25 +4250,17 @@ func (m *MapMetaDataSlab) SplitChildSlab(storage SlabStorage, child MapSlab, chi
 	m.header.size += mapSlabHeaderSize
 
 	// Store modified slabs
-	err = storage.Store(left.SlabID(), left)
+	err = storeSlab(storage, left)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", left.SlabID()))
+		return err
 	}
 
-	err = storage.Store(right.SlabID(), right)
+	err = storeSlab(storage, right)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", right.SlabID()))
+		return err
 	}
 
-	err = storage.Store(m.header.slabID, m)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
-	}
-
-	return nil
+	return storeSlab(storage, m)
 }
 
 // MergeOrRebalanceChildSlab merges or rebalances child slab.
@@ -4352,24 +4333,17 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 			}
 
 			// Store modified slabs
-			err = storage.Store(child.SlabID(), child)
+			err = storeSlab(storage, child)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.SlabID()))
+				return err
 			}
 
-			err = storage.Store(rightSib.SlabID(), rightSib)
+			err = storeSlab(storage, rightSib)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", rightSib.SlabID()))
+				return err
 			}
 
-			err = storage.Store(m.header.slabID, m)
-			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
-			}
-			return nil
+			return storeSlab(storage, m)
 		}
 
 		// Rebalance with left sib
@@ -4385,24 +4359,17 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 			m.childrenHeaders[childHeaderIndex] = child.Header()
 
 			// Store modified slabs
-			err = storage.Store(leftSib.SlabID(), leftSib)
+			err = storeSlab(storage, leftSib)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.SlabID()))
+				return err
 			}
 
-			err = storage.Store(child.SlabID(), child)
+			err = storeSlab(storage, child)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.SlabID()))
+				return err
 			}
 
-			err = storage.Store(m.header.slabID, m)
-			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
-			}
-			return nil
+			return storeSlab(storage, m)
 		}
 
 		// Rebalance with bigger sib
@@ -4418,24 +4385,18 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 			m.childrenHeaders[childHeaderIndex] = child.Header()
 
 			// Store modified slabs
-			err = storage.Store(leftSib.SlabID(), leftSib)
+			err = storeSlab(storage, leftSib)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.SlabID()))
+				return err
 			}
 
-			err = storage.Store(child.SlabID(), child)
+			err = storeSlab(storage, child)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.SlabID()))
+				return err
 			}
 
-			err = storage.Store(m.header.slabID, m)
-			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
-			}
-			return nil
+			return storeSlab(storage, m)
+
 		} else {
 			// leftSib.ByteSize() <= rightSib.ByteSize
 
@@ -4454,24 +4415,17 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 			}
 
 			// Store modified slabs
-			err = storage.Store(child.SlabID(), child)
+			err = storeSlab(storage, child)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.SlabID()))
+				return err
 			}
 
-			err = storage.Store(rightSib.SlabID(), rightSib)
+			err = storeSlab(storage, rightSib)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", rightSib.SlabID()))
+				return err
 			}
 
-			err = storage.Store(m.header.slabID, m)
-			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
-			}
-			return nil
+			return storeSlab(storage, m)
 		}
 	}
 
@@ -4500,15 +4454,14 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 		}
 
 		// Store modified slabs in storage
-		err = storage.Store(child.SlabID(), child)
+		err = storeSlab(storage, child)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.SlabID()))
+			return err
 		}
-		err = storage.Store(m.header.slabID, m)
+
+		err = storeSlab(storage, m)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+			return err
 		}
 
 		// Remove right sib from storage
@@ -4538,15 +4491,14 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 		m.header.size -= mapSlabHeaderSize
 
 		// Store modified slabs in storage
-		err = storage.Store(leftSib.SlabID(), leftSib)
+		err = storeSlab(storage, leftSib)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.SlabID()))
+			return err
 		}
-		err = storage.Store(m.header.slabID, m)
+
+		err = storeSlab(storage, m)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+			return err
 		}
 
 		// Remove child from storage
@@ -4575,15 +4527,14 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 		m.header.size -= mapSlabHeaderSize
 
 		// Store modified slabs in storage
-		err = storage.Store(leftSib.SlabID(), leftSib)
+		err = storeSlab(storage, leftSib)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", leftSib.SlabID()))
+			return err
 		}
-		err = storage.Store(m.header.slabID, m)
+
+		err = storeSlab(storage, m)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+			return err
 		}
 
 		// Remove child from storage
@@ -4616,15 +4567,14 @@ func (m *MapMetaDataSlab) MergeOrRebalanceChildSlab(
 		}
 
 		// Store modified slabs in storage
-		err = storage.Store(child.SlabID(), child)
+		err = storeSlab(storage, child)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", child.SlabID()))
+			return err
 		}
-		err = storage.Store(m.header.slabID, m)
+
+		err = storeSlab(storage, m)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.header.slabID))
+			return err
 		}
 
 		// Remove rightSib from storage
@@ -4874,10 +4824,9 @@ func NewMap(storage SlabStorage, address Address, digestBuilder DigesterBuilder,
 		extraData: extraData,
 	}
 
-	err = storage.Store(root.header.slabID, root)
+	err = storeSlab(storage, root)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", root.header.slabID))
+		return nil, err
 	}
 
 	return &OrderedMap{
@@ -5421,22 +5370,17 @@ func (m *OrderedMap) splitRoot() error {
 
 	m.root = newRoot
 
-	err = m.Storage.Store(left.SlabID(), left)
+	err = storeSlab(m.Storage, left)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", left.SlabID()))
+		return err
 	}
-	err = m.Storage.Store(right.SlabID(), right)
+
+	err = storeSlab(m.Storage, right)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", right.SlabID()))
+		return err
 	}
-	err = m.Storage.Store(m.root.SlabID(), m.root)
-	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.root.SlabID()))
-	}
-	return nil
+
+	return storeSlab(m.Storage, m.root)
 }
 
 func (m *OrderedMap) promoteChildAsNewRoot(childID SlabID) error {
@@ -5463,10 +5407,9 @@ func (m *OrderedMap) promoteChildAsNewRoot(childID SlabID) error {
 
 	m.root.SetExtraData(extraData)
 
-	err = m.Storage.Store(rootID, m.root)
+	err = storeSlab(m.Storage, m.root)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", rootID))
+		return err
 	}
 
 	err = m.Storage.Remove(childID)
@@ -6144,10 +6087,9 @@ func (m *OrderedMap) PopIterate(fn MapPopIterationFunc) error {
 
 	if !m.Inlined() {
 		// Save root slab
-		err = m.Storage.Store(m.root.SlabID(), m.root)
+		err = storeSlab(m.Storage, m.root)
 		if err != nil {
-			// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-			return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", m.root.SlabID()))
+			return err
 		}
 	}
 
@@ -6376,10 +6318,9 @@ func NewMapFromBatchData(
 
 		// Store all slabs
 		for _, slab := range slabs {
-			err = storage.Store(slab.SlabID(), slab)
+			err = storeSlab(storage, slab)
 			if err != nil {
-				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-				return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", slab.SlabID()))
+				return nil, err
 			}
 		}
 
@@ -6406,10 +6347,9 @@ func NewMapFromBatchData(
 	root.SetExtraData(extraData)
 
 	// Store root
-	err = storage.Store(root.SlabID(), root)
+	err = storeSlab(storage, root)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", root.SlabID()))
+		return nil, err
 	}
 
 	return &OrderedMap{

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -50,10 +50,9 @@ func NewStorableSlab(storage SlabStorage, address Address, storable Storable) (S
 		storable: storable,
 	}
 
-	err = storage.Store(id, slab)
+	err = storeSlab(storage, slab)
 	if err != nil {
-		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
-		return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", id))
+		return nil, err
 	}
 
 	return SlabIDStorable(id), nil

--- a/storage.go
+++ b/storage.go
@@ -1078,3 +1078,13 @@ func (s *PersistentSlabStorage) DeltasSizeWithoutTempAddresses() uint64 {
 	}
 	return size
 }
+
+func storeSlab(storage SlabStorage, slab Slab) error {
+	id := slab.SlabID()
+	err := storage.Store(id, slab)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to store slab %s", id))
+	}
+	return nil
+}


### PR DESCRIPTION
Updates #372 

This feature is needed by Cadence migrations to update static types.  For more details, see
- https://github.com/onflow/cadence/issues/3096#issuecomment-1977580596.

This PR adds `Array.SetType()` to allow updating `TypeInfo`.

NOTE: Implementation of this in atree inlining branch is different than non-inlining branch(es).
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
