### PR TITLE
Add function to check if address has unsaved changes in storage

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -594,6 +594,16 @@ type PersistentSlabStorage struct {
 
 var _ SlabStorage = &PersistentSlabStorage{}
 
+// HasUnsavedChanges returns true if there are any modified and unsaved slabs in storage with given address.
+func (s *PersistentSlabStorage) HasUnsavedChanges(address Address) bool {
+	for k := range s.deltas {
+		if k.address == address {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *PersistentSlabStorage) SlabIterator() (SlabIterator, error) {
 
 	var slabs []struct {
@@ -601,6 +611,7 @@ func (s *PersistentSlabStorage) SlabIterator() (SlabIterator, error) {
 		Slab
 	}
 
+	// Get slabs connected to slab from base storage and append those slabs to slabs slice.
 	appendChildStorables := func(slab Slab) error {
 		childStorables := slab.ChildStorables()
 
@@ -659,6 +670,7 @@ func (s *PersistentSlabStorage) SlabIterator() (SlabIterator, error) {
 		return nil
 	}
 
+	// Append slab and slabs connected to it to slabs slice.
 	appendSlab := func(id SlabID, slab Slab) error {
 		slabs = append(slabs, struct {
 			SlabID


### PR DESCRIPTION
This PR adds the new function `HasUnsavedChanges` to indicate if there are any modified and unsaved slabs in storage for a given address.

```Go
func (s *PersistentSlabStorage) HasUnsavedChanges(address Address) bool 
```

Updates Cadence issue https://github.com/onflow/cadence/issues/3584

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
