### PR TITLE
Check mutation of elements from readonly map iterator

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -456,6 +456,24 @@ func (e *MapElementCountError) Error() string {
 	return e.msg
 }
 
+// ReadOnlyIteratorElementMutationError is the error returned when readonly iterator element is mutated.
+type ReadOnlyIteratorElementMutationError struct {
+	containerValueID ValueID
+	elementValueID   ValueID
+}
+
+// NewReadOnlyIteratorElementMutationError creates ReadOnlyIteratorElementMutationError.
+func NewReadOnlyIteratorElementMutationError(containerValueID, elementValueID ValueID) error {
+	return NewFatalError(&ReadOnlyIteratorElementMutationError{
+		containerValueID: containerValueID,
+		elementValueID:   elementValueID,
+	})
+}
+
+func (e *ReadOnlyIteratorElementMutationError) Error() string {
+	return fmt.Sprintf("element (%s) cannot be mutated because it is from readonly iterator of container (%s)", e.elementValueID, e.containerValueID)
+}
+
 func wrapErrorAsExternalErrorIfNeeded(err error) error {
 	return wrapErrorfAsExternalErrorIfNeeded(err, "")
 }


### PR DESCRIPTION
Updates #409

Projects using atree might unintentionally mutate elements returned by readonly iterators.

As always, mutation of elements from readonly iterators are not guaranteed to persist.

This PR returns error from mutation functions, and supports callback functions that allow projects using atree to log or debug such mutations with extra context, panic, etc.

If elements from readonly iterators are mutated:
- those changes are not guaranteed to persist.
- mutation functions of child containers return `ReadOnlyIteratorElementMutationError`.
- `ReadOnlyMapIteratorMutationCallback` are called (if provided and mutation occurs).

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 