### PR TITLE
Avoid using unexported `Array` fields in tests

### DIFF
--- a/array.go
+++ b/array.go
@@ -3243,6 +3243,18 @@ func (a *Array) Inlinable(maxInlineSize uint64) bool {
 	return a.root.Inlinable(maxInlineSize)
 }
 
+func (a *Array) rootSlab() ArraySlab {
+	return a.root
+}
+
+func (a *Array) hasParentUpdater() bool {
+	return a.parentUpdater != nil
+}
+
+func (a *Array) getMutableElementIndexCount() int {
+	return len(a.mutableElementIndex)
+}
+
 // Storable returns array a as either:
 // - SlabIDStorable, or
 // - inlined data slab storable

--- a/array_test.go
+++ b/array_test.go
@@ -2830,7 +2830,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, storable)
 
-			require.True(t, childMap.root.IsData())
+			require.True(t, IsMapRootDataSlab(childMap))
 
 			err = array.Append(childMap)
 			require.NoError(t, err)
@@ -2871,7 +2871,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 				expectedChildMapValues[k] = v
 			}
 
-			require.False(t, childMap.root.IsData())
+			require.False(t, IsMapRootDataSlab(childMap))
 
 			err = array.Append(childMap)
 			require.NoError(t, err)

--- a/array_test.go
+++ b/array_test.go
@@ -1122,7 +1122,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValues[i] = v
 		}
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1145,7 +1145,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1171,7 +1171,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValues[i] = v
 		}
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1194,7 +1194,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1222,7 +1222,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = v
 			r++
 		}
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		r = rune('a')
@@ -1248,7 +1248,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1276,7 +1276,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = v
 			r++
 		}
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		r = rune('a')
@@ -1302,7 +1302,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1330,7 +1330,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = v
 			r++
 		}
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		r = rune('a')
@@ -1356,7 +1356,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1388,7 +1388,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValues[i] = arrayValue{v}
 		}
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1416,7 +1416,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1448,7 +1448,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValues[i] = arrayValue{v}
 		}
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1476,7 +1476,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1517,7 +1517,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValues[i] = expectedValue
 		}
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1550,7 +1550,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1591,7 +1591,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValues[i] = expectedValue
 		}
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1624,7 +1624,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1666,7 +1666,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = expectedValue
 		}
 
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1698,7 +1698,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1740,7 +1740,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = expectedValue
 		}
 
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1773,7 +1773,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
 
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1816,7 +1816,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = expectedValue
 		}
 
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1848,7 +1848,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1891,7 +1891,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = expectedValue
 		}
 
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -1924,7 +1924,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
 
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -1967,7 +1967,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValues[i] = expectedValue
 		}
 
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		i := 0
 		err = array.Iterate(func(v Value) (bool, error) {
@@ -2000,7 +2000,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, arraySize, i)
 
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -2290,9 +2290,9 @@ func TestMutableArrayIterateRange(t *testing.T) {
 
 			expectedValues[i] = arrayValue{v}
 		}
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
-		sizeBeforeMutation := array.root.Header().size
+		sizeBeforeMutation := GetArrayRootSlabByteSize(array)
 
 		i := 0
 		startIndex := uint64(1)
@@ -2316,13 +2316,13 @@ func TestMutableArrayIterateRange(t *testing.T) {
 
 			i++
 
-			require.Equal(t, array.root.Header().size, sizeBeforeMutation+uint32(i)*newElement.ByteSize())
+			require.Equal(t, GetArrayRootSlabByteSize(array), sizeBeforeMutation+uint32(i)*newElement.ByteSize())
 
 			return true, nil
 		})
 		require.NoError(t, err)
 		require.Equal(t, endIndex-startIndex, uint64(i))
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
@@ -2753,7 +2753,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			err = childArray.Append(v)
 			require.NoError(t, err)
 
-			require.True(t, childArray.root.IsData())
+			require.True(t, IsArrayRootDataSlab(childArray))
 			require.False(t, childArray.Inlined())
 
 			err = array.Append(childArray)
@@ -2795,7 +2795,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 				expectedChildArrayValues[i] = v
 			}
 
-			require.False(t, childArray.root.IsData())
+			require.False(t, IsArrayRootDataSlab(childArray))
 
 			err = array.Append(childArray)
 			require.NoError(t, err)
@@ -2975,9 +2975,7 @@ func TestArrayDecodeV0(t *testing.T) {
 	})
 
 	t.Run("metadataslab as root", func(t *testing.T) {
-		storage := newTestBasicStorage(t)
 		typeInfo := testTypeInfo{42}
-		childTypeInfo := testTypeInfo{43}
 
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
@@ -2992,15 +2990,7 @@ func TestArrayDecodeV0(t *testing.T) {
 			values[i] = NewStringValue(strings.Repeat("a", 22))
 		}
 
-		childArray, err := NewArray(storage, address, childTypeInfo)
-		childArray.root.SetSlabID(childArraySlabID)
-		require.NoError(t, err)
-
-		v := Uint64Value(0)
-		err = childArray.Append(v)
-		require.NoError(t, err)
-
-		values[arraySize-1] = arrayValue{v}
+		values[arraySize-1] = arrayValue{Uint64Value(0)}
 
 		slabData := map[SlabID][]byte{
 			// (metadata slab) headers: [{id:2 size:228 count:9} {id:3 size:270 count:11} ]
@@ -5023,12 +5013,12 @@ func TestArrayMaxInlineElement(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.True(t, array.root.IsData())
+	require.True(t, IsArrayRootDataSlab(array))
 
 	// Size of root data slab with two elements of max inlined size is target slab size minus
 	// slab id size (next slab id is omitted in root slab), and minus 1 byte
 	// (for rounding when computing max inline array element size).
-	require.Equal(t, TargetSlabSize()-SlabIDLength-1, uint64(array.root.Header().size))
+	require.Equal(t, TargetSlabSize()-SlabIDLength-1, uint64(GetArrayRootSlabByteSize(array)))
 
 	testArray(t, storage, typeInfo, address, array, values, false)
 }
@@ -5500,7 +5490,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 		testArrayLoadedElements(t, array, values)
 
-		metaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		metaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload data slabs from front to back
@@ -5529,7 +5519,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 		testArrayLoadedElements(t, array, values)
 
-		metaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		metaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload data slabs from back to front
@@ -5558,7 +5548,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 		testArrayLoadedElements(t, array, values)
 
-		metaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		metaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		require.True(t, len(metaDataSlab.childrenHeaders) > 2)
@@ -5584,7 +5574,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		// parent array (3 levels): 1 root metadata slab, 2 non-root metadata slabs, n data slabs
 		require.Equal(t, 3, getArrayMetaDataSlabCount(storage))
 
-		rootMetaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		rootMetaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload non-root metadata slabs from front to back
@@ -5610,7 +5600,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		// parent array (3 levels): 1 root metadata slab, 2 child metadata slabs, n data slabs
 		require.Equal(t, 3, getArrayMetaDataSlabCount(storage))
 
-		rootMetaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		rootMetaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload non-root metadata slabs from back to front
@@ -5677,7 +5667,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 		testArrayLoadedElements(t, array, values)
 
-		rootMetaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		rootMetaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		type slabInfo struct {
@@ -5749,7 +5739,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 			children   []*slabInfo
 		}
 
-		rootMetaDataSlab, ok := array.root.(*ArrayMetaDataSlab)
+		rootMetaDataSlab, ok := GetArrayRootSlab(array).(*ArrayMetaDataSlab)
 		require.True(t, ok)
 
 		var dataSlabCount, metadataSlabCount int
@@ -6053,10 +6043,10 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.True(t, array.root.IsData())
+	require.True(t, IsArrayRootDataSlab(array))
 
 	expectedArrayRootDataSlabSize := arrayRootDataSlabPrefixSize + initialStorableSize*arraySize
-	require.Equal(t, uint32(expectedArrayRootDataSlabSize), array.root.ByteSize())
+	require.Equal(t, uint32(expectedArrayRootDataSlabSize), GetArrayRootSlabByteSize(array))
 
 	err = VerifyArray(array, address, typeInfo, typeInfoComparator, hashInputProvider, true)
 	require.NoError(t, err)
@@ -6070,10 +6060,10 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 		require.NotNil(t, existingStorable)
 	}
 
-	require.True(t, array.root.IsData())
+	require.True(t, IsArrayRootDataSlab(array))
 
 	expectedArrayRootDataSlabSize = arrayRootDataSlabPrefixSize + mutatedStorableSize*arraySize
-	require.Equal(t, uint32(expectedArrayRootDataSlabSize), array.root.ByteSize())
+	require.Equal(t, uint32(expectedArrayRootDataSlabSize), GetArrayRootSlabByteSize(array))
 
 	err = VerifyArray(array, address, typeInfo, typeInfoComparator, hashInputProvider, true)
 	require.NoError(t, err)
@@ -6094,14 +6084,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Create an array with empty child array as element.
 		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
 
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 		require.Equal(t, uint64(arraySize), parentArray.Count())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 empty inlined child arrays
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6141,14 +6131,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent slab size
 			expectedParentSize := arrayRootDataSlabPrefixSize + expectedInlinedSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6168,13 +6158,13 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, valueID, childArray.ValueID())       // Value ID is unchanged
 
 		expectedStandaloneSlabSize := arrayRootDataSlabPrefixSize + uint32(childArray.Count())*vSize
-		require.Equal(t, expectedStandaloneSlabSize, childArray.root.ByteSize())
+		require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 		expectedParentSize = arrayRootDataSlabPrefixSize + SlabIDStorable(expectedSlabID).ByteSize()
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6193,13 +6183,13 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, valueID, childArray.ValueID()) // value ID is unchanged
 
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			expectedParentSize := arrayRootDataSlabPrefixSize + expectedInlinedSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6223,10 +6213,10 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 
 		// Test parent slab size with 2 empty inlined child arrays
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6279,14 +6269,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined child slab size
 				expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-				require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent slab size
 				expectedParentSize += vSize
-				require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6317,15 +6307,15 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())  // Value ID is unchanged
 
 			expectedStandaloneSlabSize := arrayRootDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedStandaloneSlabSize, childArray.root.ByteSize())
+			require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			//expectedParentSize := arrayRootDataSlabPrefixSize + SlabIDStorable(expectedSlabID).ByteSize()
 			expectedParentSize -= inlinedArrayDataSlabPrefixSize + uint32(childArray.Count()-1)*vSize
 			expectedParentSize += SlabIDStorable(expectedSlabID).ByteSize()
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6354,14 +6344,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			expectedParentSize -= SlabIDStorable{}.ByteSize()
 			expectedParentSize += expectedInlinedSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6389,13 +6379,13 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
 				expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-				require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				expectedParentSize -= vSize
-				require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6418,15 +6408,15 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
 
 		require.Equal(t, uint64(arraySize), parentArray.Count())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 4 empty inlined child arrays
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6478,10 +6468,10 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined child slab size
 				expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-				require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6490,7 +6480,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Parent array has 1 meta data slab and 2 data slabs.
 		// All child arrays are inlined.
 		require.Equal(t, 3, getStoredDeltas(storage))
-		require.False(t, parentArray.root.IsData())
+		require.False(t, IsArrayRootDataSlab(parentArray))
 
 		// Add one more element to child array which triggers inlined child array slab becomes standalone slab
 		for i, child := range children {
@@ -6512,17 +6502,17 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())  // Value ID is unchanged
 
 			expectedStandaloneSlabSize := arrayRootDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedStandaloneSlabSize, childArray.root.ByteSize())
+			require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		// Parent array has one data slab and all child arrays are not inlined.
 		require.Equal(t, 1+arraySize, getStoredDeltas(storage))
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove one element from child array which triggers standalone array slab becomes inlined slab again.
 		for i, child := range children {
@@ -6544,10 +6534,10 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6555,7 +6545,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Parent array has 1 meta data slab and 2 data slabs.
 		// All child arrays are inlined.
 		require.Equal(t, 3, getStoredDeltas(storage))
-		require.False(t, parentArray.root.IsData())
+		require.False(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove remaining elements from inlined child array
 		childArrayCount := children[0].array.Count()
@@ -6579,10 +6569,10 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
 				expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-				require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6591,7 +6581,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Parent array has 1 data slab.
 		// All child arrays are inlined.
 		require.Equal(t, 1, getStoredDeltas(storage))
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		for _, child := range children {
 			require.Equal(t, uint64(0), child.array.Count())
@@ -6616,15 +6606,15 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arraySize)
 
 		require.Equal(t, uint64(arraySize), parentArray.Count())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 inlined child array
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6689,20 +6679,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
 			expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent slab size
 			expectedParentSize := arrayRootDataSlabPrefixSize + expectedInlinedChildSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6734,18 +6724,18 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 		// Test inlined grand child slab size
 		expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-		require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+		require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 		expectedStandaloneSlabSize := arrayRootDataSlabPrefixSize + expectedInlinedGrandChildSize
-		require.Equal(t, expectedStandaloneSlabSize, childArray.root.ByteSize())
+		require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 		expectedParentSize = arrayRootDataSlabPrefixSize + SlabIDStorable(expectedSlabID).ByteSize()
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-		require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6777,20 +6767,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
 			expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent slab size
 			expectedParentSize := arrayRootDataSlabPrefixSize + expectedInlinedChildSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6811,15 +6801,15 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arraySize)
 
 		require.Equal(t, uint64(arraySize), parentArray.Count())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 inlined child array
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6884,20 +6874,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
 			expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent slab size
 			expectedParentSize := arrayRootDataSlabPrefixSize + expectedInlinedChildSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6931,18 +6921,18 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 		// Test inlined grand child slab size
 		expectedInlinedGrandChildSize := arrayRootDataSlabPrefixSize + uint32(gchildArray.Count()-1)*vSize + largeValueSize
-		require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+		require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 		expectedStandaloneSlabSize := inlinedArrayDataSlabPrefixSize + SlabIDStorable(expectedSlabID).ByteSize()
-		require.Equal(t, expectedStandaloneSlabSize, childArray.root.ByteSize())
+		require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 		expectedParentSize = arrayRootDataSlabPrefixSize + expectedStandaloneSlabSize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-		require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6973,20 +6963,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
 			expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent slab size
 			expectedParentSize := arrayRootDataSlabPrefixSize + expectedInlinedChildSize
-			require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7036,15 +7026,15 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(arraySize), parentArray.Count())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 inlined child array
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize + vSize*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7122,20 +7112,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined grand child slab size (1 element, unchanged)
 				expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + vSize
-				require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
 				expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize + vSize*uint32(i+1)
-				require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent slab size
 				expectedParentSize += vSize
-				require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-				require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7171,15 +7161,15 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			expectedStandaloneSlabSize := arrayRootDataSlabPrefixSize + expectedInlinedGrandChildSize + vSize*uint32(childArray.Count()-1)
-			require.Equal(t, expectedStandaloneSlabSize, childArray.root.ByteSize())
+			require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7187,7 +7177,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because child array is no longer inlined.
 
 		expectedParentSize = arrayRootDataSlabPrefixSize + SlabIDStorable(SlabID{}).ByteSize()*2
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Remove one elements from each child array to trigger child arrays being inlined again.
 		expectedParentSize = arrayRootDataSlabPrefixSize
@@ -7220,23 +7210,23 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
 			expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize + vSize*uint32(childArray.Count()-1)
-			require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			expectedParentSize += expectedInlinedChildSize
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Remove elements from child array.
 		elementCount := children[0].array.Count()
@@ -7271,20 +7261,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined grand child slab size
 				expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-				require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
 				expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize + vSize*uint32(childArray.Count()-1)
-				require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent slab size
 				expectedParentSize -= vSize
-				require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-				require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7333,14 +7323,14 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(arraySize), parentArray.Count())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7422,16 +7412,16 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined grand child slab size
 				expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + vSize*(i+1)
-				require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
 				expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-				require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-				require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7470,21 +7460,21 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			expectedInlinedChildSlabSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedInlinedChildSlabSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because child array is no longer inlined.
-		require.False(t, parentArray.root.IsData())
+		require.False(t, IsArrayRootDataSlab(parentArray))
 
 		// Add one more element to grand child array which triggers
 		// - child arrays become standalone slab (grand child arrays are still inlined)
@@ -7523,22 +7513,22 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test standalone grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			expectedStandaloneChildSlabSize := arrayRootDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedStandaloneChildSlabSize, childArray.root.ByteSize())
+			require.Equal(t, expectedStandaloneChildSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		// Parent array has one root data slab, 4 grand child array with standalone root data slab.
 		require.Equal(t, 1+arraySize, getStoredDeltas(storage))
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove elements from grand child array to trigger child array inlined again.
 		for i, child := range children {
@@ -7574,23 +7564,23 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 			expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-			require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
 			expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-			require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		// Parent array has 1 metadata slab, and two data slab, all child and grand child arrays are inlined.
 		require.Equal(t, 3, getStoredDeltas(storage))
-		require.False(t, parentArray.root.IsData())
+		require.False(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove elements from grand child array.
 		elementCount := children[0].child.array.Count()
@@ -7628,16 +7618,16 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined grand child slab size
 				expectedInlinedGrandChildSize := inlinedArrayDataSlabPrefixSize + uint32(gchildArray.Count())*vSize
-				require.Equal(t, expectedInlinedGrandChildSize, gchildArray.root.ByteSize())
+				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
 				expectedInlinedChildSize := inlinedArrayDataSlabPrefixSize + expectedInlinedGrandChildSize
-				require.Equal(t, expectedInlinedChildSize, childArray.root.ByteSize())
+				require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-				require.True(t, uint64(len(gchildArray.mutableElementIndex)) <= gchildArray.Count())
-				require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
+				require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7651,7 +7641,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, 1, getStoredDeltas(storage))
 
 		expectedParentSize = uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize*2
-		require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 	})
 }
 
@@ -7667,15 +7657,15 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 	parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
 
 	require.Equal(t, uint64(arraySize), parentArray.Count())
-	require.True(t, parentArray.root.IsData())
+	require.True(t, IsArrayRootDataSlab(parentArray))
 	require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 	// Test parent slab size with empty inlined child arrays
 	expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
-	require.Equal(t, expectedParentSize, parentArray.root.ByteSize())
+	require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 	// Test array's mutableElementIndex
-	require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+	require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 	testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7743,11 +7733,11 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7788,11 +7778,11 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7828,11 +7818,11 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7873,11 +7863,11 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7918,11 +7908,11 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7958,11 +7948,11 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
 			// Test inlined child slab size
 			expectedInlinedSize := inlinedArrayDataSlabPrefixSize + uint32(childArray.Count())*vSize
-			require.Equal(t, expectedInlinedSize, childArray.root.ByteSize())
+			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(childArray.mutableElementIndex)) <= childArray.Count())
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -8085,7 +8075,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8109,7 +8099,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 			expectedValues[i] = Uint64Value(0)
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+			require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 		}
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
@@ -8145,7 +8135,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8170,7 +8160,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
@@ -8217,7 +8207,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8242,7 +8232,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
@@ -8282,7 +8272,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8307,7 +8297,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
@@ -8354,7 +8344,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8376,7 +8366,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, len(parentArray.mutableElementIndex))
+		require.Equal(t, 0, GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
@@ -8411,7 +8401,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8433,7 +8423,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, len(parentArray.mutableElementIndex))
+		require.Equal(t, 0, GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
@@ -8480,7 +8470,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8502,7 +8492,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, len(parentArray.mutableElementIndex))
+		require.Equal(t, 0, GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
@@ -8542,7 +8532,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(len(parentArray.mutableElementIndex)) <= parentArray.Count())
+		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8564,7 +8554,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, len(parentArray.mutableElementIndex))
+		require.Equal(t, 0, GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
@@ -8616,14 +8606,14 @@ func TestArrayWithOutdatedCallback(t *testing.T) {
 		expectedValues[0] = Uint64Value(0)
 
 		// childArray.parentUpdater isn't nil before callback is invoked.
-		require.NotNil(t, childArray.parentUpdater)
+		require.True(t, ArrayHasParentUpdater(childArray))
 
 		// modify overwritten child array
 		err = childArray.Append(Uint64Value(0))
 		require.NoError(t, err)
 
 		// childArray.parentUpdater is nil after callback is invoked.
-		require.Nil(t, childArray.parentUpdater)
+		require.False(t, ArrayHasParentUpdater(childArray))
 
 		// No-op on parent
 		valueEqual(t, expectedValues, parentArray)
@@ -8671,14 +8661,14 @@ func TestArrayWithOutdatedCallback(t *testing.T) {
 		expectedValues = arrayValue{}
 
 		// childArray.parentUpdater isn't nil before callback is invoked.
-		require.NotNil(t, childArray.parentUpdater)
+		require.True(t, ArrayHasParentUpdater(childArray))
 
 		// modify removed child array
 		err = childArray.Append(Uint64Value(0))
 		require.NoError(t, err)
 
 		// childArray.parentUpdater is nil after callback is invoked.
-		require.Nil(t, childArray.parentUpdater)
+		require.False(t, ArrayHasParentUpdater(childArray))
 
 		// No-op on parent
 		valueEqual(t, expectedValues, parentArray)
@@ -8698,7 +8688,7 @@ func TestArraySetType(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), array.Count())
 		require.Equal(t, typeInfo, array.Type())
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		// Modify type info of new array
 		err = array.SetType(newTypeInfo)
@@ -8727,7 +8717,7 @@ func TestArraySetType(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 		require.Equal(t, typeInfo, array.Type())
-		require.True(t, array.root.IsData())
+		require.True(t, IsArrayRootDataSlab(array))
 
 		err = array.SetType(newTypeInfo)
 		require.NoError(t, err)
@@ -8755,7 +8745,7 @@ func TestArraySetType(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), array.Count())
 		require.Equal(t, typeInfo, array.Type())
-		require.False(t, array.root.IsData())
+		require.False(t, IsArrayRootDataSlab(array))
 
 		err = array.SetType(newTypeInfo)
 		require.NoError(t, err)
@@ -8782,12 +8772,12 @@ func TestArraySetType(t *testing.T) {
 
 		require.Equal(t, uint64(1), parentArray.Count())
 		require.Equal(t, typeInfo, parentArray.Type())
-		require.True(t, parentArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.False(t, parentArray.Inlined())
 
 		require.Equal(t, uint64(0), childArray.Count())
 		require.Equal(t, typeInfo, childArray.Type())
-		require.True(t, childArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(childArray))
 		require.True(t, childArray.Inlined())
 
 		err = childArray.SetType(newTypeInfo)
@@ -8822,12 +8812,12 @@ func TestArraySetType(t *testing.T) {
 
 		require.Equal(t, uint64(arraySize), parentArray.Count())
 		require.Equal(t, typeInfo, parentArray.Type())
-		require.False(t, parentArray.root.IsData())
+		require.False(t, IsArrayRootDataSlab(parentArray))
 		require.False(t, parentArray.Inlined())
 
 		require.Equal(t, uint64(0), childArray.Count())
 		require.Equal(t, typeInfo, childArray.Type())
-		require.True(t, childArray.root.IsData())
+		require.True(t, IsArrayRootDataSlab(childArray))
 		require.True(t, childArray.Inlined())
 
 		err = childArray.SetType(newTypeInfo)

--- a/export_test.go
+++ b/export_test.go
@@ -31,3 +31,10 @@ var (
 var (
 	TargetSlabSize = targetSlabSize
 )
+
+// Exported function of Array for testing.
+var (
+	GetArrayRootSlab                 = (*Array).rootSlab
+	ArrayHasParentUpdater            = (*Array).hasParentUpdater
+	GetArrayMutableElementIndexCount = (*Array).getMutableElementIndexCount
+)

--- a/export_test.go
+++ b/export_test.go
@@ -38,3 +38,9 @@ var (
 	ArrayHasParentUpdater            = (*Array).hasParentUpdater
 	GetArrayMutableElementIndexCount = (*Array).getMutableElementIndexCount
 )
+
+// Exported function of OrderedMap for testing.
+var (
+	GetMapRootSlab        = (*OrderedMap).rootSlab
+	GetMapDigesterBuilder = (*OrderedMap).getDigesterBuilder
+)

--- a/map.go
+++ b/map.go
@@ -4883,6 +4883,14 @@ func (m *OrderedMap) setParentUpdater(f parentUpdater) {
 	m.parentUpdater = f
 }
 
+func (m *OrderedMap) rootSlab() MapSlab {
+	return m.root
+}
+
+func (m *OrderedMap) getDigesterBuilder() DigesterBuilder {
+	return m.digesterBuilder
+}
+
 // setCallbackWithChild sets up callback function with child value (child)
 // so parent map (m) can be notified when child value is modified.
 func (m *OrderedMap) setCallbackWithChild(

--- a/map_test.go
+++ b/map_test.go
@@ -231,7 +231,7 @@ func _testMap(
 	decodedMap, err := NewMapWithRootID(
 		newTestPersistentStorageWithBaseStorageAndDeltas(t, GetBaseStorage(storage), encodedSlabs),
 		m.SlabID(),
-		m.digesterBuilder)
+		GetMapDigesterBuilder(m))
 	require.NoError(t, err)
 
 	// Verify decoded map elements
@@ -2240,7 +2240,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -2267,7 +2267,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2300,7 +2300,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -2327,7 +2327,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2360,7 +2360,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -2389,7 +2389,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2422,7 +2422,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -2451,7 +2451,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2486,7 +2486,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -2514,7 +2514,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2686,7 +2686,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -2725,7 +2725,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2770,7 +2770,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -2809,7 +2809,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2862,7 +2862,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -2904,7 +2904,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -2957,7 +2957,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -2999,7 +2999,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3052,7 +3052,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3094,7 +3094,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3311,7 +3311,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3436,7 +3436,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3478,7 +3478,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3530,7 +3530,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3572,7 +3572,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3624,7 +3624,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3666,7 +3666,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3718,7 +3718,7 @@ func TestMutableMapIterate(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3760,7 +3760,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3817,7 +3817,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -3844,7 +3844,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3877,7 +3877,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -3904,7 +3904,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3937,7 +3937,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -3966,7 +3966,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3999,7 +3999,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -4028,7 +4028,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4063,7 +4063,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -4091,7 +4091,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4261,7 +4261,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4302,7 +4302,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4347,7 +4347,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4388,7 +4388,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4441,7 +4441,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4485,7 +4485,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4538,7 +4538,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4582,7 +4582,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4635,7 +4635,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4679,7 +4679,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -4899,7 +4899,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5028,7 +5028,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5072,7 +5072,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5124,7 +5124,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5168,7 +5168,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5220,7 +5220,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5264,7 +5264,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5316,7 +5316,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5360,7 +5360,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5417,7 +5417,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -5445,7 +5445,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5478,7 +5478,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -5506,7 +5506,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5539,7 +5539,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -5570,7 +5570,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5603,7 +5603,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -5633,7 +5633,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5668,7 +5668,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
@@ -5697,7 +5697,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, mapSize, i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5871,7 +5871,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5911,7 +5911,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5956,7 +5956,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -5996,7 +5996,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6049,7 +6049,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6092,7 +6092,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6145,7 +6145,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6188,7 +6188,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6241,7 +6241,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6284,7 +6284,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6503,7 +6503,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6630,7 +6630,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6673,7 +6673,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6725,7 +6725,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6768,7 +6768,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6820,7 +6820,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6863,7 +6863,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6915,7 +6915,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6958,7 +6958,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, uint64(mapSize), i)
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -8593,7 +8593,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.Equal(t, expected[id3], stored[id3])
 
 		// Verify slab size in header is correct.
-		meta, ok := m.root.(*MapMetaDataSlab)
+		meta, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 		require.Equal(t, 2, len(meta.childrenHeaders))
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
@@ -11783,7 +11783,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.Equal(t, expected[id4], stored[id4])
 
 		// Verify slab size in header is correct.
-		meta, ok := m.root.(*MapMetaDataSlab)
+		meta, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 		require.Equal(t, 2, len(meta.childrenHeaders))
 		require.Equal(t, uint32(len(stored[id2])), meta.childrenHeaders[0].size)
@@ -13370,7 +13370,7 @@ func TestMapEncodeDecodeRandomValues(t *testing.T) {
 	storage2 := newTestPersistentStorageWithBaseStorage(t, GetBaseStorage(storage))
 
 	// Create new map from new storage
-	m2, err := NewMapWithRootID(storage2, m.SlabID(), m.digesterBuilder)
+	m2, err := NewMapWithRootID(storage2, m.SlabID(), GetMapDigesterBuilder(m))
 	require.NoError(t, err)
 
 	testMap(t, storage2, typeInfo, address, m2, keyValues, nil, false)
@@ -14322,12 +14322,12 @@ func TestMapMaxInlineElement(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.True(t, m.root.IsData())
+	require.True(t, IsMapRootDataSlab(m))
 
 	// Size of root data slab with two elements (key+value pairs) of
 	// max inlined size is target slab size minus
 	// slab id size (next slab id is omitted in root slab)
-	require.Equal(t, TargetSlabSize()-SlabIDLength, uint64(m.root.Header().size))
+	require.Equal(t, TargetSlabSize()-SlabIDLength, uint64(GetMapRootSlabByteSize(m)))
 
 	testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 }
@@ -15677,7 +15677,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 		testMapLoadedElements(t, m, values)
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload data slabs from front to back
@@ -15721,7 +15721,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 		testMapLoadedElements(t, m, values)
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload data slabs from back to front
@@ -15765,7 +15765,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 		testMapLoadedElements(t, m, values)
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		require.True(t, len(rootMetaDataSlab.childrenHeaders) > 2)
@@ -15811,7 +15811,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		// parent map (3 levels): 1 root metadata slab, 3 child metadata slabs, n data slabs
 		require.Equal(t, 4, getMapMetaDataSlabCount(storage))
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload non-root metadata slabs from front to back.
@@ -15850,7 +15850,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		// parent map (3 levels): 1 root metadata slab, 3 child metadata slabs, n data slabs
 		require.Equal(t, 4, getMapMetaDataSlabCount(storage))
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		// Unload non-root metadata slabs from back to front.
@@ -15930,7 +15930,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 		testMapLoadedElements(t, m, values)
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		type slabInfo struct {
@@ -16016,7 +16016,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			children   []*slabInfo
 		}
 
-		rootMetaDataSlab, ok := m.root.(*MapMetaDataSlab)
+		rootMetaDataSlab, ok := GetMapRootSlab(m).(*MapMetaDataSlab)
 		require.True(t, ok)
 
 		metadataSlabInfos := make([]*slabInfo, len(rootMetaDataSlab.childrenHeaders))
@@ -16519,11 +16519,11 @@ func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {
 		require.Nil(t, existingStorable)
 	}
 
-	require.True(t, m.root.IsData())
+	require.True(t, IsMapRootDataSlab(m))
 
 	expectedElementSize := singleElementPrefixSize + digestSize + Uint64Value(0).ByteSize() + initialStorableSize
 	expectedMapRootDataSlabSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize + expectedElementSize*mapSize
-	require.Equal(t, expectedMapRootDataSlabSize, m.root.ByteSize())
+	require.Equal(t, expectedMapRootDataSlabSize, GetMapRootSlabByteSize(m))
 
 	err = VerifyMap(m, address, typeInfo, typeInfoComparator, hashInputProvider, true)
 	require.NoError(t, err)
@@ -16537,11 +16537,11 @@ func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {
 		require.NotNil(t, existingStorable)
 	}
 
-	require.True(t, m.root.IsData())
+	require.True(t, IsMapRootDataSlab(m))
 
 	expectedElementSize = singleElementPrefixSize + digestSize + Uint64Value(0).ByteSize() + mutatedStorableSize
 	expectedMapRootDataSlabSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize + expectedElementSize*mapSize
-	require.Equal(t, expectedMapRootDataSlabSize, m.root.ByteSize())
+	require.Equal(t, expectedMapRootDataSlabSize, GetMapRootSlabByteSize(m))
 
 	err = VerifyMap(m, address, typeInfo, typeInfoComparator, hashInputProvider, true)
 	require.NoError(t, err)
@@ -16576,7 +16576,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		})
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -16611,13 +16611,13 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent slab size
 				expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedInlinedMapSize
 				expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
 					expectedParentElementSize*mapSize
-				require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -16653,12 +16653,12 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedStandaloneSlabSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedStandaloneSlabSize, childMap.root.ByteSize())
+			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
 			expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + SlabIDStorable(expectedSlabID).ByteSize()
 			expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
 				expectedParentElementSize*mapSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
@@ -16692,19 +16692,19 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedInlinedMapSize
 				expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
 					expectedParentElementSize*mapSize
-				require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
 		}
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 	})
 
@@ -16730,14 +16730,14 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		})
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 
-		expectedParentSize := parentMap.root.ByteSize()
+		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
 		// Appending 3 elements to child map so that inlined child map reaches max inlined size as map element.
 		for i := 0; i < 3; i++ {
@@ -16767,11 +16767,11 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent slab size
 				expectedParentSize += expectedChildElementSize
-				require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -16807,14 +16807,14 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedStandaloneSlabSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedStandaloneSlabSize, childMap.root.ByteSize())
+			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
 			// Subtract inlined child map size from expected parent size
 			expectedParentSize -= uint32(inlinedMapDataSlabPrefixSize+hkeyElementsPrefixSize) +
 				expectedChildElementSize*uint32(childMap.Count()-1)
 			// Add slab id storable size to expected parent size
 			expectedParentSize += SlabIDStorable(expectedSlabID).ByteSize()
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
@@ -16854,13 +16854,13 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Subtract slab id storable size from expected parent size
 			expectedParentSize -= SlabIDStorable(SlabID{}).ByteSize()
 			// Add expected inlined child map to expected parent size
 			expectedParentSize += expectedInlinedMapSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
@@ -16895,17 +16895,17 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				expectedParentSize -= expectedChildElementSize
-				require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
 		}
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 	})
 
@@ -16931,7 +16931,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		})
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -16965,7 +16965,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -16974,7 +16974,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		// Parent array has 1 meta data slab and 2 data slabs.
 		// All child arrays are inlined.
 		require.Equal(t, 3, getStoredDeltas(storage))
-		require.False(t, parentMap.root.IsData())
+		require.False(t, IsMapRootDataSlab(parentMap))
 
 		// Add one more element to child array which triggers inlined child array slab becomes standalone slab
 		for childKey, child := range children {
@@ -17002,7 +17002,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedStandaloneSlabSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedStandaloneSlabSize, childMap.root.ByteSize())
+			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
@@ -17010,7 +17010,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		// Parent map has one root data slab.
 		// Each child maps has one root data slab.
 		require.Equal(t, 1+mapSize, getStoredDeltas(storage)) // There are >1 stored slab because child map is no longer inlined.
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 
 		// Remove one element from each child map which triggers standalone map slab becomes inlined slab again.
 		for childKey, child := range children {
@@ -17040,14 +17040,14 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
 		// Parent map has one metadata slab + 2 data slabs.
 		require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because child map is inlined again.
-		require.False(t, parentMap.root.IsData())
+		require.False(t, IsMapRootDataSlab(parentMap))
 
 		// Remove remaining elements from each inlined child map.
 		for childKey, child := range children {
@@ -17077,7 +17077,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedInlinedMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedInlinedMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -17088,14 +17088,14 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			require.Equal(t, uint64(0), child.m.Count())
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		// Test parent map slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedEmptyInlinedMapSize
 		expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) + // standalone map data slab with 0 element
 			expectedParentElementSize*uint32(mapSize)
-		require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 	})
 }
 
@@ -17129,7 +17129,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17137,7 +17137,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 		require.Equal(t, mapSize, len(children))
 
-		expectedParentSize := parentMap.root.ByteSize()
+		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
 		// Inserting 1 elements to grand child map so that inlined grand child map reaches max inlined size as map element.
 		for childKey, child := range children {
@@ -17190,22 +17190,22 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent slab size
 			expectedParentSize += expectedGrandChildElementSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17261,23 +17261,23 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test standalone child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent slab size
 			expectedParentSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 				singleElementPrefixSize + digestSize + encodedKeySize + SlabIDStorable(SlabID{}).ByteSize()
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 2, getStoredDeltas(storage)) // There is 2 stored slab because child map is not inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17331,19 +17331,19 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedGrandChildElementSize*uint32(gchildMap.Count())
-				require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 				// Test inlined child slab size
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 				expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent child slab size
 				expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedChildMapSize
 				expectedParentMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedParentElementSize*uint32(parentMap.Count())
-				require.Equal(t, expectedParentMapSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -17353,7 +17353,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(1), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map and grand child map are inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17387,7 +17387,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17395,7 +17395,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 		require.Equal(t, mapSize, len(children))
 
-		expectedParentSize := parentMap.root.ByteSize()
+		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
 		// Inserting 1 elements to grand child map so that inlined grand child map reaches max inlined size as map element.
 		for childKey, child := range children {
@@ -17448,22 +17448,22 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent slab size
 			expectedParentSize += expectedGrandChildElementSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17523,22 +17523,22 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElement2Size := singleElementPrefixSize + digestSize + encodedKeySize + encodedLargeValueSize
 			expectedGrandChildMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElement1Size + expectedGrandChildElement2Size
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + slabIDStorableSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize + expectedChildElementSize
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent slab size
 			expectedParentSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 				singleElementPrefixSize + digestSize + encodedKeySize + expectedChildMapSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 2, getStoredDeltas(storage)) // There is 2 stored slab because child map is not inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17598,19 +17598,19 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedGrandChildElementSize*uint32(gchildMap.Count())
-				require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 				// Test inlined child slab size
 				expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 				expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent child slab size
 				expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedChildMapSize
 				expectedParentMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedParentElementSize*uint32(parentMap.Count())
-				require.Equal(t, expectedParentMapSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -17620,7 +17620,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(1), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map and grand child map are inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17652,7 +17652,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17660,7 +17660,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 		require.Equal(t, mapSize, len(children))
 
-		expectedParentSize := parentMap.root.ByteSize()
+		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
 		// Insert 1 elements to grand child map (both child map and grand child map are still inlined).
 		for childKey, child := range children {
@@ -17711,27 +17711,27 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent slab size
 			expectedParentSize += expectedGrandChildElementSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
-		expectedParentSize = parentMap.root.ByteSize()
+		expectedParentSize = GetMapRootSlabByteSize(parentMap)
 
 		// Add 1 element to each child map so child map reaches its max size
 		for childKey, child := range children {
@@ -17778,22 +17778,22 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := digestSize + singleElementPrefixSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize := digestSize + singleElementPrefixSize + encodedKeySize + encodedValueSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize + (digestSize + singleElementPrefixSize + encodedKeySize + expectedGrandChildMapSize)
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent slab size
 			expectedParentSize += digestSize + singleElementPrefixSize + encodedKeySize + encodedValueSize
-			require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17846,28 +17846,28 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test standalone child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedChildMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*2 + (digestSize + singleElementPrefixSize + encodedKeySize + expectedGrandChildMapSize)
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1+mapSize, getStoredDeltas(storage)) // There is 1+mapSize stored slab because all child maps are standalone.
 
 		// Test parent slab size
 		expectedParentSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 			(singleElementPrefixSize+digestSize+encodedKeySize+slabIDStorableSize)*mapSize
-		require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
-		expectedParentMapSize := parentMap.root.ByteSize()
+		expectedParentMapSize := GetMapRootSlabByteSize(parentMap)
 
 		// Remove one element from child map which triggers standalone child map slab becomes inlined slab again.
 		for childKey, child := range children {
@@ -17917,24 +17917,24 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize1 := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildElementSize2 := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize1 + expectedChildElementSize2*uint32(childMap.Count()-1)
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			// Test parent child slab size
 			expectedParentMapSize = expectedParentMapSize - slabIDStorableSize + expectedChildMapSize
-			require.Equal(t, expectedParentMapSize, parentMap.root.ByteSize())
+			require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map and grand child map are inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -17987,18 +17987,18 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedGrandChildElementSize*uint32(gchildMap.Count())
-				require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 				// Test inlined child slab size
 				expectedChildElementSize1 := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 				expectedChildElementSize2 := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 				expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize1 + expectedChildElementSize2*uint32(childMap.Count()-1)
-				require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent child slab size
 				expectedParentMapSize -= digestSize + singleElementPrefixSize + encodedKeySize + encodedValueSize
-				require.Equal(t, expectedParentMapSize, parentMap.root.ByteSize())
+				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -18008,7 +18008,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map and grand child map are inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -18040,7 +18040,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -18093,19 +18093,19 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
 		require.False(t, parentMap.Inlined())
-		require.False(t, parentMap.root.IsData())
+		require.False(t, IsMapRootDataSlab(parentMap))
 		// There is 3 stored slab: parent metadata slab with 2 data slabs (all child and grand child maps are inlined)
 		require.Equal(t, 3, getStoredDeltas(storage))
 
@@ -18158,26 +18158,26 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test standalone child slab size
 			expectedChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize*uint32(childMap.Count())
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
 		require.False(t, parentMap.Inlined())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1+mapSize, getStoredDeltas(storage))
 
 		// Test parent slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + slabIDStorableSize
 		expectedParentMapSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 			expectedParentElementSize*uint32(parentMap.Count())
-		require.Equal(t, expectedParentMapSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
@@ -18233,20 +18233,20 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildElementSize := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedGrandChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedGrandChildElementSize*uint32(gchildMap.Count())
-			require.Equal(t, expectedGrandChildMapSize, gchildMap.root.ByteSize())
+			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
 			expectedChildElementSize1 := singleElementPrefixSize + digestSize + encodedKeySize + expectedGrandChildMapSize
 			expectedChildElementSize2 := singleElementPrefixSize + digestSize + encodedKeySize + encodedValueSize
 			expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 				expectedChildElementSize1 + expectedChildElementSize2*uint32(childMap.Count()-1)
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.False(t, parentMap.root.IsData())
+		require.False(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 3, getStoredDeltas(storage))
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -18302,13 +18302,13 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			}
 
 			expectedChildMapSize := uint32(inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize)
-			require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 			require.Equal(t, uint64(0), childMap.Count())
 		}
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage))
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -18316,7 +18316,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		expectedChildMapSize := uint32(inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize)
 		expectedParentMapSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
 			(digestSize+singleElementPrefixSize+encodedKeySize+expectedChildMapSize)*uint32(mapSize)
-		require.Equal(t, expectedParentMapSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 	})
 }
 
@@ -18371,17 +18371,17 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 		testInlinedMapIDs(t, address, childMap)
 
 		// Test child map slab size
-		require.Equal(t, expectedEmptyInlinedMapSize, childMap.root.ByteSize())
+		require.Equal(t, expectedEmptyInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 		// Test parent map slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedEmptyInlinedMapSize
 		expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) + // standalone map data slab with 0 element
 			expectedParentElementSize*uint32(i+1)
-		require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 	}
 
 	require.Equal(t, uint64(mapSize), parentMap.Count())
-	require.True(t, parentMap.root.IsData())
+	require.True(t, IsMapRootDataSlab(parentMap))
 	require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 	testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -18441,7 +18441,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 				expectedChildElementSize := singleElementPrefixSize + digestSize + k.ByteSize() + v.ByteSize()
 				expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 					expectedChildElementSize*uint32(childMap.Count())
-				require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
@@ -18488,7 +18488,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 					expectedChildElementSize := singleElementPrefixSize + digestSize + k.ByteSize() + v.ByteSize()
 					expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 						expectedChildElementSize*uint32(childMap.Count())
-					require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+					require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 					testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 				}
@@ -18535,13 +18535,13 @@ func createMapWithEmptyChildMap(
 		testInlinedMapIDs(t, address, childMap)
 
 		// Test child map slab size
-		require.Equal(t, expectedEmptyInlinedMapSize, childMap.root.ByteSize())
+		require.Equal(t, expectedEmptyInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 		// Test parent map slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + ks.ByteSize() + expectedEmptyInlinedMapSize
 		expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) + // standalone map data slab with 0 element
 			expectedParentElementSize*uint32(i+1)
-		require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 	}
 
 	return parentMap, expectedKeyValues
@@ -18597,19 +18597,19 @@ func createMapWithEmpty2LevelChildMap(
 		testInlinedMapIDs(t, address, childMap)
 
 		// Test grand child map slab size
-		require.Equal(t, expectedEmptyInlinedMapSize, gchildMap.root.ByteSize())
+		require.Equal(t, expectedEmptyInlinedMapSize, GetMapRootSlabByteSize(gchildMap))
 
 		// Test child map slab size
 		expectedChildElementSize := singleElementPrefixSize + digestSize + ks.ByteSize() + expectedEmptyInlinedMapSize
 		expectedChildMapSize := inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize +
 			expectedChildElementSize*uint32(childMap.Count())
-		require.Equal(t, expectedChildMapSize, childMap.root.ByteSize())
+		require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 		// Test parent map slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + ks.ByteSize() + expectedChildMapSize
 		expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) + // standalone map data slab with 0 element
 			expectedParentElementSize*uint32(i+1)
-		require.Equal(t, expectedParentSize, parentMap.root.ByteSize())
+		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 	}
 
 	testNotInlinedMapIDs(t, address, parentMap)
@@ -19303,15 +19303,15 @@ func TestMapSetType(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), m.Count())
 		require.Equal(t, typeInfo, m.Type())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
-		seed := m.root.ExtraData().Seed
+		seed := m.Seed()
 
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, uint64(0), m.Count())
 		require.Equal(t, newTypeInfo, m.Type())
-		require.Equal(t, seed, m.root.ExtraData().Seed)
+		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
 		err = storage.FastCommit(runtime.NumCPU())
@@ -19336,15 +19336,15 @@ func TestMapSetType(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 		require.Equal(t, typeInfo, m.Type())
-		require.True(t, m.root.IsData())
+		require.True(t, IsMapRootDataSlab(m))
 
-		seed := m.root.ExtraData().Seed
+		seed := m.Seed()
 
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, m.Type())
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.Equal(t, seed, m.root.ExtraData().Seed)
+		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
 		err = storage.FastCommit(runtime.NumCPU())
@@ -19369,15 +19369,15 @@ func TestMapSetType(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), m.Count())
 		require.Equal(t, typeInfo, m.Type())
-		require.False(t, m.root.IsData())
+		require.False(t, IsMapRootDataSlab(m))
 
-		seed := m.root.ExtraData().Seed
+		seed := m.Seed()
 
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, m.Type())
 		require.Equal(t, uint64(mapSize), m.Count())
-		require.Equal(t, seed, m.root.ExtraData().Seed)
+		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
 		err = storage.FastCommit(runtime.NumCPU())
@@ -19395,7 +19395,7 @@ func TestMapSetType(t *testing.T) {
 		childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		childMapSeed := childMap.root.ExtraData().Seed
+		childMapSeed := childMap.Seed()
 
 		existingStorable, err := parentMap.Set(compare, hashInputProvider, Uint64Value(0), childMap)
 		require.NoError(t, err)
@@ -19403,19 +19403,19 @@ func TestMapSetType(t *testing.T) {
 
 		require.Equal(t, uint64(1), parentMap.Count())
 		require.Equal(t, typeInfo, parentMap.Type())
-		require.True(t, parentMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(parentMap))
 		require.False(t, parentMap.Inlined())
 
 		require.Equal(t, uint64(0), childMap.Count())
 		require.Equal(t, typeInfo, childMap.Type())
-		require.True(t, childMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(childMap))
 		require.True(t, childMap.Inlined())
 
 		err = childMap.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, childMap.Type())
 		require.Equal(t, uint64(0), childMap.Count())
-		require.Equal(t, childMapSeed, childMap.root.ExtraData().Seed)
+		require.Equal(t, childMapSeed, childMap.Seed())
 
 		// Commit modified slabs in storage
 		err = storage.FastCommit(runtime.NumCPU())
@@ -19441,7 +19441,7 @@ func TestMapSetType(t *testing.T) {
 		childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		childMapSeed := childMap.root.ExtraData().Seed
+		childMapSeed := childMap.Seed()
 
 		mapSize := 10_000
 		for i := 0; i < mapSize-1; i++ {
@@ -19457,19 +19457,19 @@ func TestMapSetType(t *testing.T) {
 
 		require.Equal(t, uint64(mapSize), parentMap.Count())
 		require.Equal(t, typeInfo, parentMap.Type())
-		require.False(t, parentMap.root.IsData())
+		require.False(t, IsMapRootDataSlab(parentMap))
 		require.False(t, parentMap.Inlined())
 
 		require.Equal(t, uint64(0), childMap.Count())
 		require.Equal(t, typeInfo, childMap.Type())
-		require.True(t, childMap.root.IsData())
+		require.True(t, IsMapRootDataSlab(childMap))
 		require.True(t, childMap.Inlined())
 
 		err = childMap.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, childMap.Type())
 		require.Equal(t, uint64(0), childMap.Count())
-		require.Equal(t, childMapSeed, childMap.root.ExtraData().Seed)
+		require.Equal(t, childMapSeed, childMap.Seed())
 
 		// Commit modified slabs in storage
 		err = storage.FastCommit(runtime.NumCPU())
@@ -19505,14 +19505,14 @@ func testExistingMapSetType(
 	require.NoError(t, err)
 	require.Equal(t, expectedCount, m.Count())
 	require.Equal(t, expectedTypeInfo, m.Type())
-	require.Equal(t, expectedSeed, m.root.ExtraData().Seed)
+	require.Equal(t, expectedSeed, m.Seed())
 
 	// Modify type info of existing map
 	err = m.SetType(newTypeInfo)
 	require.NoError(t, err)
 	require.Equal(t, expectedCount, m.Count())
 	require.Equal(t, newTypeInfo, m.Type())
-	require.Equal(t, expectedSeed, m.root.ExtraData().Seed)
+	require.Equal(t, expectedSeed, m.Seed())
 
 	// Commit data in storage
 	err = storage.FastCommit(runtime.NumCPU())
@@ -19526,7 +19526,7 @@ func testExistingMapSetType(
 	require.NoError(t, err)
 	require.Equal(t, expectedCount, m2.Count())
 	require.Equal(t, newTypeInfo, m2.Type())
-	require.Equal(t, expectedSeed, m2.root.ExtraData().Seed)
+	require.Equal(t, expectedSeed, m2.Seed())
 }
 
 func testExistingInlinedMapSetType(
@@ -19555,14 +19555,14 @@ func testExistingInlinedMapSetType(
 
 	require.Equal(t, expectedCount, childMap.Count())
 	require.Equal(t, expectedTypeInfo, childMap.Type())
-	require.Equal(t, expectedSeed, childMap.root.ExtraData().Seed)
+	require.Equal(t, expectedSeed, childMap.Seed())
 
 	// Modify type info of existing map
 	err = childMap.SetType(newTypeInfo)
 	require.NoError(t, err)
 	require.Equal(t, expectedCount, childMap.Count())
 	require.Equal(t, newTypeInfo, childMap.Type())
-	require.Equal(t, expectedSeed, childMap.root.ExtraData().Seed)
+	require.Equal(t, expectedSeed, childMap.Seed())
 
 	// Commit data in storage
 	err = storage.FastCommit(runtime.NumCPU())
@@ -19583,5 +19583,5 @@ func testExistingInlinedMapSetType(
 
 	require.Equal(t, expectedCount, childMap2.Count())
 	require.Equal(t, newTypeInfo, childMap2.Type())
-	require.Equal(t, expectedSeed, childMap.root.ExtraData().Seed)
+	require.Equal(t, expectedSeed, childMap.Seed())
 }

--- a/map_test.go
+++ b/map_test.go
@@ -7411,8 +7411,6 @@ func TestMapDecodeV0(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		storage := newTestBasicStorage(t)
-
 		digesterBuilder := &mockDigesterBuilder{}
 
 		const mapSize = 8
@@ -7429,20 +7427,10 @@ func TestMapDecodeV0(t *testing.T) {
 			r++
 		}
 
-		// Create nested array
-		typeInfo2 := testTypeInfo{43}
-
 		mapSlabID := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
 		id3 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 3})
 		nestedSlabID := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 4})
-
-		childArray, err := NewArray(storage, address, typeInfo2)
-		childArray.root.SetSlabID(nestedSlabID)
-		require.NoError(t, err)
-
-		err = childArray.Append(Uint64Value(0))
-		require.NoError(t, err)
 
 		k := NewStringValue(strings.Repeat(string(r), 22))
 
@@ -19230,14 +19218,14 @@ func TestMapWithOutdatedCallback(t *testing.T) {
 		expectedKeyValues[k] = Uint64Value(0)
 
 		// childArray.parentUpdater isn't nil before callback is invoked.
-		require.NotNil(t, childArray.parentUpdater)
+		require.True(t, ArrayHasParentUpdater(childArray))
 
 		// modify overwritten child array
 		err = childArray.Append(Uint64Value(0))
 		require.NoError(t, err)
 
 		// childArray.parentUpdater is nil after callback is invoked.
-		require.Nil(t, childArray.parentUpdater)
+		require.False(t, ArrayHasParentUpdater(childArray))
 
 		// No-op on parent
 		valueEqual(t, expectedKeyValues, parentMap)
@@ -19289,14 +19277,14 @@ func TestMapWithOutdatedCallback(t *testing.T) {
 		delete(expectedKeyValues, k)
 
 		// childArray.parentUpdater isn't nil before callback is invoked.
-		require.NotNil(t, childArray.parentUpdater)
+		require.True(t, ArrayHasParentUpdater(childArray))
 
 		// modify removed child array
 		err = childArray.Append(Uint64Value(0))
 		require.NoError(t, err)
 
 		// childArray.parentUpdater is nil after callback is invoked.
-		require.Nil(t, childArray.parentUpdater)
+		require.False(t, ArrayHasParentUpdater(childArray))
 
 		// No-op on parent
 		valueEqual(t, expectedKeyValues, parentMap)

--- a/utils_test.go
+++ b/utils_test.go
@@ -470,3 +470,28 @@ func IsArrayRootDataSlab(array *Array) bool {
 func GetArrayRootSlabByteSize(array *Array) uint32 {
 	return GetArrayRootSlab(array).ByteSize()
 }
+
+func IsMapRootDataSlab(m *OrderedMap) bool {
+	return GetMapRootSlab(m).IsData()
+}
+
+func GetMapRootSlabByteSize(m *OrderedMap) uint32 {
+	return GetMapRootSlab(m).ByteSize()
+}
+
+func NewArrayRootDataSlab(id SlabID, storables []Storable) ArraySlab {
+	size := uint32(arrayRootDataSlabPrefixSize)
+
+	for _, storable := range storables {
+		size += storable.ByteSize()
+	}
+
+	return &ArrayDataSlab{
+		header: ArraySlabHeader{
+			slabID: id,
+			size:   size,
+			count:  uint32(len(storables)),
+		},
+		elements: storables,
+	}
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -462,3 +462,11 @@ func testEqualValueIDAndSlabID(t *testing.T, slabID SlabID, valueID ValueID) {
 	require.Equal(t, sidAddress[:], valueID[:SlabAddressLength])
 	require.Equal(t, sidIndex[:], valueID[SlabAddressLength:])
 }
+
+func IsArrayRootDataSlab(array *Array) bool {
+	return GetArrayRootSlab(array).IsData()
+}
+
+func GetArrayRootSlabByteSize(array *Array) uint32 {
+	return GetArrayRootSlab(array).ByteSize()
+}


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464


______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
