### PR TITLE
Rename and export `SlabIDLength` and related constants

### DIFF
--- a/array_debug.go
+++ b/array_debug.go
@@ -826,7 +826,7 @@ func computeSize(data []byte) (int, error) {
 	size -= inlinedSlabExtrDataSize
 
 	if !h.isRoot() && isDataSlab && !h.hasNextSlabID() {
-		size += slabIDSize
+		size += SlabIDLength
 	}
 
 	return size, nil
@@ -954,22 +954,22 @@ func verifyArrayValueID(a *Array) error {
 
 	vid := a.ValueID()
 
-	if !bytes.Equal(vid[:slabAddressSize], rootSlabID.address[:]) {
+	if !bytes.Equal(vid[:SlabAddressLength], rootSlabID.address[:]) {
 		return NewFatalError(
 			fmt.Errorf(
 				"expect first %d bytes of array value ID as %v, got %v",
-				slabAddressSize,
+				SlabAddressLength,
 				rootSlabID.address[:],
-				vid[:slabAddressSize]))
+				vid[:SlabAddressLength]))
 	}
 
-	if !bytes.Equal(vid[slabAddressSize:], rootSlabID.index[:]) {
+	if !bytes.Equal(vid[SlabAddressLength:], rootSlabID.index[:]) {
 		return NewFatalError(
 			fmt.Errorf(
 				"expect second %d bytes of array value ID as %v, got %v",
-				slabIndexSize,
+				SlabIndexLength,
 				rootSlabID.index[:],
-				vid[slabAddressSize:]))
+				vid[SlabAddressLength:]))
 	}
 
 	return nil

--- a/array_test.go
+++ b/array_test.go
@@ -5027,7 +5027,7 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	// Size of root data slab with two elements of max inlined size is target slab size minus
 	// slab id size (next slab id is omitted in root slab), and minus 1 byte
 	// (for rounding when computing max inline array element size).
-	require.Equal(t, targetThreshold-slabIDSize-1, uint64(array.root.Header().size))
+	require.Equal(t, targetThreshold-SlabIDLength-1, uint64(array.root.Header().size))
 
 	testArray(t, storage, typeInfo, address, array, values, false)
 }
@@ -6025,8 +6025,8 @@ func TestArrayID(t *testing.T) {
 	sid := array.SlabID()
 	id := array.ValueID()
 
-	require.Equal(t, sid.address[:], id[:8])
-	require.Equal(t, sid.index[:], id[8:])
+	require.Equal(t, sid.address[:], id[:SlabAddressLength])
+	require.Equal(t, sid.index[:], id[SlabAddressLength:])
 }
 
 func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
@@ -6118,8 +6118,8 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 		valueID := childArray.ValueID()
-		require.Equal(t, address[:], valueID[:slabAddressSize])
-		require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+		require.Equal(t, address[:], valueID[:SlabAddressLength])
+		require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 		v := NewStringValue(strings.Repeat("a", 9))
 		vSize := v.size
@@ -6245,8 +6245,8 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 			valueID := childArray.ValueID()
-			require.Equal(t, address[:], valueID[:slabAddressSize])
-			require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+			require.Equal(t, address[:], valueID[:SlabAddressLength])
+			require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 			children[i].array = childArray
 			children[i].valueID = valueID
@@ -6445,8 +6445,8 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 			valueID := childArray.ValueID()
-			require.Equal(t, address[:], valueID[:slabAddressSize])
-			require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+			require.Equal(t, address[:], valueID[:SlabAddressLength])
+			require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 			children[i].array = childArray
 			children[i].valueID = valueID
@@ -6638,8 +6638,8 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 		valueID := childArray.ValueID()
-		require.Equal(t, address[:], valueID[:slabAddressSize])
-		require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+		require.Equal(t, address[:], valueID[:SlabAddressLength])
+		require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 		// Get inlined grand child array
 		e, err = childArray.Get(0)
@@ -6652,9 +6652,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, SlabIDUndefined, gchildArray.SlabID())
 
 		gValueID := gchildArray.ValueID()
-		require.Equal(t, address[:], gValueID[:slabAddressSize])
-		require.NotEqual(t, SlabIndexUndefined[:], gValueID[slabAddressSize:])
-		require.NotEqual(t, valueID[slabAddressSize:], gValueID[slabAddressSize:])
+		require.Equal(t, address[:], gValueID[:SlabAddressLength])
+		require.NotEqual(t, SlabIndexUndefined[:], gValueID[SlabAddressLength:])
+		require.NotEqual(t, valueID[SlabAddressLength:], gValueID[SlabAddressLength:])
 
 		v := NewStringValue(strings.Repeat("a", 9))
 		vSize := v.size
@@ -6833,8 +6833,8 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 		valueID := childArray.ValueID()
-		require.Equal(t, address[:], valueID[:slabAddressSize])
-		require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+		require.Equal(t, address[:], valueID[:SlabAddressLength])
+		require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 		// Get inlined grand child array
 		e, err = childArray.Get(0)
@@ -6847,9 +6847,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, SlabIDUndefined, gchildArray.SlabID())
 
 		gValueID := gchildArray.ValueID()
-		require.Equal(t, address[:], gValueID[:slabAddressSize])
-		require.NotEqual(t, SlabIndexUndefined[:], gValueID[slabAddressSize:])
-		require.NotEqual(t, valueID[slabAddressSize:], gValueID[slabAddressSize:])
+		require.Equal(t, address[:], gValueID[:SlabAddressLength])
+		require.NotEqual(t, SlabIndexUndefined[:], gValueID[SlabAddressLength:])
+		require.NotEqual(t, valueID[SlabAddressLength:], gValueID[SlabAddressLength:])
 
 		v := NewStringValue(strings.Repeat("a", 9))
 		vSize := v.size
@@ -7066,8 +7066,8 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 			valueID := childArray.ValueID()
-			require.Equal(t, address[:], valueID[:slabAddressSize])
-			require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+			require.Equal(t, address[:], valueID[:SlabAddressLength])
+			require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 			e, err = childArray.Get(0)
 			require.NoError(t, err)
@@ -7079,9 +7079,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, SlabIDUndefined, gchildArray.SlabID())
 
 			gValueID := gchildArray.ValueID()
-			require.Equal(t, address[:], gValueID[:slabAddressSize])
-			require.NotEqual(t, SlabIndexUndefined[:], gValueID[slabAddressSize:])
-			require.NotEqual(t, valueID[slabAddressSize:], gValueID[slabAddressSize:])
+			require.Equal(t, address[:], gValueID[:SlabAddressLength])
+			require.NotEqual(t, SlabIndexUndefined[:], gValueID[SlabAddressLength:])
+			require.NotEqual(t, valueID[SlabAddressLength:], gValueID[SlabAddressLength:])
 
 			children[i] = arrayInfo{
 				array:   childArray,
@@ -7362,8 +7362,8 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 			valueID := childArray.ValueID()
-			require.Equal(t, address[:], valueID[:slabAddressSize])
-			require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+			require.Equal(t, address[:], valueID[:SlabAddressLength])
+			require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 			e, err = childArray.Get(0)
 			require.NoError(t, err)
@@ -7375,9 +7375,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, SlabIDUndefined, gchildArray.SlabID())
 
 			gValueID := gchildArray.ValueID()
-			require.Equal(t, address[:], gValueID[:slabAddressSize])
-			require.NotEqual(t, SlabIndexUndefined[:], gValueID[slabAddressSize:])
-			require.NotEqual(t, valueID[slabAddressSize:], gValueID[slabAddressSize:])
+			require.Equal(t, address[:], gValueID[:SlabAddressLength])
+			require.NotEqual(t, SlabIndexUndefined[:], gValueID[SlabAddressLength:])
+			require.NotEqual(t, valueID[SlabAddressLength:], gValueID[SlabAddressLength:])
 
 			children[i] = arrayInfo{
 				array:   childArray,
@@ -7695,8 +7695,8 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 		require.Equal(t, SlabIDUndefined, childArray.SlabID())
 
 		valueID := childArray.ValueID()
-		require.Equal(t, address[:], valueID[:slabAddressSize])
-		require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+		require.Equal(t, address[:], valueID[:SlabAddressLength])
+		require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 
 		children[i] = &struct {
 			array       *Array

--- a/map_debug.go
+++ b/map_debug.go
@@ -1407,22 +1407,22 @@ func verifyMapValueID(m *OrderedMap) error {
 
 	vid := m.ValueID()
 
-	if !bytes.Equal(vid[:slabAddressSize], rootSlabID.address[:]) {
+	if !bytes.Equal(vid[:SlabAddressLength], rootSlabID.address[:]) {
 		return NewFatalError(
 			fmt.Errorf(
 				"expect first %d bytes of array value ID as %v, got %v",
-				slabAddressSize,
+				SlabAddressLength,
 				rootSlabID.address[:],
-				vid[:slabAddressSize]))
+				vid[:SlabAddressLength]))
 	}
 
-	if !bytes.Equal(vid[slabAddressSize:], rootSlabID.index[:]) {
+	if !bytes.Equal(vid[SlabAddressLength:], rootSlabID.index[:]) {
 		return NewFatalError(
 			fmt.Errorf(
 				"expect second %d bytes of array value ID as %v, got %v",
-				slabIndexSize,
+				SlabIndexLength,
 				rootSlabID.index[:],
-				vid[slabAddressSize:]))
+				vid[SlabAddressLength:]))
 	}
 
 	return nil

--- a/map_test.go
+++ b/map_test.go
@@ -8610,7 +8610,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
 
 		const inlinedExtraDataSize = 8
-		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+slabIDSize), meta.childrenHeaders[1].size)
+		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+SlabIDLength), meta.childrenHeaders[1].size)
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -11798,7 +11798,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, 2, len(meta.childrenHeaders))
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
-		require.Equal(t, uint32(len(stored[id3])+slabIDSize), meta.childrenHeaders[1].size)
+		require.Equal(t, uint32(len(stored[id3])+SlabIDLength), meta.childrenHeaders[1].size)
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -14338,7 +14338,7 @@ func TestMapMaxInlineElement(t *testing.T) {
 	// Size of root data slab with two elements (key+value pairs) of
 	// max inlined size is target slab size minus
 	// slab id size (next slab id is omitted in root slab)
-	require.Equal(t, targetThreshold-slabIDSize, uint64(m.root.Header().size))
+	require.Equal(t, targetThreshold-SlabIDLength, uint64(m.root.Header().size))
 
 	testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 }
@@ -16492,8 +16492,8 @@ func TestMapID(t *testing.T) {
 	sid := m.SlabID()
 	id := m.ValueID()
 
-	require.Equal(t, sid.address[:], id[:8])
-	require.Equal(t, sid.index[:], id[8:])
+	require.Equal(t, sid.address[:], id[:SlabAddressLength])
+	require.Equal(t, sid.index[:], id[SlabAddressLength:])
 }
 
 func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {

--- a/storable.go
+++ b/storable.go
@@ -180,7 +180,7 @@ func (v SlabIDStorable) Encode(enc *Encoder) error {
 	copy(enc.Scratch[:], v.address[:])
 	copy(enc.Scratch[8:], v.index[:])
 
-	err = enc.CBOR.EncodeBytes(enc.Scratch[:slabIDSize])
+	err = enc.CBOR.EncodeBytes(enc.Scratch[:SlabIDLength])
 	if err != nil {
 		return NewEncodingError(err)
 	}
@@ -190,7 +190,7 @@ func (v SlabIDStorable) Encode(enc *Encoder) error {
 
 func (v SlabIDStorable) ByteSize() uint32 {
 	// tag number (2 bytes) + byte string header (1 byte) + slab id (16 bytes)
-	return 2 + 1 + slabIDSize
+	return 2 + 1 + SlabIDLength
 }
 
 func (v SlabIDStorable) String() string {

--- a/storage_test.go
+++ b/storage_test.go
@@ -116,46 +116,46 @@ func TestSlabIDToRawBytes(t *testing.T) {
 	})
 
 	t.Run("undefined", func(t *testing.T) {
-		b := make([]byte, slabIDSize)
+		b := make([]byte, SlabIDLength)
 		size, err := SlabIDUndefined.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 		require.Equal(t, want, b)
-		require.Equal(t, slabIDSize, size)
+		require.Equal(t, SlabIDLength, size)
 	})
 
 	t.Run("temp address", func(t *testing.T) {
 		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 0}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
-		b := make([]byte, slabIDSize)
+		b := make([]byte, SlabIDLength)
 		size, err := id.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
 		require.Equal(t, want, b)
-		require.Equal(t, slabIDSize, size)
+		require.Equal(t, SlabIDLength, size)
 	})
 
 	t.Run("temp index", func(t *testing.T) {
 		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 1}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 0})
-		b := make([]byte, slabIDSize)
+		b := make([]byte, SlabIDLength)
 		size, err := id.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}
 		require.Equal(t, want, b)
-		require.Equal(t, slabIDSize, size)
+		require.Equal(t, SlabIDLength, size)
 	})
 
 	t.Run("perm", func(t *testing.T) {
 		id := NewSlabID(Address{0, 0, 0, 0, 0, 0, 0, 1}, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
-		b := make([]byte, slabIDSize)
+		b := make([]byte, SlabIDLength)
 		size, err := id.ToRawBytes(b)
 		require.NoError(t, err)
 
 		want := []byte{0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2}
 		require.Equal(t, want, b)
-		require.Equal(t, slabIDSize, size)
+		require.Equal(t, SlabIDLength, size)
 	})
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -395,8 +395,8 @@ func mapEqual(t *testing.T, expected mapValue, actual *OrderedMap) {
 
 func valueIDToSlabID(vid ValueID) SlabID {
 	var id SlabID
-	copy(id.address[:], vid[:slabAddressSize])
-	copy(id.index[:], vid[slabAddressSize:])
+	copy(id.address[:], vid[:SlabAddressLength])
+	copy(id.index[:], vid[SlabAddressLength:])
 	return id
 }
 
@@ -411,16 +411,16 @@ func testNotInlinedMapIDs(t *testing.T, address Address, m *OrderedMap) {
 func testInlinedSlabIDAndValueID(t *testing.T, expectedAddress Address, slabID SlabID, valueID ValueID) {
 	require.Equal(t, SlabIDUndefined, slabID)
 
-	require.Equal(t, expectedAddress[:], valueID[:slabAddressSize])
-	require.NotEqual(t, SlabIndexUndefined[:], valueID[slabAddressSize:])
+	require.Equal(t, expectedAddress[:], valueID[:SlabAddressLength])
+	require.NotEqual(t, SlabIndexUndefined[:], valueID[SlabAddressLength:])
 }
 
 func testNotInlinedSlabIDAndValueID(t *testing.T, expectedAddress Address, slabID SlabID, valueID ValueID) {
 	require.Equal(t, expectedAddress, slabID.address)
 	require.NotEqual(t, SlabIndexUndefined, slabID.index)
 
-	require.Equal(t, slabID.address[:], valueID[:slabAddressSize])
-	require.Equal(t, slabID.index[:], valueID[slabAddressSize:])
+	require.Equal(t, slabID.address[:], valueID[:SlabAddressLength])
+	require.Equal(t, slabID.index[:], valueID[SlabAddressLength:])
 }
 
 type arrayValue []Value


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

This PR renames and exports these constants:
- `SlabAddressLength`
- `SlabIndexLength`
- `SlabIDLength`
- `ValueIDLength`

While at it, this PR also replaces hard-coded number with these constants if applicable.
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
