### PR TITLE
Avoid using unexported `SlabID` fields in tests

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -6111,11 +6111,10 @@ func TestArrayID(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	sid := array.SlabID()
-	id := array.ValueID()
+	slabID := array.SlabID()
+	valueID := array.ValueID()
 
-	require.Equal(t, sid.address[:], id[:SlabAddressLength])
-	require.Equal(t, sid.index[:], id[SlabAddressLength:])
+	testEqualValueIDAndSlabID(t, slabID, valueID)
 }
 
 func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {

--- a/array_test.go
+++ b/array_test.go
@@ -5675,6 +5675,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with composite values, unload random composite value", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
+
 			storage := newTestPersistentStorage(t)
 
 			const arraySize = 500
@@ -5712,6 +5713,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with composite values, unload random data slab", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
+
 			storage := newTestPersistentStorage(t)
 
 			const arraySize = 500
@@ -5778,6 +5780,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with composite values, unload random slab", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
+
 			storage := newTestPersistentStorage(t)
 
 			const arraySize = 500

--- a/map_test.go
+++ b/map_test.go
@@ -15053,7 +15053,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			sort.Slice(externalCollisionSlabIDs, func(i, j int) bool {
 				a := externalCollisionSlabIDs[i]
 				b := externalCollisionSlabIDs[j]
-				if a.address == b.address {
+				if a.Address() == b.Address() {
 					return a.IndexAsUint64() < b.IndexAsUint64()
 				}
 				return a.AddressAsUint64() < b.AddressAsUint64()
@@ -15254,7 +15254,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			sort.Slice(externalCollisionSlabIDs, func(i, j int) bool {
 				a := externalCollisionSlabIDs[i]
 				b := externalCollisionSlabIDs[j]
-				if a.address == b.address {
+				if a.Address() == b.Address() {
 					return a.IndexAsUint64() < b.IndexAsUint64()
 				}
 				return a.AddressAsUint64() < b.AddressAsUint64()
@@ -15470,7 +15470,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			sort.Slice(externalCollisionSlabIDs, func(i, j int) bool {
 				a := externalCollisionSlabIDs[i]
 				b := externalCollisionSlabIDs[j]
-				if a.address == b.address {
+				if a.Address() == b.Address() {
 					return a.IndexAsUint64() < b.IndexAsUint64()
 				}
 				return a.AddressAsUint64() < b.AddressAsUint64()
@@ -15985,6 +15985,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with composite values, unload composite value at random index", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
+
 			storage := newTestPersistentStorage(t)
 
 			const mapSize = 500
@@ -16028,6 +16029,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with composite values, unload random data slab", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
+
 			storage := newTestPersistentStorage(t)
 
 			const mapSize = 500
@@ -16109,6 +16111,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with composite values, unload random slab", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
+
 			storage := newTestPersistentStorage(t)
 
 			const mapSize = 500

--- a/map_test.go
+++ b/map_test.go
@@ -16646,11 +16646,10 @@ func TestMapID(t *testing.T) {
 	m, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	sid := m.SlabID()
-	id := m.ValueID()
+	slabID := m.SlabID()
+	valueID := m.ValueID()
 
-	require.Equal(t, sid.address[:], id[:SlabAddressLength])
-	require.Equal(t, sid.index[:], id[SlabAddressLength:])
+	testEqualValueIDAndSlabID(t, slabID, valueID)
 }
 
 func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {

--- a/storage_test.go
+++ b/storage_test.go
@@ -292,9 +292,8 @@ func TestLedgerBaseStorageStore(t *testing.T) {
 		if owner == nil {
 			break
 		}
-		var id SlabID
-		copy(id.address[:], owner)
-		copy(id.index[:], key[1:])
+
+		id := NewSlabIDFromRawAddressAndIndex(owner, key[1:])
 
 		require.True(t, LedgerKeyIsSlabKey(string(key)))
 		require.Equal(t, values[id], value)
@@ -364,7 +363,7 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove non-existent value
-	err = baseStorage.Remove(NewSlabID(id.address, id.index.Next()))
+	err = baseStorage.Remove(NewSlabID(id.Address(), id.Index().Next()))
 	require.NoError(t, err)
 
 	// Retrieve removed value
@@ -381,9 +380,6 @@ func TestLedgerBaseStorageRemove(t *testing.T) {
 		if owner == nil {
 			break
 		}
-		var id SlabID
-		copy(id.address[:], owner)
-		copy(id.index[:], key[1:])
 
 		require.True(t, LedgerKeyIsSlabKey(string(key)))
 		require.Nil(t, value)
@@ -402,18 +398,18 @@ func TestLedgerBaseStorageGenerateSlabID(t *testing.T) {
 
 	id, err := baseStorage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
+	require.Equal(t, address1, id.Address())
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index())
 
 	id, err = baseStorage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
+	require.Equal(t, address1, id.Address())
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index())
 
 	id, err = baseStorage.GenerateSlabID(address2)
 	require.NoError(t, err)
-	require.Equal(t, address2, id.address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
+	require.Equal(t, address2, id.Address())
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index())
 }
 
 func TestBasicSlabStorageStore(t *testing.T) {
@@ -504,7 +500,7 @@ func TestBasicSlabStorageRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove non-existent value
-	err = storage.Remove(NewSlabID(id.address, id.index.Next()))
+	err = storage.Remove(NewSlabID(id.Address(), id.Index().Next()))
 	require.NoError(t, err)
 
 	// Retrieve removed value
@@ -524,18 +520,18 @@ func TestBasicSlabStorageGenerateSlabID(t *testing.T) {
 
 	id, err := storage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
+	require.Equal(t, address1, id.Address())
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index())
 
 	id, err = storage.GenerateSlabID(address1)
 	require.NoError(t, err)
-	require.Equal(t, address1, id.address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
+	require.Equal(t, address1, id.Address())
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index())
 
 	id, err = storage.GenerateSlabID(address2)
 	require.NoError(t, err)
-	require.Equal(t, address2, id.address)
-	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
+	require.Equal(t, address2, id.Address())
+	require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index())
 }
 
 func TestBasicSlabStorageSlabIDs(t *testing.T) {
@@ -543,9 +539,9 @@ func TestBasicSlabStorageSlabIDs(t *testing.T) {
 	address := Address{1}
 	index := SlabIndex{0, 0, 0, 0, 0, 0, 0, 0}
 	wantIDs := map[SlabID]bool{
-		{address: address, index: index.Next()}: true,
-		{address: address, index: index.Next()}: true,
-		{address: address, index: index.Next()}: true,
+		NewSlabID(address, index.Next()): true,
+		NewSlabID(address, index.Next()): true,
+		NewSlabID(address, index.Next()): true,
 	}
 
 	storage := NewBasicSlabStorage(nil, nil, nil, nil)
@@ -1195,26 +1191,26 @@ func TestPersistentStorageGenerateSlabID(t *testing.T) {
 
 		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
+		require.Equal(t, address, id.Address())
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index())
 
 		id, err = storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
+		require.Equal(t, address, id.Address())
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index())
 	})
 	t.Run("perm address", func(t *testing.T) {
 		address := Address{1}
 
 		id, err := storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.index)
+		require.Equal(t, address, id.Address())
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1}, id.Index())
 
 		id, err = storage.GenerateSlabID(address)
 		require.NoError(t, err)
-		require.Equal(t, address, id.address)
-		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.index)
+		require.Equal(t, address, id.Address())
+		require.Equal(t, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2}, id.Index())
 	})
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -402,10 +402,10 @@ func mapEqual(t *testing.T, expected mapValue, actual *OrderedMap) {
 }
 
 func valueIDToSlabID(vid ValueID) SlabID {
-	var id SlabID
-	copy(id.address[:], vid[:SlabAddressLength])
-	copy(id.index[:], vid[SlabAddressLength:])
-	return id
+	return NewSlabIDFromRawAddressAndIndex(
+		vid[:SlabAddressLength],
+		vid[SlabAddressLength:],
+	)
 }
 
 func testInlinedMapIDs(t *testing.T, address Address, m *OrderedMap) {
@@ -424,11 +424,10 @@ func testInlinedSlabIDAndValueID(t *testing.T, expectedAddress Address, slabID S
 }
 
 func testNotInlinedSlabIDAndValueID(t *testing.T, expectedAddress Address, slabID SlabID, valueID ValueID) {
-	require.Equal(t, expectedAddress, slabID.address)
-	require.NotEqual(t, SlabIndexUndefined, slabID.index)
+	require.Equal(t, expectedAddress, slabID.Address())
+	require.NotEqual(t, SlabIndexUndefined, slabID.Index())
 
-	require.Equal(t, slabID.address[:], valueID[:SlabAddressLength])
-	require.Equal(t, slabID.index[:], valueID[SlabAddressLength:])
+	testEqualValueIDAndSlabID(t, slabID, valueID)
 }
 
 type arrayValue []Value
@@ -463,4 +462,22 @@ func GetDeltasCount(storage *PersistentSlabStorage) int {
 
 func GetCacheCount(storage *PersistentSlabStorage) int {
 	return len(GetCache(storage))
+}
+
+func NewSlabIDFromRawAddressAndIndex(rawAddress, rawIndex []byte) SlabID {
+	var address Address
+	copy(address[:], rawAddress)
+
+	var index SlabIndex
+	copy(index[:], rawIndex)
+
+	return NewSlabID(address, index)
+}
+
+func testEqualValueIDAndSlabID(t *testing.T, slabID SlabID, valueID ValueID) {
+	sidAddress := slabID.Address()
+	sidIndex := slabID.Index()
+
+	require.Equal(t, sidAddress[:], valueID[:SlabAddressLength])
+	require.Equal(t, sidIndex[:], valueID[SlabAddressLength:])
 }


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
