### PR TITLE
Update comment for NondeterministicFastCommit

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -969,8 +969,10 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 	return nil
 }
 
-// NondeterministicFastCommit commits changes in nondeterministic order.
-// This is used by migration program when ordering isn't required.
+// NondeterministicFastCommit commits changed slabs in nondeterministic order.
+// Encoded slab data is deterministic (e.g. array and map iteration is deterministic).
+// IMPORTANT: This function is used by migration programs when commit order of slabs
+// is not required to be deterministic (while preserving deterministic array and map iteration).
 func (s *PersistentSlabStorage) NondeterministicFastCommit(numWorkers int) error {
 	// No changes
 	if len(s.deltas) == 0 {


### PR DESCRIPTION
This PR updates comments to mention that encoded slabs are still deterministic, so array and map iterations will remain deterministic.  Only the sequence of changed slabs getting committed is nondeterministic.

`NondeterministicFastCommit` is used by migration programs that don't require commit sequence of slabs to be deterministic while still preserving deterministic encoding of slab data (e.g. iteration of arrays and maps remain deterministic).
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
