### PR TITLE
Add BatchPreload to decode slabs in parallel and cache

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -1561,12 +1561,16 @@ func (s *PersistentSlabStorage) getAllChildReferences(slab Slab) (
 	return references, brokenReferences, nil
 }
 
+// BatchPreload decodeds and caches slabs of given ids in parallel.
+// This is useful for storage health or data validation in migration programs.
 func (s *PersistentSlabStorage) BatchPreload(ids []SlabID, numWorkers int) error {
 	if len(ids) == 0 {
 		return nil
 	}
 
-	minCountForBatchPreload := 11
+	// Use 11 for min slab count for parallel decoding because micro benchmarks showed
+	// performance regression for <= 10 slabs when decoding slabs in parallel.
+	const minCountForBatchPreload = 11
 	if len(ids) < minCountForBatchPreload {
 
 		for _, id := range ids {

--- a/storage_bench_test.go
+++ b/storage_bench_test.go
@@ -132,3 +132,122 @@ func BenchmarkStorageNondeterministicFastCommit(b *testing.B) {
 	benchmarkNondeterministicFastCommit(b, fixedSeed, 100_000)
 	benchmarkNondeterministicFastCommit(b, fixedSeed, 1_000_000)
 }
+
+func benchmarkRetrieve(b *testing.B, seed int64, numberOfSlabs int) {
+
+	r := rand.New(rand.NewSource(seed))
+
+	encMode, err := cbor.EncOptions{}.EncMode()
+	require.NoError(b, err)
+
+	decMode, err := cbor.DecOptions{}.DecMode()
+	require.NoError(b, err)
+
+	encodedSlabs := make(map[SlabID][]byte)
+	ids := make([]SlabID, 0, numberOfSlabs)
+	for i := 0; i < numberOfSlabs; i++ {
+		addr := generateRandomAddress(r)
+
+		var index SlabIndex
+		binary.BigEndian.PutUint64(index[:], uint64(i))
+
+		id := SlabID{addr, index}
+
+		slab := generateLargeSlab(id)
+
+		data, err := EncodeSlab(slab, encMode)
+		require.NoError(b, err)
+
+		encodedSlabs[id] = data
+		ids = append(ids, id)
+	}
+
+	b.Run(strconv.Itoa(numberOfSlabs), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+
+			baseStorage := NewInMemBaseStorageFromMap(encodedSlabs)
+			storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, decodeStorable, decodeTypeInfo)
+
+			b.StartTimer()
+
+			for _, id := range ids {
+				_, found, err := storage.Retrieve(id)
+				require.True(b, found)
+				require.NoError(b, err)
+			}
+		}
+	})
+}
+
+func benchmarkBatchPreload(b *testing.B, seed int64, numberOfSlabs int) {
+
+	r := rand.New(rand.NewSource(seed))
+
+	encMode, err := cbor.EncOptions{}.EncMode()
+	require.NoError(b, err)
+
+	decMode, err := cbor.DecOptions{}.DecMode()
+	require.NoError(b, err)
+
+	encodedSlabs := make(map[SlabID][]byte)
+	ids := make([]SlabID, 0, numberOfSlabs)
+	for i := 0; i < numberOfSlabs; i++ {
+		addr := generateRandomAddress(r)
+
+		var index SlabIndex
+		binary.BigEndian.PutUint64(index[:], uint64(i))
+
+		id := SlabID{addr, index}
+
+		slab := generateLargeSlab(id)
+
+		data, err := EncodeSlab(slab, encMode)
+		require.NoError(b, err)
+
+		encodedSlabs[id] = data
+		ids = append(ids, id)
+	}
+
+	b.Run(strconv.Itoa(numberOfSlabs), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			b.StopTimer()
+
+			baseStorage := NewInMemBaseStorageFromMap(encodedSlabs)
+			storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, decodeStorable, decodeTypeInfo)
+
+			b.StartTimer()
+
+			err = storage.BatchPreload(ids, runtime.NumCPU())
+			require.NoError(b, err)
+
+			for _, id := range ids {
+				_, found, err := storage.Retrieve(id)
+				require.True(b, found)
+				require.NoError(b, err)
+			}
+		}
+	})
+}
+
+func BenchmarkStorageRetrieve(b *testing.B) {
+	fixedSeed := int64(1234567) // intentionally use fixed constant rather than time, etc.
+
+	benchmarkRetrieve(b, fixedSeed, 10)
+	benchmarkRetrieve(b, fixedSeed, 100)
+	benchmarkRetrieve(b, fixedSeed, 1_000)
+	benchmarkRetrieve(b, fixedSeed, 10_000)
+	benchmarkRetrieve(b, fixedSeed, 100_000)
+	benchmarkRetrieve(b, fixedSeed, 1_000_000)
+}
+
+func BenchmarkStorageBatchPreload(b *testing.B) {
+	fixedSeed := int64(1234567) // intentionally use fixed constant rather than time, etc.
+
+	benchmarkBatchPreload(b, fixedSeed, 10)
+	benchmarkBatchPreload(b, fixedSeed, 100)
+	benchmarkBatchPreload(b, fixedSeed, 1_000)
+	benchmarkBatchPreload(b, fixedSeed, 10_000)
+	benchmarkBatchPreload(b, fixedSeed, 100_000)
+	benchmarkBatchPreload(b, fixedSeed, 1_000_000)
+}

--- a/storage_test.go
+++ b/storage_test.go
@@ -19,6 +19,7 @@
 package atree
 
 import (
+	"encoding/binary"
 	"errors"
 	"math/rand"
 	"runtime"
@@ -4597,4 +4598,173 @@ func testStorageNondeterministicFastCommit(t *testing.T, numberOfAccounts int, n
 		require.False(t, found)
 		require.Nil(t, storedValue)
 	}
+}
+
+func TestStorageBatchPreload(t *testing.T) {
+	t.Run("0 slab", func(t *testing.T) {
+		numberOfAccounts := 0
+		numberOfSlabsPerAccount := 0
+		testStorageBatchPreload(t, numberOfAccounts, numberOfSlabsPerAccount)
+	})
+
+	t.Run("1 slab", func(t *testing.T) {
+		numberOfAccounts := 1
+		numberOfSlabsPerAccount := 1
+		testStorageBatchPreload(t, numberOfAccounts, numberOfSlabsPerAccount)
+	})
+
+	t.Run("10 slab", func(t *testing.T) {
+		numberOfAccounts := 1
+		numberOfSlabsPerAccount := 10
+		testStorageBatchPreload(t, numberOfAccounts, numberOfSlabsPerAccount)
+	})
+
+	t.Run("100 slabs", func(t *testing.T) {
+		numberOfAccounts := 10
+		numberOfSlabsPerAccount := 10
+		testStorageBatchPreload(t, numberOfAccounts, numberOfSlabsPerAccount)
+	})
+
+	t.Run("10_000 slabs", func(t *testing.T) {
+		numberOfAccounts := 10
+		numberOfSlabsPerAccount := 1_000
+		testStorageBatchPreload(t, numberOfAccounts, numberOfSlabsPerAccount)
+	})
+}
+
+func testStorageBatchPreload(t *testing.T, numberOfAccounts int, numberOfSlabsPerAccount int) {
+
+	indexesByAddress := make(map[Address]uint64)
+
+	generateSlabID := func(address Address) SlabID {
+		nextIndex := indexesByAddress[address] + 1
+
+		var idx SlabIndex
+		binary.BigEndian.PutUint64(idx[:], nextIndex)
+
+		indexesByAddress[address] = nextIndex
+
+		return NewSlabID(address, idx)
+	}
+
+	encMode, err := cbor.EncOptions{}.EncMode()
+	require.NoError(t, err)
+
+	decMode, err := cbor.DecOptions{}.DecMode()
+	require.NoError(t, err)
+
+	r := newRand(t)
+
+	encodedSlabs := make(map[SlabID][]byte)
+
+	// Generate and encode slabs
+	for i := 0; i < numberOfAccounts; i++ {
+
+		addr := generateRandomAddress(r)
+
+		for j := 0; j < numberOfSlabsPerAccount; j++ {
+
+			slabID := generateSlabID(addr)
+
+			slab := generateRandomSlab(slabID, r)
+
+			encodedSlabs[slabID], err = EncodeSlab(slab, encMode)
+			require.NoError(t, err)
+		}
+	}
+
+	baseStorage := NewInMemBaseStorageFromMap(encodedSlabs)
+	storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, decodeStorable, decodeTypeInfo)
+
+	ids := make([]SlabID, 0, len(encodedSlabs))
+	for id := range encodedSlabs {
+		ids = append(ids, id)
+	}
+
+	// Batch preload slabs from base storage
+	err = storage.BatchPreload(ids, runtime.NumCPU())
+	require.NoError(t, err)
+	require.Equal(t, len(encodedSlabs), len(storage.cache))
+	require.Equal(t, 0, len(storage.deltas))
+
+	// Compare encoded data
+	for id, data := range encodedSlabs {
+		cachedData, err := EncodeSlab(storage.cache[id], encMode)
+		require.NoError(t, err)
+
+		require.Equal(t, cachedData, data)
+	}
+}
+
+func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
+
+	encMode, err := cbor.EncOptions{}.EncMode()
+	require.NoError(t, err)
+
+	decMode, err := cbor.DecOptions{}.DecMode()
+	require.NoError(t, err)
+
+	r := newRand(t)
+
+	t.Run("empty storage", func(t *testing.T) {
+		const numberOfSlabs = 10
+
+		ids := make([]SlabID, numberOfSlabs)
+		for i := 0; i < numberOfSlabs; i++ {
+			var index SlabIndex
+			binary.BigEndian.PutUint64(index[:], uint64(i))
+
+			ids[i] = NewSlabID(generateRandomAddress(r), index)
+		}
+
+		baseStorage := NewInMemBaseStorage()
+		storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, decodeStorable, decodeTypeInfo)
+
+		err := storage.BatchPreload(ids, runtime.NumCPU())
+		require.NoError(t, err)
+
+		require.Equal(t, 0, len(storage.cache))
+		require.Equal(t, 0, len(storage.deltas))
+	})
+
+	t.Run("non-empty storage", func(t *testing.T) {
+		const numberOfSlabs = 10
+
+		ids := make([]SlabID, numberOfSlabs)
+		encodedSlabs := make(map[SlabID][]byte)
+
+		for i := 0; i < numberOfSlabs; i++ {
+			var index SlabIndex
+			binary.BigEndian.PutUint64(index[:], uint64(i))
+
+			id := NewSlabID(generateRandomAddress(r), index)
+
+			slab := generateRandomSlab(id, r)
+
+			encodedSlabs[id], err = EncodeSlab(slab, encMode)
+			require.NoError(t, err)
+
+			ids[i] = id
+		}
+
+		// Append a slab ID that doesn't exist in storage.
+		ids = append(ids, NewSlabID(generateRandomAddress(r), SlabIndex{numberOfSlabs}))
+
+		baseStorage := NewInMemBaseStorageFromMap(encodedSlabs)
+		storage := NewPersistentSlabStorage(baseStorage, encMode, decMode, decodeStorable, decodeTypeInfo)
+
+		err := storage.BatchPreload(ids, runtime.NumCPU())
+		require.NoError(t, err)
+
+		require.Equal(t, len(encodedSlabs), len(storage.cache))
+		require.Equal(t, 0, len(storage.deltas))
+
+		// Compare encoded data
+		for id, data := range encodedSlabs {
+			cachedData, err := EncodeSlab(storage.cache[id], encMode)
+			require.NoError(t, err)
+
+			require.Equal(t, cachedData, data)
+		}
+	})
 }


### PR DESCRIPTION
Updates #394

This PR adds `BatchPreload` which decodes slabs in parallel and stores decoded slabs in cache for later retrieval.

Migration benchmark (not available yet) will use https://github.com/onflow/flow-go/tree/feature/atree-inlining-cadence-v0.42

Casual microbenchmark (on my busy desktop):

```
                           │  before.txt  │              after.txt               │
                           │    sec/op    │    sec/op     vs base                │
StorageRetrieve/10-12         36.23µ ± 3%   35.33µ ±  4%        ~ (p=0.075 n=10)
StorageRetrieve/100-12        469.6µ ± 8%   124.3µ ±  0%  -73.52% (p=0.000 n=10)
StorageRetrieve/1000-12       6.678m ± 7%   2.303m ± 20%  -65.51% (p=0.000 n=10)
StorageRetrieve/10000-12      29.81m ± 2%   12.26m ±  5%  -58.86% (p=0.000 n=10)
StorageRetrieve/100000-12    303.33m ± 1%   88.40m ±  1%  -70.86% (p=0.000 n=10)
StorageRetrieve/1000000-12     3.442 ± 1%    1.137 ±  3%  -66.96% (p=0.000 n=10)
geomean                       12.34m        4.816m        -60.98%

                           │  before.txt  │              after.txt              │
                           │     B/op     │     B/op      vs base               │
StorageRetrieve/10-12        21.59Ki ± 0%   21.59Ki ± 0%       ~ (p=1.000 n=10)
StorageRetrieve/100-12       219.8Ki ± 0%   224.7Ki ± 0%  +2.24% (p=0.000 n=10)
StorageRetrieve/1000-12      2.266Mi ± 0%   2.272Mi ± 0%  +0.27% (p=0.000 n=10)
StorageRetrieve/10000-12     21.94Mi ± 0%   22.14Mi ± 0%  +0.91% (p=0.000 n=10)
StorageRetrieve/100000-12    215.3Mi ± 0%   218.5Mi ± 0%  +1.50% (p=0.000 n=10)
StorageRetrieve/1000000-12   2.211Gi ± 0%   2.212Gi ± 0%  +0.05% (p=0.000 n=10)
geomean                      6.919Mi        6.976Mi       +0.82%

                           │ before.txt  │              after.txt               │
                           │  allocs/op  │  allocs/op   vs base                 │
StorageRetrieve/10-12         76.00 ± 0%    76.00 ± 0%       ~ (p=1.000 n=10) ¹
StorageRetrieve/100-12        745.0 ± 0%    759.0 ± 0%  +1.88% (p=0.000 n=10)
StorageRetrieve/1000-12      7.161k ± 0%   7.153k ± 0%  -0.11% (p=0.000 n=10)
StorageRetrieve/10000-12     70.77k ± 0%   70.58k ± 0%  -0.27% (p=0.000 n=10)
StorageRetrieve/100000-12    711.9k ± 0%   709.7k ± 0%  -0.31% (p=0.000 n=10)
StorageRetrieve/1000000-12   7.115M ± 0%   7.077M ± 0%  -0.54% (p=0.000 n=10)
geomean                      22.93k        22.95k       +0.11%
```
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
