### PR TITLE
Add functions to check availablility of CBOR tag numbers

### DIFF
--- a/storable.go
+++ b/storable.go
@@ -73,8 +73,27 @@ func hasPointer(storable Storable) bool {
 const (
 	// WARNING: tag numbers defined in here in github.com/onflow/atree
 	// MUST not overlap with tag numbers used by Cadence internal value encoding.
-	// As of Oct. 2, 2023, Cadence uses tag numbers from 128 to 224.
+	// As of Aug. 14, 2024, Cadence uses tag numbers from 128 to 230.
 	// See runtime/interpreter/encode.go at github.com/onflow/cadence.
+
+	// Atree reserves CBOR tag numbers [240, 255] for internal use.
+	// Applications must use non-overlapping CBOR tag numbers to encode
+	// elements managed by atree containers.
+	minInternalCBORTagNumber = 240
+	maxInternalCBORTagNumber = 255
+
+	// Reserved CBOR tag numbers for atree internal use.
+
+	// Replace _ when new tag number is needed (use higher tag numbers first).
+	// Atree will use higher tag numbers first because Cadence will use lower tag numbers first.
+	// This approach allows more flexibility in case we need to revisit ranges used by Atree and Cadence.
+
+	_ = 240
+	_ = 241
+	_ = 242
+	_ = 243
+	_ = 244
+	_ = 245
 
 	CBORTagTypeInfoRef = 246
 
@@ -91,6 +110,22 @@ const (
 
 	CBORTagSlabID = 255
 )
+
+// IsCBORTagNumberRangeAvailable returns true if the specified range is not reserved for internal use by atree.
+// Applications must only use available (unreserved) CBOR tag numbers to encode elements in atree managed containers.
+func IsCBORTagNumberRangeAvailable(minTagNum, maxTagNum uint64) (bool, error) {
+	if minTagNum > maxTagNum {
+		return false, NewUserError(fmt.Errorf("min CBOR tag number %d must be <= max CBOR tag number %d", minTagNum, maxTagNum))
+	}
+
+	return maxTagNum < minInternalCBORTagNumber || minTagNum > maxInternalCBORTagNumber, nil
+}
+
+// ReservedCBORTagNumberRange returns minTagNum and maxTagNum of the range of CBOR tag numbers
+// reserved for internal use by atree.
+func ReservedCBORTagNumberRange() (minTagNum, maxTagNum uint64) {
+	return minInternalCBORTagNumber, maxInternalCBORTagNumber
+}
 
 type SlabIDStorable SlabID
 


### PR DESCRIPTION
This PR:
* Adds `IsCBORTagNumberRangeAvailable()`
* Adds `ReservedCBORTagNumberRange()`
* Reserves CBOR tag numbers [240, 255] for atree internal use

`IsCBORTagNumberRangeAvailable()` checks if specified range of CBOR tag numbers can be used to encode elements managed by atree containers.

`ReservedCBORTagNumberRange()` returns minTagNum and maxTagNum of the range of CBOR tag numbers reserved by atree.

Currently, Atree and Cadence uses CBOR tag numbers:
* Atree: 246 to 255
* Cadence: 128 to 230 to encode internal Cadence values

This PR reserves CBOR tag numbers [240, 255] for atree internal use. Applications must use unreserved CBOR tag numbers to encode elements managed by atree containers.

When a new tag number is needed, Atree will use higher tag number first from its reserved range.  By contrast, Cadence will use lower tag numbers first from its own (different) reserved range. This allows Atree and Cadence more flexibility in case we need to revisit the allocation of adjacent unused ranges for Atree and Cadence.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
