### PR TITLE
Export PersistentSlabStorage funcs in export_test.go

### DIFF
--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -168,8 +168,10 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	require.NoError(b, storage.Commit())
 	totalLookupTime = time.Since(start)
 
+	baseStorage := GetBaseStorage(storage)
+
 	// random lookup
-	storage.baseStorage.ResetReporter()
+	baseStorage.ResetReporter()
 	storage.DropCache()
 	array, err = NewArrayWithRootID(storage, arrayID)
 	require.NoError(b, err)
@@ -177,13 +179,14 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	ind := r.Intn(int(array.Count()))
 	_, err = array.Get(uint64(ind))
 	require.NoError(b, err)
-	storageOverheadRatio := float64(storage.baseStorage.Size()) / float64(totalRawDataSize)
-	b.ReportMetric(float64(storage.baseStorage.SegmentsTouched()), "segments_touched")
-	b.ReportMetric(float64(storage.baseStorage.SegmentCounts()), "segments_total")
+
+	storageOverheadRatio := float64(baseStorage.Size()) / float64(totalRawDataSize)
+	b.ReportMetric(float64(baseStorage.SegmentsTouched()), "segments_touched")
+	b.ReportMetric(float64(baseStorage.SegmentCounts()), "segments_total")
 	b.ReportMetric(float64(totalRawDataSize), "storage_raw_data_size")
-	b.ReportMetric(float64(storage.baseStorage.Size()), "storage_stored_data_size")
+	b.ReportMetric(float64(baseStorage.Size()), "storage_stored_data_size")
 	b.ReportMetric(storageOverheadRatio, "storage_overhead_ratio")
-	b.ReportMetric(float64(storage.baseStorage.BytesRetrieved()), "storage_bytes_loaded_for_lookup")
+	b.ReportMetric(float64(baseStorage.BytesRetrieved()), "storage_bytes_loaded_for_lookup")
 	// b.ReportMetric(float64(array.Count()), "number_of_elements")
 	b.ReportMetric(float64(int(totalAppendTime)), "append_100_time_(ns)")
 	b.ReportMetric(float64(int(totalRemoveTime)), "remove_100_time_(ns)")
@@ -247,10 +250,12 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 	}
 	require.NoError(b, storage.Commit())
 
-	storageOverheadRatio := float64(storage.baseStorage.Size()) / float64(totalRawDataSize)
-	b.ReportMetric(float64(storage.baseStorage.SegmentsTouched()), "segments_touched")
-	b.ReportMetric(float64(storage.baseStorage.SegmentCounts()), "segments_total")
+	baseStorage := GetBaseStorage(storage)
+
+	storageOverheadRatio := float64(baseStorage.Size()) / float64(totalRawDataSize)
+	b.ReportMetric(float64(baseStorage.SegmentsTouched()), "segments_touched")
+	b.ReportMetric(float64(baseStorage.SegmentCounts()), "segments_total")
 	b.ReportMetric(float64(totalRawDataSize), "storage_raw_data_size")
-	b.ReportMetric(float64(storage.baseStorage.Size()), "storage_stored_data_size")
+	b.ReportMetric(float64(baseStorage.Size()), "storage_stored_data_size")
 	b.ReportMetric(storageOverheadRatio, "storage_overhead_ratio")
 }

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,28 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree
+
+// Exported functions of PersistentSlabStorage for testing.
+var (
+	GetBaseStorage = (*PersistentSlabStorage).getBaseStorage
+	GetCache       = (*PersistentSlabStorage).getCache
+	GetDeltas      = (*PersistentSlabStorage).getDeltas
+	GetCBOREncMode = (*PersistentSlabStorage).getCBOREncMode
+	GetCBORDecMode = (*PersistentSlabStorage).getCBORDecMode
+)

--- a/storage.go
+++ b/storage.go
@@ -600,6 +600,26 @@ type PersistentSlabStorage struct {
 
 var _ SlabStorage = &PersistentSlabStorage{}
 
+func (s *PersistentSlabStorage) getBaseStorage() BaseStorage {
+	return s.baseStorage
+}
+
+func (s *PersistentSlabStorage) getCache() map[SlabID]Slab {
+	return s.cache
+}
+
+func (s *PersistentSlabStorage) getDeltas() map[SlabID]Slab {
+	return s.deltas
+}
+
+func (s *PersistentSlabStorage) getCBOREncMode() cbor.EncMode {
+	return s.cborEncMode
+}
+
+func (s *PersistentSlabStorage) getCBORDecMode() cbor.DecMode {
+	return s.cborDecMode
+}
+
 // HasUnsavedChanges returns true if there are any modified and unsaved slabs in storage with given address.
 func (s *PersistentSlabStorage) HasUnsavedChanges(address Address) bool {
 	for k := range s.deltas {

--- a/storage_test.go
+++ b/storage_test.go
@@ -1035,7 +1035,7 @@ func TestPersistentStorageSlabIterator(t *testing.T) {
 				break
 			}
 
-			encodedSlab, err := EncodeSlab(slab, storage.cborEncMode)
+			encodedSlab, err := EncodeSlab(slab, GetCBOREncMode(storage))
 			require.NoError(t, err)
 
 			require.Equal(t, encodedSlab, data[id])
@@ -1875,7 +1875,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		require.Equal(t, 0, len(skippedRootIDs))
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Fix broken reference
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(_ Value) bool {
@@ -1886,7 +1886,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		require.Equal(t, 0, len(skippedRootIDs))
 
 		// No data is modified during fixing broken reference
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check health after fixing broken reference
 		rootIDSet, err = CheckStorageHealth(storage, -1)
@@ -2010,7 +2010,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Fix broken references
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(_ Value) bool {
@@ -2024,7 +2024,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		require.Equal(t, 0, len(skippedRootIDs))
-		require.Equal(t, 1, len(storage.deltas))
+		require.Equal(t, 1, GetDeltasCount(storage))
 
 		// Check health after fixing broken reference
 		rootIDs, err := CheckStorageHealth(storage, -1)
@@ -2037,10 +2037,10 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check encoded data
-		baseStorage := storage.baseStorage.(*InMemBaseStorage)
+		baseStorage := GetBaseStorage(storage).(*InMemBaseStorage)
 		require.Equal(t, 1, len(baseStorage.segments))
 
 		savedData, found, err := baseStorage.Retrieve(rootID)
@@ -2164,7 +2164,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Fix broken references
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(_ Value) bool {
@@ -2178,7 +2178,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		require.Equal(t, 0, len(skippedRootIDs))
-		require.Equal(t, 1, len(storage.deltas))
+		require.Equal(t, 1, GetDeltasCount(storage))
 
 		// Check health after fixing broken reference
 		rootIDs, err := CheckStorageHealth(storage, -1)
@@ -2191,10 +2191,10 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check encoded data
-		baseStorage := storage.baseStorage.(*InMemBaseStorage)
+		baseStorage := GetBaseStorage(storage).(*InMemBaseStorage)
 		require.Equal(t, 1, len(baseStorage.segments))
 
 		savedData, found, err := baseStorage.Retrieve(rootID)
@@ -2409,7 +2409,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Fix broken reference
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(_ Value) bool {
@@ -2423,7 +2423,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		require.Equal(t, 0, len(skippedRootIDs))
-		require.Equal(t, 3, len(storage.deltas))
+		require.Equal(t, 3, GetDeltasCount(storage))
 
 		// Check health after fixing broken reference
 		rootIDs, err := CheckStorageHealth(storage, -1)
@@ -2436,10 +2436,10 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check encoded data
-		baseStorage := storage.baseStorage.(*InMemBaseStorage)
+		baseStorage := GetBaseStorage(storage).(*InMemBaseStorage)
 		require.Equal(t, 1, len(baseStorage.segments))
 
 		savedData, found, err := baseStorage.Retrieve(rootID)
@@ -2653,7 +2653,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Fix broken reference
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(_ Value) bool {
@@ -2667,7 +2667,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		require.Equal(t, 0, len(skippedRootIDs))
-		require.Equal(t, 3, len(storage.deltas))
+		require.Equal(t, 3, GetDeltasCount(storage))
 
 		// Check health after fixing broken reference
 		rootIDs, err := CheckStorageHealth(storage, -1)
@@ -2680,10 +2680,10 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check encoded data
-		baseStorage := storage.baseStorage.(*InMemBaseStorage)
+		baseStorage := GetBaseStorage(storage).(*InMemBaseStorage)
 		require.Equal(t, 1, len(baseStorage.segments))
 
 		savedData, found, err := baseStorage.Retrieve(rootID)
@@ -2942,7 +2942,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Fix broken reference
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(_ Value) bool {
@@ -2956,7 +2956,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		require.Equal(t, 0, len(skippedRootIDs))
-		require.Equal(t, 1, len(storage.deltas))
+		require.Equal(t, 1, GetDeltasCount(storage))
 
 		// Check health after fixing broken reference
 		rootIDs, err := CheckStorageHealth(storage, -1)
@@ -2969,10 +2969,10 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check encoded data
-		baseStorage := storage.baseStorage.(*InMemBaseStorage)
+		baseStorage := GetBaseStorage(storage).(*InMemBaseStorage)
 		require.Equal(t, 4, len(baseStorage.segments))
 
 		savedData, found, err := baseStorage.Retrieve(nestedContainerRootID)
@@ -3265,7 +3265,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		}
 
 		// No data is modified because no fix happened
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Only fix one map with broken reference
 		fixedRootIDs, skippedRootIDs, err = storage.FixLoadedBrokenReferences(func(v Value) bool {
@@ -3278,12 +3278,12 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		require.Equal(t, brokenRefs[rootID1], fixedRootIDs[rootID1])
 		require.Equal(t, 1, len(skippedRootIDs))
 		require.Equal(t, brokenRefs[rootID2], skippedRootIDs[rootID2])
-		require.Equal(t, 3, len(storage.deltas))
+		require.Equal(t, 3, GetDeltasCount(storage))
 
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check health after only fixing one map with broken reference
 		_, err = CheckStorageHealth(storage, -1)
@@ -3297,7 +3297,7 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		require.Equal(t, 1, len(fixedRootIDs))
 		require.Equal(t, brokenRefs[rootID2], fixedRootIDs[rootID2])
 		require.Equal(t, 0, len(skippedRootIDs))
-		require.Equal(t, 1, len(storage.deltas))
+		require.Equal(t, 1, GetDeltasCount(storage))
 
 		// Check health after fixing remaining maps with broken reference
 		returnedRootIDs, err := CheckStorageHealth(storage, -1)
@@ -3307,10 +3307,10 @@ func TestFixLoadedBrokenReferences(t *testing.T) {
 		// Save data in storage
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Check encoded data
-		baseStorage := storage.baseStorage.(*InMemBaseStorage)
+		baseStorage := GetBaseStorage(storage).(*InMemBaseStorage)
 		require.Equal(t, 2, len(baseStorage.segments))
 
 		savedData, found, err := baseStorage.Retrieve(rootID1)
@@ -5137,12 +5137,12 @@ func testStorageBatchPreload(t *testing.T, numberOfAccounts int, numberOfSlabsPe
 	// Batch preload slabs from base storage
 	err = storage.BatchPreload(ids, runtime.NumCPU())
 	require.NoError(t, err)
-	require.Equal(t, len(encodedSlabs), len(storage.cache))
-	require.Equal(t, 0, len(storage.deltas))
+	require.Equal(t, len(encodedSlabs), GetCacheCount(storage))
+	require.Equal(t, 0, GetDeltasCount(storage))
 
 	// Compare encoded data
 	for id, data := range encodedSlabs {
-		cachedData, err := EncodeSlab(storage.cache[id], encMode)
+		cachedData, err := EncodeSlab(GetCache(storage)[id], encMode)
 		require.NoError(t, err)
 
 		require.Equal(t, cachedData, data)
@@ -5176,8 +5176,8 @@ func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
 		err := storage.BatchPreload(ids, runtime.NumCPU())
 		require.NoError(t, err)
 
-		require.Equal(t, 0, len(storage.cache))
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, 0, GetCacheCount(storage))
+		require.Equal(t, 0, GetDeltasCount(storage))
 	})
 
 	t.Run("non-empty storage", func(t *testing.T) {
@@ -5209,12 +5209,12 @@ func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
 		err := storage.BatchPreload(ids, runtime.NumCPU())
 		require.NoError(t, err)
 
-		require.Equal(t, len(encodedSlabs), len(storage.cache))
-		require.Equal(t, 0, len(storage.deltas))
+		require.Equal(t, len(encodedSlabs), GetCacheCount(storage))
+		require.Equal(t, 0, GetDeltasCount(storage))
 
 		// Compare encoded data
 		for id, data := range encodedSlabs {
-			cachedData, err := EncodeSlab(storage.cache[id], encMode)
+			cachedData, err := EncodeSlab(GetCache(storage)[id], encMode)
 			require.NoError(t, err)
 
 			require.Equal(t, cachedData, data)

--- a/utils_test.go
+++ b/utils_test.go
@@ -201,12 +201,11 @@ func newTestPersistentStorageWithBaseStorage(t testing.TB, baseStorage BaseStora
 }
 
 func newTestPersistentStorageWithBaseStorageAndDeltas(t testing.TB, baseStorage BaseStorage, data map[SlabID][]byte) *PersistentSlabStorage {
-	storage := newTestPersistentStorageWithBaseStorage(t, baseStorage)
 	for id, b := range data {
-		err := storage.baseStorage.Store(id, b)
+		err := baseStorage.Store(id, b)
 		require.NoError(t, err)
 	}
-	return storage
+	return newTestPersistentStorageWithBaseStorage(t, baseStorage)
 }
 
 func newTestBasicStorage(t testing.TB) *BasicSlabStorage {
@@ -456,4 +455,12 @@ var _ Value = &someValue{}
 
 func (v someValue) Storable(SlabStorage, Address, uint64) (Storable, error) {
 	panic("not reachable")
+}
+
+func GetDeltasCount(storage *PersistentSlabStorage) int {
+	return len(GetDeltas(storage))
+}
+
+func GetCacheCount(storage *PersistentSlabStorage) int {
+	return len(GetCache(storage))
 }


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

Currently, some tests are using unexported fields of `PersistentSlabStorage`.

This commit improves decoupling:
- in storage.go, create unexported functions for those fields
- in export_test.go, export those unexported functions in same package, so those exported functions can be used for testing in test package.
- modify tests to use the newly exported functions.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
