### PR TITLE
Make smoke tests check if CBOR tag nums are reserved

### DIFF
--- a/cmd/stress/storable.go
+++ b/cmd/stress/storable.go
@@ -32,11 +32,62 @@ import (
 // This file contains value implementations for testing purposes.
 
 const (
+	reservedMinTagNum                 = 161
+	reservedMinTagNumForContainerType = 230
+	reservedMaxTagNum                 = 239
+)
+
+const (
+	// CBOR tag numbers used to encode elements.
+
 	cborTagUInt8Value  = 161
 	cborTagUInt16Value = 162
 	cborTagUInt32Value = 163
 	cborTagUInt64Value = 164
+
+	// CBOR tag numbers in this block cannot exceed 230 (reservedMinTagNumForContainerType).
 )
+
+const (
+	// CBOR tag numbers used to encode container types.
+	// Replace _ when new tag number is needed (use lower tag numbers first).
+
+	arrayTypeTagNum = reservedMinTagNumForContainerType + iota
+	compositeTypeTagNum
+	mapTypeTagNum
+	_
+	_
+	_
+	_
+	_
+	_
+	_
+)
+
+func init() {
+	// Check if the CBOR tag number range is reserved for internal use by atree.
+	// Smoke tests must only use available (unreserved by atree) CBOR tag numbers
+	// to encode elements in atree managed containers.
+
+	// As of Aug 15, 2024:
+	// - Atree reserves CBOR tag numbers [240, 255] for atree internal use.
+	// - Smoke tests reserve CBOR tag numbers [161, 239] to encode elements.
+
+	tagNumOK, err := atree.IsCBORTagNumberRangeAvailable(reservedMinTagNum, reservedMaxTagNum)
+	if err != nil {
+		panic(err)
+	}
+
+	if !tagNumOK {
+		atreeMinTagNum, atreeMaxTagNum := atree.ReservedCBORTagNumberRange()
+		panic(fmt.Errorf(
+			"smoke test tag numbers [%d, %d] overlaps with atree internal tag numbers [%d, %d]",
+			reservedMinTagNum,
+			reservedMaxTagNum,
+			atreeMinTagNum,
+			atreeMaxTagNum))
+	}
+}
 
 type Uint8Value uint8
 

--- a/cmd/stress/typeinfo.go
+++ b/cmd/stress/typeinfo.go
@@ -29,10 +29,6 @@ import (
 const (
 	maxArrayTypeValue = 10
 	maxMapTypeValue   = 10
-
-	arrayTypeTagNum     = 246
-	mapTypeTagNum       = 245
-	compositeTypeTagNum = 244
 )
 
 type arrayTypeInfo struct {
@@ -51,10 +47,6 @@ func (i arrayTypeInfo) Copy() atree.TypeInfo {
 
 func (i arrayTypeInfo) IsComposite() bool {
 	return false
-}
-
-func (i arrayTypeInfo) Identifier() string {
-	return fmt.Sprintf("array(%d)", i)
 }
 
 func (i arrayTypeInfo) Encode(e *cbor.StreamEncoder) error {
@@ -86,10 +78,6 @@ func (i mapTypeInfo) Copy() atree.TypeInfo {
 
 func (i mapTypeInfo) IsComposite() bool {
 	return false
-}
-
-func (i mapTypeInfo) Identifier() string {
-	return fmt.Sprintf("map(%d)", i)
 }
 
 func (i mapTypeInfo) Encode(e *cbor.StreamEncoder) error {
@@ -151,10 +139,6 @@ func (i compositeTypeInfo) Copy() atree.TypeInfo {
 
 func (i compositeTypeInfo) IsComposite() bool {
 	return true
-}
-
-func (i compositeTypeInfo) Identifier() string {
-	return fmt.Sprintf("composite(%d_%d)", i.fieldStartIndex, i.fieldEndIndex)
 }
 
 func (i compositeTypeInfo) Encode(e *cbor.StreamEncoder) error {


### PR DESCRIPTION
This PR checks if CBOR tag number is reserved by atree for internal use before smoke tests use it to encode Cadence values as elements in atree containers.

As of Aug 15, 2024:
- Atree reserves CBOR tag numbers [240, 255] for internal use.
- Smoke tests reserves CBOR tag numbers [161, 239] for encoding elements in atree containers.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
