### PR TITLE
Use encoded type info to deduplicate extra data

### DIFF
--- a/array.go
+++ b/array.go
@@ -720,14 +720,15 @@ func (a *ArrayDataSlab) encodeAsInlined(enc *Encoder) error {
 			fmt.Errorf("failed to encode standalone array data slab as inlined"))
 	}
 
-	extraDataIndex := enc.inlinedExtraData().addArrayExtraData(a.extraData)
+	extraDataIndex, err := enc.inlinedExtraData().addArrayExtraData(a.extraData)
+	if err != nil {
+		return NewEncodingError(err)
+	}
 
 	if extraDataIndex > maxInlinedExtraDataIndex {
 		return NewEncodingError(
 			fmt.Errorf("failed to encode inlined array data slab: extra data index %d exceeds limit %d", extraDataIndex, maxInlinedExtraDataIndex))
 	}
-
-	var err error
 
 	// Encode tag number and array head of 3 elements
 	err = enc.CBOR.EncodeRawBytes([]byte{

--- a/map.go
+++ b/map.go
@@ -3007,13 +3007,14 @@ func (m *MapDataSlab) encodeAsInlined(enc *Encoder) error {
 
 func (m *MapDataSlab) encodeAsInlinedMap(enc *Encoder) error {
 
-	extraDataIndex := enc.inlinedExtraData().addMapExtraData(m.extraData)
+	extraDataIndex, err := enc.inlinedExtraData().addMapExtraData(m.extraData)
+	if err != nil {
+		return NewEncodingError(err)
+	}
 
 	if extraDataIndex > maxInlinedExtraDataIndex {
 		return NewEncodingError(fmt.Errorf("extra data index %d exceeds limit %d", extraDataIndex, maxInlinedExtraDataIndex))
 	}
-
-	var err error
 
 	// Encode tag number and array head of 3 elements
 	err = enc.CBOR.EncodeRawBytes([]byte{
@@ -3067,7 +3068,10 @@ func encodeAsInlinedCompactMap(
 	values []Storable,
 ) error {
 
-	extraDataIndex, cachedKeys := enc.inlinedExtraData().addCompactMapExtraData(extraData, hkeys, keys)
+	extraDataIndex, cachedKeys, err := enc.inlinedExtraData().addCompactMapExtraData(extraData, hkeys, keys)
+	if err != nil {
+		return NewEncodingError(err)
+	}
 
 	if len(keys) != len(cachedKeys) {
 		return NewEncodingError(fmt.Errorf("number of elements %d is different from number of elements in cached compact map type %d", len(keys), len(cachedKeys)))
@@ -3077,8 +3081,6 @@ func encodeAsInlinedCompactMap(
 		// This should never happen because of slab size.
 		return NewEncodingError(fmt.Errorf("extra data index %d exceeds limit %d", extraDataIndex, maxInlinedExtraDataIndex))
 	}
-
-	var err error
 
 	// Encode tag number and array head of 3 elements
 	err = enc.CBOR.EncodeRawBytes([]byte{


### PR DESCRIPTION
This handles edge case for Cadence `type.ID()` returning same ID for different types.

Currently, we use `TypeInfo.Identifier()` to deduplicate extra data and type info.  However, `TypeInfo.Identifier()` is implemented in another package and we can't enforce its uniqueness for different types.  If `TypeInfo.Identifier()` returns same ID for different types, different types is wrongly deduplicated.

This PR uses encoded type info via `TypeInfo.Encode()` to deduplicate extra data.  This prevents differently encoded type info from being deduplicated by mistake.

This PR also uses `sync.Pool` to reuse buffer for type info encoding.

This problem was found by using latest testnet data for atree migration + Cadence v0.42. Prior tests using mainnet data did not encounter this issue.
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
