### PR TITLE
Rename vars to reduce confusion (sizes vs counts)

### DIFF
--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -30,10 +30,10 @@ var noopStorable Storable
 
 func BenchmarkArrayGet100x(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		numberOfOps      int
-		long             bool
+		name              string
+		initialArrayCount int
+		numberOfOps       int
+		long              bool
 	}{
 		{"10", 10, 100, false},
 		{"1000", 1000, 100, false},
@@ -47,17 +47,17 @@ func BenchmarkArrayGet100x(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkArrayGet(b, bm.initialArraySize, bm.numberOfOps)
+			benchmarkArrayGet(b, bm.initialArrayCount, bm.numberOfOps)
 		})
 	}
 }
 
 func BenchmarkArrayInsert100x(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		numberOfOps      int
-		long             bool
+		name              string
+		initialArrayCount int
+		numberOfOps       int
+		long              bool
 	}{
 		{"10", 10, 100, false},
 		{"1000", 1000, 100, false},
@@ -71,17 +71,17 @@ func BenchmarkArrayInsert100x(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkArrayInsert(b, bm.initialArraySize, bm.numberOfOps)
+			benchmarkArrayInsert(b, bm.initialArrayCount, bm.numberOfOps)
 		})
 	}
 }
 
 func BenchmarkArrayRemove100x(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		numberOfOps      int
-		long             bool
+		name              string
+		initialArrayCount int
+		numberOfOps       int
+		long              bool
 	}{
 		{"100", 100, 100, false},
 		{"1000", 1000, 100, false},
@@ -95,7 +95,7 @@ func BenchmarkArrayRemove100x(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkArrayRemove(b, bm.initialArraySize, bm.numberOfOps)
+			benchmarkArrayRemove(b, bm.initialArrayCount, bm.numberOfOps)
 		})
 	}
 }
@@ -103,9 +103,9 @@ func BenchmarkArrayRemove100x(b *testing.B) {
 // BenchmarkArrayRemoveAll benchmarks removing all elements in a loop.
 func BenchmarkArrayRemoveAll(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		long             bool
+		name              string
+		initialArrayCount int
+		long              bool
 	}{
 		{"100", 100, false},
 		{"1000", 1000, false},
@@ -117,7 +117,7 @@ func BenchmarkArrayRemoveAll(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkArrayRemoveAll(b, bm.initialArraySize)
+			benchmarkArrayRemoveAll(b, bm.initialArrayCount)
 		})
 	}
 }
@@ -125,9 +125,9 @@ func BenchmarkArrayRemoveAll(b *testing.B) {
 // BenchmarkArrayPopIterate benchmarks removing all elements using PopIterate.
 func BenchmarkArrayPopIterate(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		long             bool
+		name              string
+		initialArrayCount int
+		long              bool
 	}{
 		{"100", 100, false},
 		{"1000", 1000, false},
@@ -139,16 +139,16 @@ func BenchmarkArrayPopIterate(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkArrayPopIterate(b, bm.initialArraySize)
+			benchmarkArrayPopIterate(b, bm.initialArrayCount)
 		})
 	}
 }
 
 func BenchmarkNewArrayFromAppend(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		long             bool
+		name              string
+		initialArrayCount int
+		long              bool
 	}{
 		{"100", 100, false},
 		{"1000", 1000, false},
@@ -160,16 +160,16 @@ func BenchmarkNewArrayFromAppend(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkNewArrayFromAppend(b, bm.initialArraySize)
+			benchmarkNewArrayFromAppend(b, bm.initialArrayCount)
 		})
 	}
 }
 
 func BenchmarkNewArrayFromBatchData(b *testing.B) {
 	benchmarks := []struct {
-		name             string
-		initialArraySize int
-		long             bool
+		name              string
+		initialArrayCount int
+		long              bool
 	}{
 		{"100", 100, false},
 		{"1000", 1000, false},
@@ -181,12 +181,12 @@ func BenchmarkNewArrayFromBatchData(b *testing.B) {
 			if bm.long && testing.Short() {
 				b.Skipf("Skipping %s in short mode", bm.name)
 			}
-			benchmarkNewArrayFromBatchData(b, bm.initialArraySize)
+			benchmarkNewArrayFromBatchData(b, bm.initialArrayCount)
 		})
 	}
 }
 
-func setupArray(b *testing.B, r *rand.Rand, storage *PersistentSlabStorage, initialArraySize int) *Array {
+func setupArray(b *testing.B, r *rand.Rand, storage *PersistentSlabStorage, initialArrayCount int) *Array {
 
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
@@ -195,7 +195,7 @@ func setupArray(b *testing.B, r *rand.Rand, storage *PersistentSlabStorage, init
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(b, err)
 
-	for i := 0; i < initialArraySize; i++ {
+	for i := 0; i < initialArrayCount; i++ {
 		v := RandomValue(r)
 		err := array.Append(v)
 		require.NoError(b, err)
@@ -214,7 +214,7 @@ func setupArray(b *testing.B, r *rand.Rand, storage *PersistentSlabStorage, init
 	return newArray
 }
 
-func benchmarkArrayGet(b *testing.B, initialArraySize, numberOfOps int) {
+func benchmarkArrayGet(b *testing.B, initialArrayCount, numberOfOps int) {
 
 	b.StopTimer()
 
@@ -222,7 +222,7 @@ func benchmarkArrayGet(b *testing.B, initialArraySize, numberOfOps int) {
 
 	storage := newTestPersistentStorage(b)
 
-	array := setupArray(b, r, storage, initialArraySize)
+	array := setupArray(b, r, storage, initialArrayCount)
 
 	var value Value
 
@@ -238,7 +238,7 @@ func benchmarkArrayGet(b *testing.B, initialArraySize, numberOfOps int) {
 	noopValue = value
 }
 
-func benchmarkArrayInsert(b *testing.B, initialArraySize, numberOfOps int) {
+func benchmarkArrayInsert(b *testing.B, initialArrayCount, numberOfOps int) {
 
 	b.StopTimer()
 
@@ -250,7 +250,7 @@ func benchmarkArrayInsert(b *testing.B, initialArraySize, numberOfOps int) {
 
 		b.StopTimer()
 
-		array := setupArray(b, r, storage, initialArraySize)
+		array := setupArray(b, r, storage, initialArrayCount)
 
 		b.StartTimer()
 
@@ -262,7 +262,7 @@ func benchmarkArrayInsert(b *testing.B, initialArraySize, numberOfOps int) {
 	}
 }
 
-func benchmarkArrayRemove(b *testing.B, initialArraySize, numberOfOps int) {
+func benchmarkArrayRemove(b *testing.B, initialArrayCount, numberOfOps int) {
 
 	b.StopTimer()
 
@@ -274,7 +274,7 @@ func benchmarkArrayRemove(b *testing.B, initialArraySize, numberOfOps int) {
 
 		b.StopTimer()
 
-		array := setupArray(b, r, storage, initialArraySize)
+		array := setupArray(b, r, storage, initialArrayCount)
 
 		b.StartTimer()
 
@@ -285,7 +285,7 @@ func benchmarkArrayRemove(b *testing.B, initialArraySize, numberOfOps int) {
 	}
 }
 
-func benchmarkArrayRemoveAll(b *testing.B, initialArraySize int) {
+func benchmarkArrayRemoveAll(b *testing.B, initialArrayCount int) {
 
 	b.StopTimer()
 
@@ -299,11 +299,11 @@ func benchmarkArrayRemoveAll(b *testing.B, initialArraySize int) {
 
 		b.StopTimer()
 
-		array := setupArray(b, r, storage, initialArraySize)
+		array := setupArray(b, r, storage, initialArrayCount)
 
 		b.StartTimer()
 
-		for i := initialArraySize - 1; i >= 0; i-- {
+		for i := initialArrayCount - 1; i >= 0; i-- {
 			storable, _ = array.Remove(uint64(i))
 		}
 	}
@@ -311,7 +311,7 @@ func benchmarkArrayRemoveAll(b *testing.B, initialArraySize int) {
 	noopStorable = storable
 }
 
-func benchmarkArrayPopIterate(b *testing.B, initialArraySize int) {
+func benchmarkArrayPopIterate(b *testing.B, initialArrayCount int) {
 
 	b.StopTimer()
 
@@ -325,7 +325,7 @@ func benchmarkArrayPopIterate(b *testing.B, initialArraySize int) {
 
 		b.StopTimer()
 
-		array := setupArray(b, r, storage, initialArraySize)
+		array := setupArray(b, r, storage, initialArrayCount)
 
 		b.StartTimer()
 
@@ -340,7 +340,7 @@ func benchmarkArrayPopIterate(b *testing.B, initialArraySize int) {
 	noopStorable = storable
 }
 
-func benchmarkNewArrayFromAppend(b *testing.B, initialArraySize int) {
+func benchmarkNewArrayFromAppend(b *testing.B, initialArrayCount int) {
 
 	b.StopTimer()
 
@@ -348,7 +348,7 @@ func benchmarkNewArrayFromAppend(b *testing.B, initialArraySize int) {
 
 	storage := newTestPersistentStorage(b)
 
-	array := setupArray(b, r, storage, initialArraySize)
+	array := setupArray(b, r, storage, initialArrayCount)
 
 	b.StartTimer()
 
@@ -366,7 +366,7 @@ func benchmarkNewArrayFromAppend(b *testing.B, initialArraySize int) {
 	}
 }
 
-func benchmarkNewArrayFromBatchData(b *testing.B, initialArraySize int) {
+func benchmarkNewArrayFromBatchData(b *testing.B, initialArrayCount int) {
 
 	b.StopTimer()
 
@@ -374,7 +374,7 @@ func benchmarkNewArrayFromBatchData(b *testing.B, initialArraySize int) {
 
 	storage := newTestPersistentStorage(b)
 
-	array := setupArray(b, r, storage, initialArraySize)
+	array := setupArray(b, r, storage, initialArrayCount)
 
 	b.StartTimer()
 

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -64,7 +64,7 @@ func RandomValue(r *rand.Rand) Value {
 }
 
 // BenchmarkArray benchmarks the performance of the atree array
-func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
+func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
 	r := newRand(b)
 
@@ -86,7 +86,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 	var totalLookupTime time.Duration
 
 	// setup
-	for i := 0; i < initialArraySize; i++ {
+	for i := 0; i < initialArrayCount; i++ {
 		v := RandomValue(r)
 		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -197,7 +197,7 @@ func benchmarkArray(b *testing.B, initialArraySize, numberOfElements int) {
 func BenchmarkLArrayMemoryImpact(b *testing.B) { benchmarkLongTermImpactOnMemory(b, 10_000, 1000_000) }
 
 // BenchmarkArray benchmarks the performance of the atree array
-func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps int) {
+func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOps int) {
 
 	r := newRand(b)
 
@@ -214,7 +214,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArraySize, numberOfOps
 	var totalRawDataSize uint32
 
 	// setup
-	for i := 0; i < initialArraySize; i++ {
+	for i := 0; i < initialArrayCount; i++ {
 		v := RandomValue(r)
 
 		storable, err := v.Storable(storage, array.Address(), MaxInlineArrayElementSize())

--- a/array_test.go
+++ b/array_test.go
@@ -194,7 +194,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 	SetThreshold(256)
 	defer SetThreshold(1024)
 
-	const arraySize = 4096
+	const arrayCount = 4096
 
 	typeInfo := testTypeInfo{42}
 	storage := newTestPersistentStorage(t)
@@ -203,8 +203,8 @@ func TestArrayAppendAndGet(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]Value, arraySize)
-	for i := uint64(0); i < arraySize; i++ {
+	values := make([]Value, arrayCount)
+	for i := uint64(0); i < arrayCount; i++ {
 		v := Uint64Value(i)
 		values[i] = v
 		err := array.Append(v)
@@ -227,7 +227,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 func TestArraySetAndGet(t *testing.T) {
 
 	t.Run("new elements with similar bytesize", func(t *testing.T) {
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -236,8 +236,8 @@ func TestArraySetAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -246,7 +246,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		testArray(t, storage, typeInfo, address, array, values, false)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			oldValue := values[i]
 			newValue := Uint64Value(i * 10)
 			values[i] = newValue
@@ -270,7 +270,7 @@ func TestArraySetAndGet(t *testing.T) {
 		// When elements are overwritten with values from math.MaxUint64-49 to math.MaxUint64,
 		// array tree is 2 levels, with 1 metadata slab, and 2 data slabs.
 
-		const arraySize = 50
+		const arrayCount = 50
 
 		SetThreshold(256)
 		defer SetThreshold(1024)
@@ -282,8 +282,8 @@ func TestArraySetAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -292,9 +292,9 @@ func TestArraySetAndGet(t *testing.T) {
 
 		testArray(t, storage, typeInfo, address, array, values, false)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			oldValue := values[i]
-			newValue := Uint64Value(math.MaxUint64 - arraySize + i + 1)
+			newValue := Uint64Value(math.MaxUint64 - arrayCount + i + 1)
 			values[i] = newValue
 
 			existingStorable, err := array.Set(i, newValue)
@@ -317,7 +317,7 @@ func TestArraySetAndGet(t *testing.T) {
 		// When elements are overwritten with values from 0-49,
 		// array tree will be 1 level, with 0 metadata slab, and 1 data slab (root).
 
-		const arraySize = 50
+		const arrayCount = 50
 
 		SetThreshold(256)
 		defer SetThreshold(1024)
@@ -329,9 +329,9 @@ func TestArraySetAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
-			v := Uint64Value(math.MaxUint64 - arraySize + i + 1)
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
+			v := Uint64Value(math.MaxUint64 - arrayCount + i + 1)
 			values[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -339,7 +339,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		testArray(t, storage, typeInfo, address, array, values, false)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			oldValue := values[i]
 			newValue := Uint64Value(i)
 			values[i] = newValue
@@ -357,7 +357,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 	t.Run("index out of bounds", func(t *testing.T) {
 
-		const arraySize = 1024
+		const arrayCount = 1024
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -366,8 +366,8 @@ func TestArraySetAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values = append(values, v)
 			err := array.Append(v)
@@ -398,7 +398,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("insert-first", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -407,10 +407,10 @@ func TestArrayInsertAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
-			v := Uint64Value(arraySize - i - 1)
-			values[arraySize-i-1] = v
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
+			v := Uint64Value(arrayCount - i - 1)
+			values[arrayCount-i-1] = v
 			err := array.Insert(0, v)
 			require.NoError(t, err)
 		}
@@ -420,7 +420,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("insert-last", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -429,8 +429,8 @@ func TestArrayInsertAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Insert(i, v)
@@ -442,7 +442,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("insert", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -451,15 +451,15 @@ func TestArrayInsertAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize; i += 2 {
+		values := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount; i += 2 {
 			v := Uint64Value(i)
 			values = append(values, v)
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		for i := uint64(1); i < arraySize; i += 2 {
+		for i := uint64(1); i < arrayCount; i += 2 {
 			v := Uint64Value(i)
 
 			values = append(values, nil)
@@ -475,7 +475,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("index out of bounds", func(t *testing.T) {
 
-		const arraySize = 1024
+		const arrayCount = 1024
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -484,8 +484,8 @@ func TestArrayInsertAndGet(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values = append(values, v)
 			err := array.Append(v)
@@ -514,7 +514,7 @@ func TestArrayRemove(t *testing.T) {
 
 	t.Run("remove-first", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -523,8 +523,8 @@ func TestArrayRemove(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -533,9 +533,9 @@ func TestArrayRemove(t *testing.T) {
 
 		require.True(t, typeInfoComparator(typeInfo, array.Type()))
 		require.Equal(t, address, array.Address())
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			existingStorable, err := array.Remove(0)
 			require.NoError(t, err)
 
@@ -549,7 +549,7 @@ func TestArrayRemove(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, arraySize-i-1, array.Count())
+			require.Equal(t, arrayCount-i-1, array.Count())
 
 			if i%256 == 0 {
 				testArray(t, storage, typeInfo, address, array, values[i+1:], false)
@@ -561,7 +561,7 @@ func TestArrayRemove(t *testing.T) {
 
 	t.Run("remove-last", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -570,8 +570,8 @@ func TestArrayRemove(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -580,9 +580,9 @@ func TestArrayRemove(t *testing.T) {
 
 		require.True(t, typeInfoComparator(typeInfo, array.Type()))
 		require.Equal(t, address, array.Address())
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
-		for i := arraySize - 1; i >= 0; i-- {
+		for i := arrayCount - 1; i >= 0; i-- {
 			existingStorable, err := array.Remove(uint64(i))
 			require.NoError(t, err)
 
@@ -608,7 +608,7 @@ func TestArrayRemove(t *testing.T) {
 
 	t.Run("remove", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -617,8 +617,8 @@ func TestArrayRemove(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -627,10 +627,10 @@ func TestArrayRemove(t *testing.T) {
 
 		require.True(t, typeInfoComparator(typeInfo, array.Type()))
 		require.Equal(t, address, array.Address())
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
 		// Remove every other elements
-		for i := uint64(0); i < arraySize/2; i++ {
+		for i := uint64(0); i < arrayCount/2; i++ {
 			v := values[i]
 
 			existingStorable, err := array.Remove(i)
@@ -656,14 +656,14 @@ func TestArrayRemove(t *testing.T) {
 			}
 		}
 
-		require.Equal(t, arraySize/2, len(values))
+		require.Equal(t, arrayCount/2, len(values))
 
 		testArray(t, storage, typeInfo, address, array, values, false)
 	})
 
 	t.Run("index out of bounds", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -672,8 +672,8 @@ func TestArrayRemove(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -717,7 +717,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -726,7 +726,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -738,14 +738,14 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arraySize), i)
+		require.Equal(t, uint64(arrayCount), i)
 	})
 
 	t.Run("set", func(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -754,12 +754,12 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(0))
 			require.NoError(t, err)
 		}
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			existingStorable, err := array.Set(i, Uint64Value(i))
 			require.NoError(t, err)
 
@@ -775,14 +775,14 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arraySize), i)
+		require.Equal(t, uint64(arrayCount), i)
 	})
 
 	t.Run("insert", func(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -791,12 +791,12 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i += 2 {
+		for i := uint64(0); i < arrayCount; i += 2 {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
 
-		for i := uint64(1); i < arraySize; i += 2 {
+		for i := uint64(1); i < arrayCount; i += 2 {
 			err := array.Insert(i, Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -808,14 +808,14 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arraySize), i)
+		require.Equal(t, uint64(arrayCount), i)
 	})
 
 	t.Run("remove", func(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -824,7 +824,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -845,7 +845,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arraySize/2), i)
+		require.Equal(t, uint64(arrayCount/2), i)
 	})
 
 	t.Run("stop", func(t *testing.T) {
@@ -1105,7 +1105,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 15
+		const arrayCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1114,8 +1114,8 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			err = array.Append(v)
 			require.NoError(t, err)
@@ -1144,7 +1144,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1154,7 +1154,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 1024
+		const arrayCount = 1024
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1163,8 +1163,8 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			err = array.Append(v)
 			require.NoError(t, err)
@@ -1193,7 +1193,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1203,7 +1203,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 15
+		const arrayCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1212,9 +1212,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
+		expectedValues := make([]Value, arrayCount)
 		r := rune('a')
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			v := NewStringValue(string(r))
 			err = array.Append(v)
 			require.NoError(t, err)
@@ -1247,7 +1247,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1257,7 +1257,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 200
+		const arrayCount = 200
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1266,9 +1266,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
+		expectedValues := make([]Value, arrayCount)
 		r := rune('a')
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			v := NewStringValue(string(r))
 			err = array.Append(v)
 			require.NoError(t, err)
@@ -1301,7 +1301,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1311,7 +1311,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 80
+		const arrayCount = 80
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1320,9 +1320,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
+		expectedValues := make([]Value, arrayCount)
 		r := rune('a')
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			v := NewStringValue(strings.Repeat(string(r), 25))
 			err = array.Append(v)
 			require.NoError(t, err)
@@ -1355,7 +1355,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1365,7 +1365,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 15
+		const arrayCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1374,8 +1374,8 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
@@ -1415,7 +1415,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1425,7 +1425,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 25
+		const arrayCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -1434,8 +1434,8 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
@@ -1475,7 +1475,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1486,9 +1486,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 15
-			childArraySize        = 1
-			mutatedChildArraySize = 4
+			arrayCount             = 15
+			childArrayCount        = 1
+			mutatedChildArrayCount = 4
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1498,13 +1498,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1523,14 +1523,14 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
 			// Mutate array elements by inserting more elements to child arrays.
-			for j := i; j < i+mutatedChildArraySize-childArraySize; j++ {
+			for j := i; j < i+mutatedChildArrayCount-childArrayCount; j++ {
 				newElement := Uint64Value(j)
 
 				err := childArray.Append(newElement)
@@ -1539,7 +1539,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, newElement)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1549,7 +1549,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1560,9 +1560,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 25
-			childArraySize        = 1
-			mutatedChildArraySize = 4
+			arrayCount             = 25
+			childArrayCount        = 1
+			mutatedChildArrayCount = 4
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1572,13 +1572,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1597,14 +1597,14 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
 			// Mutate array elements by inserting more elements to child arrays.
-			for j := i; j < i+mutatedChildArraySize-childArraySize; j++ {
+			for j := i; j < i+mutatedChildArrayCount-childArrayCount; j++ {
 				newElement := Uint64Value(j)
 
 				err := childArray.Append(newElement)
@@ -1613,7 +1613,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, newElement)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1623,7 +1623,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1634,9 +1634,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 10
-			childArraySize        = 10
-			mutatedChildArraySize = 1
+			arrayCount             = 10
+			childArrayCount        = 10
+			mutatedChildArrayCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1646,13 +1646,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1672,13 +1672,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
-			for j := childArraySize - 1; j > mutatedChildArraySize-1; j-- {
+			for j := childArrayCount - 1; j > mutatedChildArrayCount-1; j-- {
 				existingStorble, err := childArray.Remove(uint64(j))
 				require.NoError(t, err)
 
@@ -1687,17 +1687,17 @@ func TestMutableArrayIterate(t *testing.T) {
 				require.Equal(t, Uint64Value(i+j), existingValue)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
-			expectedValues[i] = expectedChildArrayValues[:mutatedChildArraySize]
+			expectedValues[i] = expectedChildArrayValues[:mutatedChildArrayCount]
 
 			i++
 
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1708,9 +1708,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 2
-			childArraySize        = 1
-			mutatedChildArraySize = 50
+			arrayCount             = 2
+			childArrayCount        = 1
+			mutatedChildArrayCount = 50
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1720,13 +1720,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1746,13 +1746,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
-			for j := childArraySize; j < mutatedChildArraySize; j++ {
+			for j := childArrayCount; j < mutatedChildArrayCount; j++ {
 				v := Uint64Value(i + j)
 
 				err := childArray.Append(v)
@@ -1761,7 +1761,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, v)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1771,7 +1771,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 
 		require.True(t, IsArrayRootDataSlab(array))
 
@@ -1783,9 +1783,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 10
-			childArraySize        = 10
-			mutatedChildArraySize = 50
+			arrayCount             = 10
+			childArrayCount        = 10
+			mutatedChildArrayCount = 50
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1795,14 +1795,14 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
 
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1822,13 +1822,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
-			for j := childArraySize; j < mutatedChildArraySize; j++ {
+			for j := childArrayCount; j < mutatedChildArrayCount; j++ {
 				v := Uint64Value(i + j)
 
 				err := childArray.Append(v)
@@ -1837,7 +1837,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, v)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1847,7 +1847,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
@@ -1858,9 +1858,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 2
-			childArraySize        = 50
-			mutatedChildArraySize = 1
+			arrayCount             = 2
+			childArrayCount        = 50
+			mutatedChildArrayCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1870,14 +1870,14 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
 
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1897,13 +1897,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
-			for j := childArraySize - 1; j > mutatedChildArraySize-1; j-- {
+			for j := childArrayCount - 1; j > mutatedChildArrayCount-1; j-- {
 				existingStorable, err := childArray.Remove(uint64(j))
 				require.NoError(t, err)
 
@@ -1912,7 +1912,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				require.Equal(t, Uint64Value(i+j), value)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues[:1]
@@ -1922,7 +1922,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 
 		require.True(t, IsArrayRootDataSlab(array))
 
@@ -1934,9 +1934,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			arraySize             = 4
-			childArraySize        = 50
-			mutatedChildArraySize = 25
+			arrayCount             = 4
+			childArrayCount        = 50
+			mutatedChildArrayCount = 25
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -1946,14 +1946,14 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			var expectedValue arrayValue
 
-			for j := i; j < i+childArraySize; j++ {
+			for j := i; j < i+childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -1973,13 +1973,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		err = array.Iterate(func(v Value) (bool, error) {
 			childArray, ok := v.(*Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArraySize), childArray.Count())
+			require.Equal(t, uint64(childArrayCount), childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(arrayValue)
 			require.True(t, ok)
 
-			for j := childArraySize - 1; j >= mutatedChildArraySize; j-- {
+			for j := childArrayCount - 1; j >= mutatedChildArrayCount; j-- {
 				existingStorable, err := childArray.Remove(uint64(j))
 				require.NoError(t, err)
 
@@ -1988,17 +1988,17 @@ func TestMutableArrayIterate(t *testing.T) {
 				require.Equal(t, Uint64Value(i+j), value)
 			}
 
-			require.Equal(t, uint64(mutatedChildArraySize), childArray.Count())
+			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
 			require.True(t, childArray.Inlined())
 
-			expectedValues[i] = expectedChildArrayValues[:mutatedChildArraySize]
+			expectedValues[i] = expectedChildArrayValues[:mutatedChildArrayCount]
 
 			i++
 
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 
 		require.False(t, IsArrayRootDataSlab(array))
 
@@ -2141,15 +2141,15 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 	})
 
 	t.Run("dataslab as root", func(t *testing.T) {
-		const arraySize = 10
+		const arrayCount = 10
 
 		storage := newTestPersistentStorage(t)
 
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			value := Uint64Value(i)
 			values[i] = value
 			err := array.Append(value)
@@ -2163,15 +2163,15 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 1024
+		const arrayCount = 1024
 
 		storage := newTestPersistentStorage(t)
 
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			value := Uint64Value(i)
 			values[i] = value
 			err := array.Append(value)
@@ -2182,14 +2182,14 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		const arraySize = 10
+		const arrayCount = 10
 
 		storage := newTestPersistentStorage(t)
 
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -2215,8 +2215,8 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 10
-		for i := uint64(0); i < arraySize; i++ {
+		const arrayCount = 10
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -2267,7 +2267,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 15
+		const arrayCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -2276,8 +2276,8 @@ func TestMutableArrayIterateRange(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
@@ -2328,14 +2328,14 @@ func TestMutableArrayIterateRange(t *testing.T) {
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		const arraySize = 10
+		const arrayCount = 10
 
 		storage := newTestPersistentStorage(t)
 
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -2361,8 +2361,8 @@ func TestMutableArrayIterateRange(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 10
-		for i := uint64(0); i < arraySize; i++ {
+		const arrayCount = 10
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -2393,7 +2393,7 @@ func TestArrayRootSlabID(t *testing.T) {
 	SetThreshold(256)
 	defer SetThreshold(1024)
 
-	const arraySize = 4096
+	const arrayCount = 4096
 
 	typeInfo := testTypeInfo{42}
 	storage := newTestPersistentStorage(t)
@@ -2406,7 +2406,7 @@ func TestArrayRootSlabID(t *testing.T) {
 	require.NotEqual(t, SlabIDUndefined, savedRootID)
 
 	// Append elements
-	for i := uint64(0); i < arraySize; i++ {
+	for i := uint64(0); i < arrayCount; i++ {
 		err := array.Append(Uint64Value(i))
 		require.NoError(t, err)
 		require.Equal(t, savedRootID, array.SlabID())
@@ -2414,10 +2414,10 @@ func TestArrayRootSlabID(t *testing.T) {
 
 	require.True(t, typeInfoComparator(typeInfo, array.Type()))
 	require.Equal(t, address, array.Address())
-	require.Equal(t, uint64(arraySize), array.Count())
+	require.Equal(t, uint64(arrayCount), array.Count())
 
 	// Remove elements
-	for i := uint64(0); i < arraySize; i++ {
+	for i := uint64(0); i < arrayCount; i++ {
 		storable, err := array.Remove(0)
 		require.NoError(t, err)
 		require.Equal(t, Uint64Value(i), storable)
@@ -2435,7 +2435,7 @@ func TestArraySetRandomValues(t *testing.T) {
 	SetThreshold(256)
 	defer SetThreshold(1024)
 
-	const arraySize = 4096
+	const arrayCount = 4096
 
 	r := newRand(t)
 
@@ -2446,15 +2446,15 @@ func TestArraySetRandomValues(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]Value, arraySize)
-	for i := uint64(0); i < arraySize; i++ {
+	values := make([]Value, arrayCount)
+	for i := uint64(0); i < arrayCount; i++ {
 		v := Uint64Value(i)
 		values[i] = v
 		err := array.Append(v)
 		require.NoError(t, err)
 	}
 
-	for i := uint64(0); i < arraySize; i++ {
+	for i := uint64(0); i < arrayCount; i++ {
 		oldValue := values[i]
 		newValue := randomValue(r, int(MaxInlineArrayElementSize()))
 		values[i] = newValue
@@ -2477,7 +2477,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 	t.Run("insert-first", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		r := newRand(t)
 
@@ -2488,10 +2488,10 @@ func TestArrayInsertRandomValues(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := randomValue(r, int(MaxInlineArrayElementSize()))
-			values[arraySize-i-1] = v
+			values[arrayCount-i-1] = v
 
 			err := array.Insert(0, v)
 			require.NoError(t, err)
@@ -2502,7 +2502,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 	t.Run("insert-last", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		r := newRand(t)
 
@@ -2513,8 +2513,8 @@ func TestArrayInsertRandomValues(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := randomValue(r, int(MaxInlineArrayElementSize()))
 			values[i] = v
 
@@ -2527,7 +2527,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 	t.Run("insert-random", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		r := newRand(t)
 
@@ -2538,8 +2538,8 @@ func TestArrayInsertRandomValues(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			k := r.Intn(int(i) + 1)
 			v := randomValue(r, int(MaxInlineArrayElementSize()))
 
@@ -2559,7 +2559,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 	SetThreshold(256)
 	defer SetThreshold(1024)
 
-	const arraySize = 4096
+	const arrayCount = 4096
 
 	r := newRand(t)
 
@@ -2570,9 +2570,9 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]Value, arraySize)
+	values := make([]Value, arrayCount)
 	// Insert n random values into array
-	for i := uint64(0); i < arraySize; i++ {
+	for i := uint64(0); i < arrayCount; i++ {
 		v := randomValue(r, int(MaxInlineArrayElementSize()))
 		values[i] = v
 
@@ -2583,7 +2583,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 	testArray(t, storage, typeInfo, address, array, values, false)
 
 	// Remove n elements at random index
-	for i := uint64(0); i < arraySize; i++ {
+	for i := uint64(0); i < arrayCount; i++ {
 		k := r.Intn(int(array.Count()))
 
 		existingStorable, err := array.Remove(uint64(k))
@@ -2732,7 +2732,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("small array", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		childTypeInfo := testTypeInfo{43}
@@ -2743,8 +2743,8 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create child arrays with 1 element.
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, childTypeInfo)
 			require.NoError(t, err)
 
@@ -2768,8 +2768,8 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("big array", func(t *testing.T) {
 
-		const arraySize = 4096
-		const childArraySize = 40
+		const arrayCount = 4096
+		const childArrayCount = 40
 
 		typeInfo := testTypeInfo{42}
 		childTypeInfo := testTypeInfo{43}
@@ -2780,13 +2780,13 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create child arrays with 40 element.
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childArray, err := NewArray(storage, address, childTypeInfo)
 			require.NoError(t, err)
 
-			expectedChildArrayValues := make([]Value, childArraySize)
-			for i := uint64(0); i < childArraySize; i++ {
+			expectedChildArrayValues := make([]Value, childArrayCount)
+			for i := uint64(0); i < childArrayCount; i++ {
 				v := Uint64Value(math.MaxUint64)
 
 				err := childArray.Append(v)
@@ -2809,7 +2809,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("small map", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		childArayTypeInfo := testTypeInfo{43}
@@ -2819,8 +2819,8 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), childArayTypeInfo)
 			require.NoError(t, err)
 
@@ -2843,7 +2843,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("big map", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		nestedTypeInfo := testTypeInfo{43}
@@ -2853,8 +2853,8 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), nestedTypeInfo)
 			require.NoError(t, err)
@@ -2984,13 +2984,13 @@ func TestArrayDecodeV0(t *testing.T) {
 		arrayDataSlabID2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 3})
 		childArraySlabID := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 4})
 
-		const arraySize = 20
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize-1; i++ {
+		const arrayCount = 20
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount-1; i++ {
 			values[i] = NewStringValue(strings.Repeat("a", 22))
 		}
 
-		values[arraySize-1] = arrayValue{Uint64Value(0)}
+		values[arrayCount-1] = arrayValue{Uint64Value(0)}
 
 		slabData := map[SlabID][]byte{
 			// (metadata slab) headers: [{id:2 size:228 count:9} {id:3 size:270 count:11} ]
@@ -3199,9 +3199,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 18
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		const arrayCount = 18
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := NewStringValue(strings.Repeat("a", 22))
 			values[i] = v
 
@@ -3313,9 +3313,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 2
-		expectedValues := make([]Value, arraySize)
-		for i := 0; i < arraySize; i++ {
+		const arrayCount = 2
+		expectedValues := make([]Value, arrayCount)
+		for i := 0; i < arrayCount; i++ {
 			v := Uint64Value(i)
 
 			childArray, err := NewArray(storage, address, childTypeInfo)
@@ -3393,9 +3393,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 2
-		expectedValues := make([]Value, arraySize)
-		for i := 0; i < arraySize; i++ {
+		const arrayCount = 2
+		expectedValues := make([]Value, arrayCount)
+		for i := 0; i < arrayCount; i++ {
 			v := Uint64Value(i)
 
 			var ti TypeInfo
@@ -3482,9 +3482,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 2
-		expectedValues := make([]Value, arraySize)
-		for i := 0; i < arraySize; i++ {
+		const arrayCount = 2
+		expectedValues := make([]Value, arrayCount)
+		for i := 0; i < arrayCount; i++ {
 			v := Uint64Value(i)
 
 			gchildArray, err := NewArray(storage, address, typeInfo2)
@@ -3575,9 +3575,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 2
-		expectedValues := make([]Value, arraySize)
-		for i := 0; i < arraySize; i++ {
+		const arrayCount = 2
+		expectedValues := make([]Value, arrayCount)
+		for i := 0; i < arrayCount; i++ {
 			v := Uint64Value(i)
 
 			var ti TypeInfo
@@ -3686,9 +3686,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 20
-		expectedValues := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize-2; i++ {
+		const arrayCount = 20
+		expectedValues := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount-2; i++ {
 			v := NewStringValue(strings.Repeat("a", 22))
 
 			err := array.Append(v)
@@ -3711,7 +3711,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, arrayValue{v})
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -3830,9 +3830,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 20
-		expectedValues := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize-2; i++ {
+		const arrayCount = 20
+		expectedValues := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount-2; i++ {
 			v := NewStringValue(strings.Repeat("a", 22))
 
 			err := array.Append(v)
@@ -3863,7 +3863,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, arrayValue{v})
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -3983,9 +3983,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 20
-		expectedValues := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize-1; i++ {
+		const arrayCount = 20
+		expectedValues := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount-1; i++ {
 			v := NewStringValue(strings.Repeat("a", 22))
 
 			err := array.Append(v)
@@ -3994,13 +3994,13 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, v)
 		}
 
-		const childArraySize = 5
+		const childArrayCount = 5
 
 		childArray, err := NewArray(storage, address, typeInfo2)
 		require.NoError(t, err)
 
-		expectedChildArrayValues := make([]Value, childArraySize)
-		for i := 0; i < childArraySize; i++ {
+		expectedChildArrayValues := make([]Value, childArrayCount)
+		for i := 0; i < childArrayCount; i++ {
 			v := NewStringValue(strings.Repeat("b", 22))
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -4012,7 +4012,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 
 		expectedValues = append(expectedValues, arrayValue(expectedChildArrayValues))
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 		require.Equal(t, uint64(5), childArray.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -4146,9 +4146,9 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arraySize = 20
-		expectedValues := make([]Value, 0, arraySize)
-		for i := uint64(0); i < arraySize-1; i++ {
+		const arrayCount = 20
+		expectedValues := make([]Value, 0, arrayCount)
+		for i := uint64(0); i < arrayCount-1; i++ {
 			v := NewStringValue(strings.Repeat("a", 22))
 
 			err := array.Append(v)
@@ -4163,10 +4163,10 @@ func TestArrayEncodeDecode(t *testing.T) {
 		gchildArray, err := NewArray(storage, address, typeInfo2)
 		require.NoError(t, err)
 
-		const gchildArraySize = 5
+		const gchildArrayCount = 5
 
-		expectedGChildArrayValues := make([]Value, gchildArraySize)
-		for i := 0; i < gchildArraySize; i++ {
+		expectedGChildArrayValues := make([]Value, gchildArrayCount)
+		for i := 0; i < gchildArrayCount; i++ {
 			v := NewStringValue(strings.Repeat("b", 22))
 
 			err = gchildArray.Append(v)
@@ -4185,7 +4185,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			arrayValue(expectedGChildArrayValues),
 		})
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 		require.Equal(t, uint64(1), childArray.Count())
 		require.Equal(t, uint64(5), gchildArray.Count())
 
@@ -4443,14 +4443,14 @@ func TestArrayStringElement(t *testing.T) {
 
 	t.Run("inline", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		r := newRand(t)
 
 		stringSize := int(MaxInlineArrayElementSize() - 3)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			s := randStr(r, stringSize)
 			values[i] = NewStringValue(s)
 		}
@@ -4462,7 +4462,7 @@ func TestArrayStringElement(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(values[i])
 			require.NoError(t, err)
 		}
@@ -4476,14 +4476,14 @@ func TestArrayStringElement(t *testing.T) {
 
 	t.Run("external slab", func(t *testing.T) {
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		r := newRand(t)
 
 		stringSize := int(MaxInlineArrayElementSize() + 512)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			s := randStr(r, stringSize)
 			values[i] = NewStringValue(s)
 		}
@@ -4495,7 +4495,7 @@ func TestArrayStringElement(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(values[i])
 			require.NoError(t, err)
 		}
@@ -4504,13 +4504,13 @@ func TestArrayStringElement(t *testing.T) {
 
 		stats, err := GetArrayStats(array)
 		require.NoError(t, err)
-		require.Equal(t, uint64(arraySize), stats.StorableSlabCount)
+		require.Equal(t, uint64(arrayCount), stats.StorableSlabCount)
 	})
 }
 
 func TestArrayStoredValue(t *testing.T) {
 
-	const arraySize = 4096
+	const arrayCount = 4096
 
 	typeInfo := testTypeInfo{42}
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -4519,8 +4519,8 @@ func TestArrayStoredValue(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]Value, arraySize)
-	for i := uint64(0); i < arraySize; i++ {
+	values := make([]Value, arrayCount)
+	for i := uint64(0); i < arrayCount; i++ {
 		v := Uint64Value(i)
 		values[i] = v
 		err := array.Append(v)
@@ -4582,7 +4582,7 @@ func TestArrayPopIterate(t *testing.T) {
 
 	t.Run("root-dataslab", func(t *testing.T) {
 
-		const arraySize = 10
+		const arrayCount = 10
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -4591,8 +4591,8 @@ func TestArrayPopIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -4603,11 +4603,11 @@ func TestArrayPopIterate(t *testing.T) {
 		err = array.PopIterate(func(v Storable) {
 			vv, err := v.StoredValue(storage)
 			require.NoError(t, err)
-			valueEqual(t, values[arraySize-i-1], vv)
+			valueEqual(t, values[arrayCount-i-1], vv)
 			i++
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 
 		testEmptyArray(t, storage, typeInfo, address, array)
 	})
@@ -4616,7 +4616,7 @@ func TestArrayPopIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -4625,8 +4625,8 @@ func TestArrayPopIterate(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
@@ -4637,11 +4637,11 @@ func TestArrayPopIterate(t *testing.T) {
 		err = array.PopIterate(func(v Storable) {
 			vv, err := v.StoredValue(storage)
 			require.NoError(t, err)
-			valueEqual(t, values[arraySize-i-1], vv)
+			valueEqual(t, values[arrayCount-i-1], vv)
 			i++
 		})
 		require.NoError(t, err)
-		require.Equal(t, arraySize, i)
+		require.Equal(t, arrayCount, i)
 
 		testEmptyArray(t, storage, typeInfo, address, array)
 	})
@@ -4680,7 +4680,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 	t.Run("root-dataslab", func(t *testing.T) {
 
-		const arraySize = 10
+		const arrayCount = 10
 
 		typeInfo := testTypeInfo{42}
 		array, err := NewArray(
@@ -4689,15 +4689,15 @@ func TestArrayFromBatchData(t *testing.T) {
 			typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4723,7 +4723,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		typeInfo := testTypeInfo{42}
 
@@ -4733,15 +4733,15 @@ func TestArrayFromBatchData(t *testing.T) {
 			typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := Uint64Value(i)
 			values[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4866,7 +4866,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const arraySize = 4096
+		const arrayCount = 4096
 
 		r := newRand(t)
 
@@ -4878,8 +4878,8 @@ func TestArrayFromBatchData(t *testing.T) {
 			typeInfo)
 		require.NoError(t, err)
 
-		values := make([]Value, arraySize)
-		for i := uint64(0); i < arraySize; i++ {
+		values := make([]Value, arrayCount)
+		for i := uint64(0); i < arrayCount; i++ {
 			v := randomValue(r, int(MaxInlineArrayElementSize()))
 			values[i] = v
 
@@ -4887,7 +4887,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4970,7 +4970,7 @@ func TestArrayNestedStorables(t *testing.T) {
 
 	typeInfo := testTypeInfo{42}
 
-	const arraySize = 1024 * 4
+	const arrayCount = 1024 * 4
 
 	storage := newTestPersistentStorage(t)
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -4978,8 +4978,8 @@ func TestArrayNestedStorables(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]Value, arraySize)
-	for i := uint64(0); i < arraySize; i++ {
+	values := make([]Value, arrayCount)
+	for i := uint64(0); i < arrayCount; i++ {
 		s := strings.Repeat("a", int(i))
 		v := SomeValue{Value: NewStringValue(s)}
 		values[i] = someValue{NewStringValue(s)}
@@ -5029,7 +5029,7 @@ func TestArrayString(t *testing.T) {
 	defer SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const arraySize = 6
+		const arrayCount = 6
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5038,7 +5038,7 @@ func TestArrayString(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -5048,7 +5048,7 @@ func TestArrayString(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const arraySize = 120
+		const arrayCount = 120
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5057,7 +5057,7 @@ func TestArrayString(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -5072,7 +5072,7 @@ func TestArraySlabDump(t *testing.T) {
 	defer SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const arraySize = 6
+		const arrayCount = 6
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5081,7 +5081,7 @@ func TestArraySlabDump(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -5095,7 +5095,7 @@ func TestArraySlabDump(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const arraySize = 120
+		const arrayCount = 120
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5104,7 +5104,7 @@ func TestArraySlabDump(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < arraySize; i++ {
+		for i := uint64(0); i < arrayCount; i++ {
 			err := array.Append(Uint64Value(i))
 			require.NoError(t, err)
 		}
@@ -5196,8 +5196,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 3
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 3
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			require.Equal(t, 1, GetDeltasCount(storage))
@@ -5211,12 +5211,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 3
-			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 3
+			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5227,12 +5227,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 3
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 3
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5254,12 +5254,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 3
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 3
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5281,12 +5281,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 3
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 3
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5310,12 +5310,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 3
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 3
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5343,13 +5343,13 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root data slab with simple and composite values, unload composite element", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
-			const arraySize = 3
+			const arrayCount = 3
 
 			// Create an array with nested composite value at specified index
-			for childArrayIndex := 0; childArrayIndex < arraySize; childArrayIndex++ {
+			for childArrayIndex := 0; childArrayIndex < arrayCount; childArrayIndex++ {
 				storage := newTestPersistentStorage(t)
 
-				array, values, childSlabID := createArrayWithSimpleAndChildArrayValues(t, storage, address, typeInfo, arraySize, childArrayIndex, useWrapperValue)
+				array, values, childSlabID := createArrayWithSimpleAndChildArrayValues(t, storage, address, typeInfo, arrayCount, childArrayIndex, useWrapperValue)
 
 				// parent array: 1 root data slab
 				// nested composite element: 1 root data slab
@@ -5374,8 +5374,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 20
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 20
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			require.Equal(t, 3, GetDeltasCount(storage))
@@ -5389,12 +5389,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 20
-			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 20
+			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5405,12 +5405,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 20
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 20
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5432,12 +5432,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 20
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 20
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5459,12 +5459,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 20
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 20
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arraySize, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, values)
@@ -5487,13 +5487,13 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with simple and composite values, unload composite element", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
-			const arraySize = 20
+			const arrayCount = 20
 
 			// Create an array with composite value at specified index.
-			for childArrayIndex := 0; childArrayIndex < arraySize; childArrayIndex++ {
+			for childArrayIndex := 0; childArrayIndex < arrayCount; childArrayIndex++ {
 				storage := newTestPersistentStorage(t)
 
-				array, values, childSlabID := createArrayWithSimpleAndChildArrayValues(t, storage, address, typeInfo, arraySize, childArrayIndex, useWrapperValue)
+				array, values, childSlabID := createArrayWithSimpleAndChildArrayValues(t, storage, address, typeInfo, arrayCount, childArrayIndex, useWrapperValue)
 
 				// parent array: 1 root metadata slab, 2 data slabs
 				// nested composite value element: 1 root data slab for each
@@ -5518,8 +5518,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 30
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 30
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (2 levels): 1 root metadata slab, 3 data slabs
 			require.Equal(t, 4, GetDeltasCount(storage))
@@ -5552,8 +5552,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 30
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 30
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (2 levels): 1 root metadata slab, 3 data slabs
 			require.Equal(t, 4, GetDeltasCount(storage))
@@ -5586,8 +5586,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 30
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 30
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (2 levels): 1 root metadata slab, 3 data slabs
 			require.Equal(t, 4, GetDeltasCount(storage))
@@ -5625,8 +5625,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 250
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 250
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, 2 non-root metadata slabs, n data slabs
 			require.Equal(t, 3, getArrayMetaDataSlabCount(storage))
@@ -5656,8 +5656,8 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 250
-			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 250
+			array, values := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, 2 child metadata slabs, n data slabs
 			require.Equal(t, 3, getArrayMetaDataSlabCount(storage))
@@ -5688,12 +5688,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 500
-			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 500
+			array, values, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+arraySize)
+			require.True(t, GetDeltasCount(storage) > 1+arrayCount)
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, values)
@@ -5726,12 +5726,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 500
-			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 500
+			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+arraySize)
+			require.True(t, GetDeltasCount(storage) > 1+arrayCount)
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, values)
@@ -5801,12 +5801,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const arraySize = 500
-			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arraySize, useWrapperValue)
+			const arrayCount = 500
+			array, values, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+arraySize)
+			require.True(t, GetDeltasCount(storage) > 1+arrayCount)
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, values)
@@ -5961,7 +5961,7 @@ func createArrayWithSimpleValues(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	arraySize int,
+	arrayCount int,
 	useWrapperValue bool,
 ) (*Array, []Value) {
 
@@ -5969,9 +5969,9 @@ func createArrayWithSimpleValues(
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]Value, arraySize)
+	values := make([]Value, arrayCount)
 	r := rune('a')
-	for i := 0; i < arraySize; i++ {
+	for i := 0; i < arrayCount; i++ {
 		s := NewStringValue(strings.Repeat(string(r), 20))
 
 		if useWrapperValue {
@@ -5995,25 +5995,25 @@ func createArrayWithChildArrays(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	arraySize int,
+	arrayCount int,
 	useWrapperValue bool,
 ) (*Array, []Value, []SlabID) {
-	const childArraySize = 50
+	const childArrayCount = 50
 
 	// Create parent array
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	expectedValues := make([]Value, arraySize)
-	childSlabIDs := make([]SlabID, arraySize)
+	expectedValues := make([]Value, arrayCount)
+	childSlabIDs := make([]SlabID, arrayCount)
 
-	for i := 0; i < arraySize; i++ {
+	for i := 0; i < arrayCount; i++ {
 		// Create child array
 		childArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedChildArrayValues := make([]Value, childArraySize)
-		for j := 0; j < childArraySize; j++ {
+		expectedChildArrayValues := make([]Value, childArrayCount)
+		for j := 0; j < childArrayCount; j++ {
 			v := Uint64Value(j)
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -6045,29 +6045,29 @@ func createArrayWithSimpleAndChildArrayValues(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	arraySize int,
+	arrayCount int,
 	compositeValueIndex int,
 	useWrapperValue bool,
 ) (*Array, []Value, SlabID) {
-	const childArraySize = 50
+	const childArrayCount = 50
 
-	require.True(t, compositeValueIndex < arraySize)
+	require.True(t, compositeValueIndex < arrayCount)
 
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	expectedValues := make([]Value, arraySize)
+	expectedValues := make([]Value, arrayCount)
 	var childSlabID SlabID
 	r := 'a'
-	for i := 0; i < arraySize; i++ {
+	for i := 0; i < arrayCount; i++ {
 
 		if compositeValueIndex == i {
 			// Create child array with one element
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
-			expectedChildArrayValues := make([]Value, childArraySize)
-			for j := 0; j < childArraySize; j++ {
+			expectedChildArrayValues := make([]Value, childArrayCount)
+			for j := 0; j < childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -6148,7 +6148,7 @@ func TestArrayID(t *testing.T) {
 
 func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 	const (
-		arraySize           = 3
+		arrayCount          = 3
 		initialStorableSize = 1
 		mutatedStorableSize = 5
 	)
@@ -6160,8 +6160,8 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	values := make([]*testMutableValue, arraySize)
-	for i := uint64(0); i < arraySize; i++ {
+	values := make([]*testMutableValue, arrayCount)
+	for i := uint64(0); i < arrayCount; i++ {
 		v := newTestMutableValue(initialStorableSize)
 		values[i] = v
 
@@ -6171,13 +6171,13 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 
 	require.True(t, IsArrayRootDataSlab(array))
 
-	expectedArrayRootDataSlabSize := arrayRootDataSlabPrefixSize + initialStorableSize*arraySize
+	expectedArrayRootDataSlabSize := arrayRootDataSlabPrefixSize + initialStorableSize*arrayCount
 	require.Equal(t, uint32(expectedArrayRootDataSlabSize), GetArrayRootSlabByteSize(array))
 
 	err = VerifyArray(array, address, typeInfo, typeInfoComparator, hashInputProvider, true)
 	require.NoError(t, err)
 
-	for i := uint64(0); i < arraySize; i++ {
+	for i := uint64(0); i < arrayCount; i++ {
 		mv := values[i]
 		mv.updateStorableSize(mutatedStorableSize)
 
@@ -6188,7 +6188,7 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 
 	require.True(t, IsArrayRootDataSlab(array))
 
-	expectedArrayRootDataSlabSize = arrayRootDataSlabPrefixSize + mutatedStorableSize*arraySize
+	expectedArrayRootDataSlabSize = arrayRootDataSlabPrefixSize + mutatedStorableSize*arrayCount
 	require.Equal(t, uint32(expectedArrayRootDataSlabSize), GetArrayRootSlabByteSize(array))
 
 	err = VerifyArray(array, address, typeInfo, typeInfoComparator, hashInputProvider, true)
@@ -6201,22 +6201,22 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 	defer SetThreshold(1024)
 
 	t.Run("parent is root data slab, with one child array", func(t *testing.T) {
-		const arraySize = 1
+		const arrayCount = 1
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 		// Create an array with empty child array as element.
-		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
+		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
 		require.True(t, uint64(GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 empty inlined child arrays
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
@@ -6321,24 +6321,24 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		require.Equal(t, uint64(0), childArray.Count())
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 	})
 
 	t.Run("parent is root data slab, with two child arrays", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 		// Create an array with empty child array as element.
-		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
+		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 2 empty inlined child arrays
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
@@ -6349,9 +6349,9 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		children := make([]struct {
 			array   *Array
 			valueID ValueID
-		}, arraySize)
+		}, arrayCount)
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
@@ -6520,25 +6520,25 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		for _, child := range children {
 			require.Equal(t, uint64(0), child.array.Count())
 		}
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 	})
 
 	t.Run("parent is root metadata slab, with four child arrays", func(t *testing.T) {
-		const arraySize = 4
+		const arrayCount = 4
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 		// Create an array with empty child array as element.
-		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
+		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 4 empty inlined child arrays
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
@@ -6549,9 +6549,9 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		children := make([]struct {
 			array   *Array
 			valueID ValueID
-		}, arraySize)
+		}, arrayCount)
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
@@ -6637,7 +6637,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		// Parent array has one data slab and all child arrays are not inlined.
-		require.Equal(t, 1+arraySize, getStoredDeltas(storage))
+		require.Equal(t, 1+arrayCount, getStoredDeltas(storage))
 		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove one element from child array which triggers standalone array slab becomes inlined slab again.
@@ -6712,7 +6712,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		for _, child := range children {
 			require.Equal(t, uint64(0), child.array.Count())
 		}
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 	})
 }
 
@@ -6722,21 +6722,21 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 	defer SetThreshold(1024)
 
 	t.Run("parent is root data slab, one child array, one grand child array, changes to grand child array triggers child array slab to become standalone slab", func(t *testing.T) {
-		const arraySize = 1
+		const arrayCount = 1
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 		// Create an array with empty child array as element, which has empty child array.
-		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arraySize)
+		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 inlined child array
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
@@ -6913,25 +6913,25 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 		require.Equal(t, uint64(0), gchildArray.Count())
 		require.Equal(t, uint64(1), childArray.Count())
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 	})
 
 	t.Run("parent is root data slab, one child array, one grand child array, changes to grand child array triggers grand child array slab to become standalone slab", func(t *testing.T) {
-		const arraySize = 1
+		const arrayCount = 1
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 		// Create an array with empty child array as element, which has empty child array.
-		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arraySize)
+		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 inlined child array
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
@@ -7109,11 +7109,11 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 		require.Equal(t, uint64(0), gchildArray.Count())
 		require.Equal(t, uint64(1), childArray.Count())
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 	})
 
 	t.Run("parent is root data slab, two child array, one grand child array each, changes to child array triggers child array slab to become standalone slab", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -7126,8 +7126,8 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := 0; i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := 0; i < arrayCount; i++ {
 			// Create child array
 			child, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -7151,12 +7151,12 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			expectedValues[i] = arrayValue{arrayValue{v}}
 		}
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 1 inlined child array
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize + vSize*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arrayCount + vSize*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
@@ -7170,9 +7170,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			child   *arrayInfo
 		}
 
-		children := make([]arrayInfo, arraySize)
+		children := make([]arrayInfo, arrayCount)
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
@@ -7410,11 +7410,11 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, uint64(1), child.child.array.Count())
 			require.Equal(t, uint64(1), child.array.Count())
 		}
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 	})
 
 	t.Run("parent is root metadata slab, with four child arrays, each child array has grand child arrays", func(t *testing.T) {
-		const arraySize = 4
+		const arrayCount = 4
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -7427,8 +7427,8 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
-		for i := 0; i < arraySize; i++ {
+		expectedValues := make([]Value, arrayCount)
+		for i := 0; i < arrayCount; i++ {
 			// Create child array
 			child, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -7448,11 +7448,11 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			expectedValues[i] = arrayValue{arrayValue{}}
 		}
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
-		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arraySize
+		expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*2*arrayCount
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
@@ -7466,9 +7466,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			child   *arrayInfo
 		}
 
-		children := make([]arrayInfo, arraySize)
+		children := make([]arrayInfo, arrayCount)
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
@@ -7653,7 +7653,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		// Parent array has one root data slab, 4 grand child array with standalone root data slab.
-		require.Equal(t, 1+arraySize, getStoredDeltas(storage))
+		require.Equal(t, 1+arrayCount, getStoredDeltas(storage))
 		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove elements from grand child array to trigger child array inlined again.
@@ -7763,31 +7763,31 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, uint64(0), child.child.array.Count())
 			require.Equal(t, uint64(1), child.array.Count())
 		}
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.Equal(t, 1, getStoredDeltas(storage))
 
-		expectedParentSize = uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize*2
+		expectedParentSize = uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arrayCount*2
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 	})
 }
 
 func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
-	const arraySize = 2
+	const arrayCount = 2
 
 	typeInfo := testTypeInfo{42}
 	storage := newTestPersistentStorage(t)
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	// Create an array with empty child array as element.
-	parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arraySize)
+	parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-	require.Equal(t, uint64(arraySize), parentArray.Count())
+	require.Equal(t, uint64(arrayCount), parentArray.Count())
 	require.True(t, IsArrayRootDataSlab(parentArray))
 	require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 	// Test parent slab size with empty inlined child arrays
-	expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arraySize
+	expectedParentSize := uint32(arrayRootDataSlabPrefixSize) + uint32(inlinedArrayDataSlabPrefixSize)*arrayCount
 	require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 	// Test array's mutableElementIndex
@@ -7799,9 +7799,9 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 		array       *Array
 		valueID     ValueID
 		parentIndex int
-	}, arraySize)
+	}, arrayCount)
 
-	for i := 0; i < arraySize; i++ {
+	for i := 0; i < arrayCount; i++ {
 		e, err := parentArray.Get(uint64(i))
 		require.NoError(t, err)
 		require.Equal(t, 1, getStoredDeltas(storage))
@@ -8090,15 +8090,15 @@ func createArrayWithEmptyChildArray(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	arraySize int,
+	arrayCount int,
 ) (*Array, []Value) {
 
 	// Create parent array
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	expectedValues := make([]Value, arraySize)
-	for i := 0; i < arraySize; i++ {
+	expectedValues := make([]Value, arrayCount)
+	for i := 0; i < arrayCount; i++ {
 		// Create child array
 		child, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
@@ -8118,15 +8118,15 @@ func createArrayWithEmpty2LevelChildArray(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	arraySize int,
+	arrayCount int,
 ) (*Array, []Value) {
 
 	// Create parent array
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	expectedValues := make([]Value, arraySize)
-	for i := 0; i < arraySize; i++ {
+	expectedValues := make([]Value, arrayCount)
+	for i := 0; i < arrayCount; i++ {
 		// Create child array
 		child, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
@@ -8165,7 +8165,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8175,7 +8175,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -8206,7 +8206,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child array value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			existingStorable, err := parentArray.Set(uint64(i), Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
@@ -8232,7 +8232,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8242,7 +8242,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -8266,7 +8266,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child array value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			existingStorable, err := parentArray.Set(uint64(i), Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
@@ -8292,7 +8292,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8302,7 +8302,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -8338,7 +8338,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child map value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			existingStorable, err := parentArray.Set(uint64(i), Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
@@ -8364,7 +8364,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8374,7 +8374,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -8403,7 +8403,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child map value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			existingStorable, err := parentArray.Set(uint64(i), Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
@@ -8434,7 +8434,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8444,7 +8444,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -8475,7 +8475,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Remove child array value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			valueStorable, err := parentArray.Remove(uint64(0))
 			require.NoError(t, err)
 
@@ -8498,7 +8498,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8508,7 +8508,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -8532,7 +8532,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Remove child array value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			valueStorable, err := parentArray.Remove(uint64(0))
 			require.NoError(t, err)
 
@@ -8555,7 +8555,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8565,7 +8565,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -8601,7 +8601,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Remove child map value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			valueStorable, err := parentArray.Remove(uint64(0))
 			require.NoError(t, err)
 
@@ -8624,7 +8624,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const arraySize = 2
+		const arrayCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -8634,7 +8634,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 
 		var expectedValues arrayValue
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -8663,7 +8663,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Remove child map value
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			valueStorable, err := parentArray.Remove(uint64(0))
 			require.NoError(t, err)
 
@@ -8834,14 +8834,14 @@ func TestArraySetType(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		arraySize := 10
-		for i := 0; i < arraySize; i++ {
+		arrayCount := 10
+		for i := 0; i < arrayCount; i++ {
 			v := Uint64Value(i)
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 		require.Equal(t, typeInfo, array.Type())
 		require.True(t, IsArrayRootDataSlab(array))
 
@@ -8862,14 +8862,14 @@ func TestArraySetType(t *testing.T) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		arraySize := 10_000
-		for i := 0; i < arraySize; i++ {
+		arrayCount := 10_000
+		for i := 0; i < arrayCount; i++ {
 			v := Uint64Value(i)
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arraySize), array.Count())
+		require.Equal(t, uint64(arrayCount), array.Count())
 		require.Equal(t, typeInfo, array.Type())
 		require.False(t, IsArrayRootDataSlab(array))
 
@@ -8923,8 +8923,8 @@ func TestArraySetType(t *testing.T) {
 		parentArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		arraySize := 10_000
-		for i := 0; i < arraySize-1; i++ {
+		arrayCount := 10_000
+		for i := 0; i < arrayCount-1; i++ {
 			v := Uint64Value(i)
 			err := parentArray.Append(v)
 			require.NoError(t, err)
@@ -8936,7 +8936,7 @@ func TestArraySetType(t *testing.T) {
 		err = parentArray.Append(childArray)
 		require.NoError(t, err)
 
-		require.Equal(t, uint64(arraySize), parentArray.Count())
+		require.Equal(t, uint64(arrayCount), parentArray.Count())
 		require.Equal(t, typeInfo, parentArray.Type())
 		require.False(t, IsArrayRootDataSlab(parentArray))
 		require.False(t, parentArray.Inlined())
@@ -8954,7 +8954,7 @@ func TestArraySetType(t *testing.T) {
 		err = storage.FastCommit(runtime.NumCPU())
 		require.NoError(t, err)
 
-		testExistingInlinedArraySetType(t, parentArray.SlabID(), arraySize-1, GetBaseStorage(storage), newTypeInfo, childArray.Count())
+		testExistingInlinedArraySetType(t, parentArray.SlabID(), arrayCount-1, GetBaseStorage(storage), newTypeInfo, childArray.Count())
 	})
 }
 

--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -94,16 +94,16 @@ var newArrayValueFunc = func(
 	t *testing.T,
 	address Address,
 	typeInfo TypeInfo,
-	arraySize int,
+	arrayCount int,
 	newValue newValueFunc,
 ) newValueFunc {
 	return func(storage SlabStorage) (value Value, expected Value) {
 		array, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedValues := make([]Value, arraySize)
+		expectedValues := make([]Value, arrayCount)
 
-		for i := 0; i < arraySize; i++ {
+		for i := 0; i < arrayCount; i++ {
 			v, expectedV := newValue(storage)
 
 			err := array.Append(v)
@@ -478,27 +478,27 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	testCases := newArrayWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases {
+		for _, arrayCountTestCase := range arrayCountTestCases {
 
-			arraySize := arraySizeTestCase.arraySize
+			arrayCount := arrayCountTestCase.arrayCount
 
-			name := arraySizeTestCase.name + " " + tc.name
+			name := arrayCountTestCase.name + " " + tc.name
 			if tc.modifyName != "" {
 				name += ", " + tc.modifyName
 			}
@@ -513,8 +513,8 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 				arraySlabID := array.SlabID()
 
 				// Append WrapperValue to array
-				expectedValues := make([]Value, arraySize)
-				for i := 0; i < arraySize; i++ {
+				expectedValues := make([]Value, arrayCount)
+				for i := 0; i < arrayCount; i++ {
 					v, expectedV := tc.newElement(storage)
 
 					err := array.Append(v)
@@ -523,7 +523,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 					expectedValues[i] = expectedV
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -551,7 +551,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 					expectedValues[i] = newExpectedV
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -566,7 +566,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 				array2, err := NewArrayWithRootID(storage2, arraySlabID)
 				require.NoError(t, err)
-				require.Equal(t, uint64(arraySize), array2.Count())
+				require.Equal(t, uint64(arrayCount), array2.Count())
 
 				// Test loaded array
 				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -590,27 +590,27 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	testCases := newArrayWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases {
+		for _, arrayCountTestCase := range arrayCountTestCases {
 
-			arraySize := arraySizeTestCase.arraySize
+			arrayCount := arrayCountTestCase.arrayCount
 
-			name := arraySizeTestCase.name + " " + tc.name
+			name := arrayCountTestCase.name + " " + tc.name
 			if tc.modifyName != "" {
 				name += "," + tc.modifyName
 			}
@@ -625,8 +625,8 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 				arraySlabID := array.SlabID()
 
 				// Insert WrapperValue in reverse order to array
-				expectedValues := make([]Value, arraySize)
-				for i := arraySize - 1; i >= 0; i-- {
+				expectedValues := make([]Value, arrayCount)
+				for i := arrayCount - 1; i >= 0; i-- {
 					v, expectedV := tc.newElement(storage)
 
 					err := array.Insert(0, v)
@@ -635,7 +635,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 					expectedValues[i] = expectedV
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -663,7 +663,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 					expectedValues[i] = newExpectedV
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -678,7 +678,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 				array2, err := NewArrayWithRootID(storage2, arraySlabID)
 				require.NoError(t, err)
-				require.Equal(t, uint64(arraySize), array2.Count())
+				require.Equal(t, uint64(arrayCount), array2.Count())
 
 				// Test loaded array
 				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -702,27 +702,27 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	testCases := newArrayWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases {
+		for _, arrayCountTestCase := range arrayCountTestCases {
 
-			arraySize := arraySizeTestCase.arraySize
+			arrayCount := arrayCountTestCase.arrayCount
 
-			name := arraySizeTestCase.name + " " + tc.name
+			name := arrayCountTestCase.name + " " + tc.name
 			if tc.modifyName != "" {
 				name += "," + tc.modifyName
 			}
@@ -737,8 +737,8 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 				arraySlabID := array.SlabID()
 
 				// Insert WrapperValue to array
-				expectedValues := make([]Value, arraySize)
-				for i := 0; i < arraySize; i++ {
+				expectedValues := make([]Value, arrayCount)
+				for i := 0; i < arrayCount; i++ {
 					v, expectedV := tc.newElement(storage)
 
 					err := array.Insert(array.Count(), v)
@@ -747,14 +747,14 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[i] = expectedV
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
 				testArray(t, storage, typeInfo, address, array, expectedValues, true)
 
 				// Set new WrapperValue in array
-				for i := 0; i < arraySize; i++ {
+				for i := 0; i < arrayCount; i++ {
 					v, expected := tc.newElement(storage)
 
 					testSetElementInArray(t, storage, array, uint64(i), v, expectedValues[i])
@@ -762,7 +762,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[i] = expected
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -790,7 +790,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[i] = newExpectedV
 				}
 
-				require.Equal(t, uint64(arraySize), array.Count())
+				require.Equal(t, uint64(arrayCount), array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -805,7 +805,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				array2, err := NewArrayWithRootID(storage2, arraySlabID)
 				require.NoError(t, err)
-				require.Equal(t, uint64(arraySize), array2.Count())
+				require.Equal(t, uint64(arrayCount), array2.Count())
 
 				// Test loaded array
 				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -828,16 +828,16 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	modifyTestCases := []struct {
@@ -848,41 +848,41 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 		{name: "", needToModifyElement: false},
 	}
 
-	removeSizeTestCases := []struct {
+	removeTestCases := []struct {
 		name               string
 		removeAllElements  bool
 		removeElementCount int
 	}{
 		{name: "remove all elements", removeAllElements: true},
 		{name: "remove 1 element", removeElementCount: 1},
-		{name: fmt.Sprintf("remove %d element", smallArraySize/2), removeElementCount: smallArraySize / 2},
+		{name: fmt.Sprintf("remove %d element", smallArrayCount/2), removeElementCount: smallArrayCount / 2},
 	}
 
 	testCases := newArrayWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases {
+		for _, arrayCountTestCase := range arrayCountTestCases {
 
 			for _, modifyTestCase := range modifyTestCases {
 
-				for _, removeSizeTestCase := range removeSizeTestCases {
+				for _, removeTestCase := range removeTestCases {
 
-					arraySize := arraySizeTestCase.arraySize
+					arrayCount := arrayCountTestCase.arrayCount
 
 					needToModifyElement := modifyTestCase.needToModifyElement
 
-					removeSize := removeSizeTestCase.removeElementCount
-					if removeSizeTestCase.removeAllElements {
-						removeSize = arraySize
+					removeCount := removeTestCase.removeElementCount
+					if removeTestCase.removeAllElements {
+						removeCount = arrayCount
 					}
 
-					name := arraySizeTestCase.name + " " + tc.name
+					name := arrayCountTestCase.name + " " + tc.name
 					if modifyTestCase.needToModifyElement {
 						name += ", " + tc.modifyName
 					}
-					if removeSizeTestCase.name != "" {
-						name += ", " + removeSizeTestCase.name
+					if removeTestCase.name != "" {
+						name += ", " + removeTestCase.name
 					}
 
 					t.Run(name, func(t *testing.T) {
@@ -895,8 +895,8 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 						arraySlabID := array.SlabID()
 
 						// Insert WrapperValue to array
-						expectedValues := make([]Value, arraySize)
-						for i := 0; i < arraySize; i++ {
+						expectedValues := make([]Value, arrayCount)
+						for i := 0; i < arrayCount; i++ {
 							v, expectedV := tc.newElement(storage)
 
 							err := array.Insert(array.Count(), v)
@@ -905,7 +905,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 							expectedValues[i] = expectedV
 						}
 
-						require.Equal(t, uint64(arraySize), array.Count())
+						require.Equal(t, uint64(arrayCount), array.Count())
 
 						testArrayMutableElementIndex(t, array)
 
@@ -934,7 +934,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 								expectedValues[i] = newExpectedV
 							}
 
-							require.Equal(t, uint64(arraySize), array.Count())
+							require.Equal(t, uint64(arrayCount), array.Count())
 
 							testArrayMutableElementIndex(t, array)
 
@@ -942,7 +942,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 						}
 
 						// Remove random elements
-						for i := 0; i < removeSize; i++ {
+						for i := 0; i < removeCount; i++ {
 
 							removeIndex := r.Intn(int(array.Count()))
 
@@ -951,8 +951,8 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 							expectedValues = append(expectedValues[:removeIndex], expectedValues[removeIndex+1:]...)
 						}
 
-						require.Equal(t, uint64(arraySize-removeSize), array.Count())
-						require.Equal(t, arraySize-removeSize, len(expectedValues))
+						require.Equal(t, uint64(arrayCount-removeCount), array.Count())
+						require.Equal(t, arrayCount-removeCount, len(expectedValues))
 
 						testArrayMutableElementIndex(t, array)
 
@@ -967,7 +967,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 
 						array2, err := NewArrayWithRootID(storage2, arraySlabID)
 						require.NoError(t, err)
-						require.Equal(t, uint64(arraySize-removeSize), array2.Count())
+						require.Equal(t, uint64(arrayCount-removeCount), array2.Count())
 
 						// Test loaded array
 						testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -992,16 +992,16 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	modifyTestCases := []struct {
@@ -1012,41 +1012,41 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 		{name: "", needToModifyElement: false},
 	}
 
-	removeSizeTestCases := []struct {
+	removeTestCases := []struct {
 		name               string
 		removeAllElements  bool
 		removeElementCount int
 	}{
 		{name: "remove all elements", removeAllElements: true},
 		{name: "remove 1 element", removeElementCount: 1},
-		{name: fmt.Sprintf("remove %d element", smallArraySize/2), removeElementCount: smallArraySize / 2},
+		{name: fmt.Sprintf("remove %d element", smallArrayCount/2), removeElementCount: smallArrayCount / 2},
 	}
 
 	testCases := newArrayWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases {
+		for _, arrayCountTestCase := range arrayCountTestCases {
 
 			for _, modifyTestCase := range modifyTestCases {
 
-				for _, removeSizeTestCase := range removeSizeTestCases {
+				for _, removeTestCase := range removeTestCases {
 
-					arraySize := arraySizeTestCase.arraySize
+					arrayCount := arrayCountTestCase.arrayCount
 
 					needToModifyElement := modifyTestCase.needToModifyElement
 
-					removeSize := removeSizeTestCase.removeElementCount
-					if removeSizeTestCase.removeAllElements {
-						removeSize = arraySize
+					removeCount := removeTestCase.removeElementCount
+					if removeTestCase.removeAllElements {
+						removeCount = arrayCount
 					}
 
-					name := arraySizeTestCase.name + " " + tc.name
+					name := arrayCountTestCase.name + " " + tc.name
 					if modifyTestCase.needToModifyElement {
 						name += ", " + tc.modifyName
 					}
-					if removeSizeTestCase.name != "" {
-						name += ", " + removeSizeTestCase.name
+					if removeTestCase.name != "" {
+						name += ", " + removeTestCase.name
 					}
 
 					t.Run(name, func(t *testing.T) {
@@ -1058,10 +1058,10 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 						arraySlabID := array.SlabID()
 
-						expectedValues := make([]Value, arraySize)
+						expectedValues := make([]Value, arrayCount)
 
 						// Insert WrapperValue to array
-						for i := 0; i < arraySize; i++ {
+						for i := 0; i < arrayCount; i++ {
 							v, expectedV := tc.newElement(storage)
 
 							err := array.Insert(array.Count(), v)
@@ -1070,14 +1070,14 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 							expectedValues[i] = expectedV
 						}
 
-						require.Equal(t, uint64(arraySize), array.Count())
+						require.Equal(t, uint64(arrayCount), array.Count())
 
 						testArrayMutableElementIndex(t, array)
 
 						testArray(t, storage, typeInfo, address, array, expectedValues, true)
 
 						// Set WrapperValue in array
-						for i := 0; i < arraySize; i++ {
+						for i := 0; i < arrayCount; i++ {
 							v, expectedV := tc.newElement(storage)
 
 							testSetElementInArray(t, storage, array, uint64(i), v, expectedValues[i])
@@ -1085,7 +1085,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 							expectedValues[i] = expectedV
 						}
 
-						require.Equal(t, uint64(arraySize), array.Count())
+						require.Equal(t, uint64(arrayCount), array.Count())
 
 						testArrayMutableElementIndex(t, array)
 
@@ -1114,7 +1114,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 								expectedValues[i] = newExpectedV
 							}
 
-							require.Equal(t, uint64(arraySize), array.Count())
+							require.Equal(t, uint64(arrayCount), array.Count())
 
 							testArrayMutableElementIndex(t, array)
 
@@ -1122,7 +1122,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 						}
 
 						// Remove random elements
-						for i := 0; i < removeSize; i++ {
+						for i := 0; i < removeCount; i++ {
 
 							removeIndex := r.Intn(int(array.Count()))
 
@@ -1131,8 +1131,8 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 							expectedValues = append(expectedValues[:removeIndex], expectedValues[removeIndex+1:]...)
 						}
 
-						require.Equal(t, uint64(arraySize-removeSize), array.Count())
-						require.Equal(t, arraySize-removeSize, len(expectedValues))
+						require.Equal(t, uint64(arrayCount-removeCount), array.Count())
+						require.Equal(t, arrayCount-removeCount, len(expectedValues))
 
 						testArrayMutableElementIndex(t, array)
 
@@ -1147,7 +1147,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 						array2, err := NewArrayWithRootID(storage2, arraySlabID)
 						require.NoError(t, err)
-						require.Equal(t, uint64(arraySize-removeSize), array2.Count())
+						require.Equal(t, uint64(arrayCount-removeCount), array2.Count())
 
 						// Test loaded array
 						testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -1168,16 +1168,16 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	modifyTestCases := []struct {
@@ -1192,7 +1192,7 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases[:1] {
+		for _, arrayCountTestCase := range arrayCountTestCases[:1] {
 
 			for _, modifyTestCase := range modifyTestCases {
 
@@ -1201,11 +1201,11 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 					continue
 				}
 
-				arraySize := arraySizeTestCase.arraySize
+				arrayCount := arrayCountTestCase.arrayCount
 
 				testModifyElement := modifyTestCase.testModifyElement
 
-				name := arraySizeTestCase.name + " " + tc.name
+				name := arrayCountTestCase.name + " " + tc.name
 				if modifyTestCase.testModifyElement {
 					name += ", " + tc.modifyName
 				}
@@ -1217,10 +1217,10 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 					array, err := NewArray(storage, address, typeInfo)
 					require.NoError(t, err)
 
-					expectedValues := make([]Value, arraySize)
+					expectedValues := make([]Value, arrayCount)
 
 					// Insert WrapperValue to array
-					for i := 0; i < arraySize; i++ {
+					for i := 0; i < arrayCount; i++ {
 						v, expectedV := tc.newElement(storage)
 
 						err := array.Insert(array.Count(), v)
@@ -1229,7 +1229,7 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 						expectedValues[i] = expectedV
 					}
 
-					require.Equal(t, uint64(arraySize), array.Count())
+					require.Equal(t, uint64(arrayCount), array.Count())
 
 					testArrayMutableElementIndex(t, array)
 
@@ -1280,16 +1280,16 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallArraySize = 10
-		largeArraySize = 512
+		smallArrayCount = 10
+		largeArrayCount = 512
 	)
 
-	arraySizeTestCases := []struct {
-		name      string
-		arraySize int
+	arrayCountTestCases := []struct {
+		name       string
+		arrayCount int
 	}{
-		{name: "small array", arraySize: smallArraySize},
-		{name: "large array", arraySize: largeArraySize},
+		{name: "small array", arrayCount: smallArrayCount},
+		{name: "large array", arrayCount: largeArrayCount},
 	}
 
 	modifyTestCases := []struct {
@@ -1304,7 +1304,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		for _, arraySizeTestCase := range arraySizeTestCases[:1] {
+		for _, arrayCountTestCase := range arrayCountTestCases[:1] {
 
 			for _, modifyTestCase := range modifyTestCases {
 
@@ -1315,11 +1315,11 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 					continue
 				}
 
-				arraySize := arraySizeTestCase.arraySize
+				arrayCount := arrayCountTestCase.arrayCount
 
 				testModifyElement := modifyTestCase.testModifyElement
 
-				name := arraySizeTestCase.name + " " + tc.name
+				name := arrayCountTestCase.name + " " + tc.name
 				if modifyTestCase.testModifyElement {
 					name += ", " + tc.modifyName
 				}
@@ -1331,10 +1331,10 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 					array, err := NewArray(storage, address, typeInfo)
 					require.NoError(t, err)
 
-					expectedValues := make([]Value, arraySize)
+					expectedValues := make([]Value, arrayCount)
 
 					// Insert WrapperValue to array
-					for i := 0; i < arraySize; i++ {
+					for i := 0; i < arrayCount; i++ {
 						v, expectedV := tc.newElement(storage)
 
 						err := array.Insert(array.Count(), v)
@@ -1343,7 +1343,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 						expectedValues[i] = expectedV
 					}
 
-					require.Equal(t, uint64(arraySize), array.Count())
+					require.Equal(t, uint64(arrayCount), array.Count())
 
 					testArrayMutableElementIndex(t, array)
 
@@ -1378,7 +1378,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 						count++
 					}
 
-					require.Equal(t, uint64(arraySize), array.Count())
+					require.Equal(t, uint64(arrayCount), array.Count())
 
 					testArrayMutableElementIndex(t, array)
 
@@ -1461,8 +1461,8 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 	// Retrieve wrapped child array, and then append new elements to child array.
 	// Wrapped child array is expected to be unlined at the end of loop.
 
-	const childArraySize = 32
-	for i := 0; i < childArraySize; i++ {
+	const childArrayCount = 32
+	for i := 0; i < childArrayCount; i++ {
 		// Get element
 		element, err := array.Get(0)
 		require.NoError(t, err)
@@ -1504,8 +1504,8 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 	// Retrieve wrapped child array, and then remove elements to child array.
 	// Wrapped child array is expected to be inlined at the end of loop.
 
-	childArraySizeAfterRemoval := 2
-	removeCount := childArraySize - childArraySizeAfterRemoval
+	childArrayCountAfterRemoval := 2
+	removeCount := childArrayCount - childArrayCountAfterRemoval
 
 	for i := 0; i < removeCount; i++ {
 		// Get element
@@ -1653,8 +1653,8 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild array, and then append new elements to gchild array.
 	// Wrapped gchild array is expected to be unlined at the end of loop.
 
-	const gchildArraySize = 32
-	for i := 0; i < gchildArraySize; i++ {
+	const gchildArrayCount = 32
+	for i := 0; i < gchildArrayCount; i++ {
 		// Get element at level 1
 
 		elementAtLevel1, err := array.Get(0)
@@ -1715,8 +1715,8 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild array, and then remove elements from gchild array.
 	// Wrapped gchild array is expected to be inlined at the end of loop.
 
-	gchildArraySizeAfterRemoval := 2
-	removeCount := gchildArraySize - gchildArraySizeAfterRemoval
+	gchildArrayCountAfterRemoval := 2
+	removeCount := gchildArrayCount - gchildArrayCountAfterRemoval
 
 	for i := 0; i < removeCount; i++ {
 		// Get elementAtLevel1
@@ -1785,8 +1785,8 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 	const (
-		minWriteOperationSize = 124
-		maxWriteOperationSize = 256
+		minWriteOperationCount = 124
+		maxWriteOperationCount = 256
 	)
 
 	r := newRand(t)
@@ -1840,18 +1840,18 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	actualArraySize := 0
+	actualArrayCount := 0
 
 	t.Run("append and remove", func(t *testing.T) {
 
 		// Append elements
 
 		var appendCount int
-		for appendCount < minWriteOperationSize {
-			appendCount = r.Intn(maxWriteOperationSize + 1)
+		for appendCount < minWriteOperationCount {
+			appendCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualArraySize += appendCount
+		actualArrayCount += appendCount
 
 		for i := 0; i < appendCount; i++ {
 			newValue := newElementFuncs[r.Intn(len(newElementFuncs))]
@@ -1863,7 +1863,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = append(expectedValues, expected)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1878,7 +1878,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()) + 1)
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		removeIndex := getRandomUniquePositiveNumbers(r, int(array.Count()), removeCount)
 
@@ -1890,7 +1890,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1901,11 +1901,11 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 		// Insert elements
 
 		var insertCount int
-		for insertCount < minWriteOperationSize {
-			insertCount = r.Intn(maxWriteOperationSize + 1)
+		for insertCount < minWriteOperationCount {
+			insertCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualArraySize += insertCount
+		actualArrayCount += insertCount
 
 		lowestInsertIndex := math.MaxInt
 
@@ -1931,7 +1931,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = newExpectedValue
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1946,7 +1946,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()) + 1)
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		// Remove previously inserted element first
 
@@ -1968,7 +1968,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2002,7 +2002,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			setIndex = append(setIndex, index)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2017,7 +2017,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()))
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		// Remove some previously set elements first
 
@@ -2055,7 +2055,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2085,8 +2085,8 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 	const (
-		minWriteOperationSize = 124
-		maxWriteOperationSize = 256
+		minWriteOperationCount = 124
+		maxWriteOperationCount = 256
 	)
 
 	r := newRand(t)
@@ -2130,18 +2130,18 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	actualArraySize := 0
+	actualArrayCount := 0
 
 	t.Run("append and remove", func(t *testing.T) {
 
 		// Append elements
 
 		var appendCount int
-		for appendCount < minWriteOperationSize {
-			appendCount = r.Intn(maxWriteOperationSize + 1)
+		for appendCount < minWriteOperationCount {
+			appendCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualArraySize += appendCount
+		actualArrayCount += appendCount
 
 		for i := 0; i < appendCount; i++ {
 			v, expected := newValue(storage)
@@ -2152,7 +2152,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = append(expectedValues, expected)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2167,7 +2167,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()) + 1)
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		removeIndex := getRandomUniquePositiveNumbers(r, int(array.Count()), removeCount)
 
@@ -2179,7 +2179,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2190,11 +2190,11 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 		// Insert elements
 
 		var insertCount int
-		for insertCount < minWriteOperationSize {
-			insertCount = r.Intn(maxWriteOperationSize + 1)
+		for insertCount < minWriteOperationCount {
+			insertCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualArraySize += insertCount
+		actualArrayCount += insertCount
 
 		lowestInsertIndex := math.MaxInt
 
@@ -2219,7 +2219,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = newExpectedValue
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2234,7 +2234,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()) + 1)
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		// Remove previously inserted element first
 
@@ -2256,7 +2256,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2298,7 +2298,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			setIndex = append(setIndex, index)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2313,7 +2313,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()))
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		// Remove some previously set elements first
 
@@ -2351,7 +2351,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2381,8 +2381,8 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 	const (
-		minWriteOperationSize = 124
-		maxWriteOperationSize = 256
+		minWriteOperationCount = 124
+		maxWriteOperationCount = 256
 	)
 
 	r := newRand(t)
@@ -2439,18 +2439,18 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 	array, err := NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	actualArraySize := 0
+	actualArrayCount := 0
 
 	t.Run("append and remove", func(t *testing.T) {
 
 		// Append elements
 
 		var appendCount int
-		for appendCount < minWriteOperationSize {
-			appendCount = r.Intn(maxWriteOperationSize + 1)
+		for appendCount < minWriteOperationCount {
+			appendCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualArraySize += appendCount
+		actualArrayCount += appendCount
 
 		for i := 0; i < appendCount; i++ {
 			v, expected := newValue(storage)
@@ -2461,7 +2461,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = append(expectedValues, expected)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2474,7 +2474,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()) + 1)
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		removeIndex := getRandomUniquePositiveNumbers(r, int(array.Count()), removeCount)
 
@@ -2486,7 +2486,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2497,11 +2497,11 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 		// Insert elements
 
 		var insertCount int
-		for insertCount < minWriteOperationSize {
-			insertCount = r.Intn(maxWriteOperationSize + 1)
+		for insertCount < minWriteOperationCount {
+			insertCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualArraySize += insertCount
+		actualArrayCount += insertCount
 
 		lowestInsertIndex := math.MaxInt
 
@@ -2526,7 +2526,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = newExpectedValue
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2539,7 +2539,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()) + 1)
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		// Remove previously inserted element first
 
@@ -2561,7 +2561,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2603,7 +2603,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			setIndex = append(setIndex, index)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2616,7 +2616,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			removeCount = r.Intn(int(array.Count()))
 		}
 
-		actualArraySize -= removeCount
+		actualArrayCount -= removeCount
 
 		// Remove some previously set elements first
 
@@ -2654,7 +2654,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArraySize), array.Count())
+		require.Equal(t, uint64(actualArrayCount), array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2687,15 +2687,15 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 
 	t.Run("modify level-1 wrapper array in [SomeValue([SomeValue(uint64)])]", func(t *testing.T) {
 		const (
-			arraySize      = 3
-			childArraySize = 2
+			arrayCount      = 3
+			childArrayCount = 2
 		)
 
 		typeInfo := testTypeInfo{42}
 
 		r := newRand(t)
 
-		createStorage := func(arraySize int) (
+		createStorage := func(arrayCount int) (
 			_ BaseStorage,
 			rootSlabID SlabID,
 			expectedValues []Value,
@@ -2707,14 +2707,14 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 					t,
 					address,
 					typeInfo,
-					arraySize,
+					arrayCount,
 					newWrapperValueFunc(
 						1,
 						newArrayValueFunc(
 							t,
 							address,
 							typeInfo,
-							childArraySize,
+							childArrayCount,
 							newWrapperValueFunc(
 								1,
 								newRandomUint64ValueFunc(r)))))
@@ -2734,8 +2734,8 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 
 		// Create a base storage with array in the format of
 		// [SomeValue([SomeValue(uint64)])]
-		baseStorage, rootSlabID, expectedValues := createStorage(arraySize)
-		require.Equal(t, arraySize, len(expectedValues))
+		baseStorage, rootSlabID, expectedValues := createStorage(arrayCount)
+		require.Equal(t, arrayCount, len(expectedValues))
 
 		// Create a new storage with encoded array
 		storage := newTestPersistentStorageWithBaseStorage(t, baseStorage)
@@ -2795,14 +2795,14 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 
 	t.Run("modify 2-level wrapper array in [SomeValue([SomeValue([SomeValue(uint64)])])]", func(t *testing.T) {
 		const (
-			arraySize       = 4
-			childArraySize  = 3
-			gchildArraySize = 2
+			arrayCount       = 4
+			childArrayCount  = 3
+			gchildArrayCount = 2
 		)
 
 		typeInfo := testTypeInfo{42}
 
-		createStorage := func(arraySize int) (
+		createStorage := func(arrayCount int) (
 			_ BaseStorage,
 			rootSlabID SlabID,
 			expectedValues []Value,
@@ -2816,21 +2816,21 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 					t,
 					address,
 					typeInfo,
-					arraySize,
+					arrayCount,
 					newWrapperValueFunc(
 						1,
 						newArrayValueFunc(
 							t,
 							address,
 							typeInfo,
-							childArraySize,
+							childArrayCount,
 							newWrapperValueFunc(
 								1,
 								newArrayValueFunc(
 									t,
 									address,
 									typeInfo,
-									gchildArraySize,
+									gchildArrayCount,
 									newWrapperValueFunc(
 										1,
 										newRandomUint64ValueFunc(r)))))))
@@ -2850,8 +2850,8 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 
 		// Create a base storage with array in the format of
 		// [SomeValue([SomeValue([SomeValue(uint64)])])]
-		baseStorage, rootSlabID, expectedValues := createStorage(arraySize)
-		require.Equal(t, arraySize, len(expectedValues))
+		baseStorage, rootSlabID, expectedValues := createStorage(arrayCount)
+		require.Equal(t, arrayCount, len(expectedValues))
 
 		// Create a new storage with encoded array
 		storage := newTestPersistentStorageWithBaseStorage(t, baseStorage)

--- a/map_test.go
+++ b/map_test.go
@@ -310,15 +310,15 @@ func TestMapSetAndGet(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			mapSize       = 2048
+			mapCount      = 2048
 			keyStringSize = 16
 		)
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
 		i := uint64(0)
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -346,15 +346,15 @@ func TestMapSetAndGet(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			mapSize       = 2048
+			mapCount      = 2048
 			keyStringSize = 16
 		)
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
 		i := uint64(0)
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -377,7 +377,7 @@ func TestMapSetAndGet(t *testing.T) {
 		// Overwrite values
 		for k, v := range keyValues {
 			oldValue := v.(Uint64Value)
-			newValue := Uint64Value(uint64(oldValue) + mapSize)
+			newValue := Uint64Value(uint64(oldValue) + mapCount)
 
 			existingStorable, err := m.Set(compare, hashInputProvider, k, newValue)
 			require.NoError(t, err)
@@ -398,14 +398,14 @@ func TestMapSetAndGet(t *testing.T) {
 		defer SetThreshold(1024)
 
 		const (
-			mapSize          = 2048
+			mapCount         = 2048
 			keyStringMaxSize = 1024
 		)
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for len(keyValues) < mapSize {
+		keyValues := make(map[Value]Value, mapCount)
+		for len(keyValues) < mapCount {
 			slen := r.Intn(keyStringMaxSize)
 			k := NewStringValue(randStr(r, slen))
 			v := randomValue(r, int(MaxInlineMapElementSize()))
@@ -431,7 +431,7 @@ func TestMapSetAndGet(t *testing.T) {
 	t.Run("unique keys with hash collision", func(t *testing.T) {
 
 		const (
-			mapSize       = 1024
+			mapCount      = 1024
 			keyStringSize = 16
 		)
 
@@ -439,7 +439,7 @@ func TestMapSetAndGet(t *testing.T) {
 		defer SetThreshold(1024)
 
 		savedMaxCollisionLimitPerDigest := MaxCollisionLimitPerDigest
-		MaxCollisionLimitPerDigest = uint32(math.Ceil(float64(mapSize) / 10))
+		MaxCollisionLimitPerDigest = uint32(math.Ceil(float64(mapCount) / 10))
 		defer func() {
 			MaxCollisionLimitPerDigest = savedMaxCollisionLimitPerDigest
 		}()
@@ -447,9 +447,9 @@ func TestMapSetAndGet(t *testing.T) {
 		r := newRand(t)
 
 		digesterBuilder := &mockDigesterBuilder{}
-		keyValues := make(map[Value]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
 		i := uint64(0)
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -479,7 +479,7 @@ func TestMapSetAndGet(t *testing.T) {
 
 	t.Run("replicate keys with hash collision", func(t *testing.T) {
 		const (
-			mapSize       = 1024
+			mapCount      = 1024
 			keyStringSize = 16
 		)
 
@@ -487,7 +487,7 @@ func TestMapSetAndGet(t *testing.T) {
 		defer SetThreshold(1024)
 
 		savedMaxCollisionLimitPerDigest := MaxCollisionLimitPerDigest
-		MaxCollisionLimitPerDigest = uint32(math.Ceil(float64(mapSize) / 10))
+		MaxCollisionLimitPerDigest = uint32(math.Ceil(float64(mapCount) / 10))
 		defer func() {
 			MaxCollisionLimitPerDigest = savedMaxCollisionLimitPerDigest
 		}()
@@ -495,9 +495,9 @@ func TestMapSetAndGet(t *testing.T) {
 		r := newRand(t)
 
 		digesterBuilder := &mockDigesterBuilder{}
-		keyValues := make(map[Value]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
 		i := uint64(0)
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -525,7 +525,7 @@ func TestMapSetAndGet(t *testing.T) {
 		// Overwrite values
 		for k, v := range keyValues {
 			oldValue := v.(Uint64Value)
-			newValue := Uint64Value(uint64(oldValue) + mapSize)
+			newValue := Uint64Value(uint64(oldValue) + mapCount)
 
 			existingStorable, err := m.Set(compare, hashInputProvider, k, newValue)
 			require.NoError(t, err)
@@ -544,7 +544,7 @@ func TestMapSetAndGet(t *testing.T) {
 
 func TestMapGetKeyNotFound(t *testing.T) {
 	t.Run("no collision", func(t *testing.T) {
-		const mapSize = 1024
+		const mapCount = 1024
 
 		typeInfo := testTypeInfo{42}
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -553,8 +553,8 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		m, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -579,7 +579,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 	})
 
 	t.Run("collision", func(t *testing.T) {
-		const mapSize = 256
+		const mapCount = 256
 
 		typeInfo := testTypeInfo{42}
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -589,8 +589,8 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -622,7 +622,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 	})
 
 	t.Run("collision group", func(t *testing.T) {
-		const mapSize = 256
+		const mapCount = 256
 
 		typeInfo := testTypeInfo{42}
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -632,8 +632,8 @@ func TestMapGetKeyNotFound(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -669,21 +669,21 @@ func TestMapHas(t *testing.T) {
 
 	t.Run("no error", func(t *testing.T) {
 		const (
-			mapSize       = 2048
+			mapCount      = 2048
 			keyStringSize = 16
 		)
 
 		r := newRand(t)
 
-		keys := make(map[Value]bool, mapSize*2)
-		keysToInsert := make([]Value, 0, mapSize)
-		keysToNotInsert := make([]Value, 0, mapSize)
-		for len(keysToInsert) < mapSize || len(keysToNotInsert) < mapSize {
+		keys := make(map[Value]bool, mapCount*2)
+		keysToInsert := make([]Value, 0, mapCount)
+		keysToNotInsert := make([]Value, 0, mapCount)
+		for len(keysToInsert) < mapCount || len(keysToNotInsert) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			if !keys[k] {
 				keys[k] = true
 
-				if len(keysToInsert) < mapSize {
+				if len(keysToInsert) < mapCount {
 					keysToInsert = append(keysToInsert, k)
 				} else {
 					keysToNotInsert = append(keysToNotInsert, k)
@@ -780,7 +780,7 @@ func TestMapRemove(t *testing.T) {
 	defer SetThreshold(1024)
 
 	const (
-		mapSize              = 2048
+		mapCount             = 2048
 		smallKeyStringSize   = 16
 		smallValueStringSize = 16
 		largeKeyStringSize   = 512
@@ -789,15 +789,15 @@ func TestMapRemove(t *testing.T) {
 
 	r := newRand(t)
 
-	smallKeyValues := make(map[Value]Value, mapSize)
-	for len(smallKeyValues) < mapSize {
+	smallKeyValues := make(map[Value]Value, mapCount)
+	for len(smallKeyValues) < mapCount {
 		k := NewStringValue(randStr(r, smallKeyStringSize))
 		v := NewStringValue(randStr(r, smallValueStringSize))
 		smallKeyValues[k] = v
 	}
 
-	largeKeyValues := make(map[Value]Value, mapSize)
-	for len(largeKeyValues) < mapSize {
+	largeKeyValues := make(map[Value]Value, mapCount)
+	for len(largeKeyValues) < mapCount {
 		k := NewStringValue(randStr(r, largeKeyStringSize))
 		v := NewStringValue(randStr(r, largeValueStringSize))
 		largeKeyValues[k] = v
@@ -1029,7 +1029,7 @@ func TestMapRemove(t *testing.T) {
 	})
 
 	t.Run("no collision key not found", func(t *testing.T) {
-		const mapSize = 1024
+		const mapCount = 1024
 
 		typeInfo := testTypeInfo{42}
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -1038,8 +1038,8 @@ func TestMapRemove(t *testing.T) {
 		m, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -1065,7 +1065,7 @@ func TestMapRemove(t *testing.T) {
 	})
 
 	t.Run("collision key not found", func(t *testing.T) {
-		const mapSize = 256
+		const mapCount = 256
 
 		typeInfo := testTypeInfo{42}
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -1075,8 +1075,8 @@ func TestMapRemove(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -1155,16 +1155,16 @@ func TestReadOnlyMapIterate(t *testing.T) {
 
 	t.Run("no collision", func(t *testing.T) {
 		const (
-			mapSize       = 2048
+			mapCount      = 2048
 			keyStringSize = 16
 		)
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
 		i := uint64(0)
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			if _, found := keyValues[k]; !found {
 				keyValues[k] = Uint64Value(i)
@@ -1200,7 +1200,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		// Iterate keys
 		i = uint64(0)
@@ -1211,7 +1211,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		// Iterate values
 		i = uint64(0)
@@ -1223,14 +1223,14 @@ func TestReadOnlyMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("collision", func(t *testing.T) {
 		const (
-			mapSize         = 1024
+			mapCount        = 1024
 			keyStringSize   = 16
 			valueStringSize = 16
 		)
@@ -1245,9 +1245,9 @@ func TestReadOnlyMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, 0, mapSize)
-		for len(keyValues) < mapSize {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, 0, mapCount)
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 
 			if _, found := keyValues[k]; !found {
@@ -1281,7 +1281,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		// Iterate keys
 		i = uint64(0)
@@ -1291,7 +1291,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		// Iterate values
 		i = uint64(0)
@@ -1301,7 +1301,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -2216,7 +2216,7 @@ func TestMutableMapIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 15
+		const mapCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -2226,9 +2226,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -2239,7 +2239,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2266,7 +2266,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2276,7 +2276,7 @@ func TestMutableMapIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 25
+		const mapCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -2286,9 +2286,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -2299,7 +2299,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 			keyValues[k] = v
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2326,7 +2326,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2336,7 +2336,7 @@ func TestMutableMapIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 15
+		const mapCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -2346,9 +2346,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -2359,7 +2359,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2388,7 +2388,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2398,7 +2398,7 @@ func TestMutableMapIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 25
+		const mapCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -2408,9 +2408,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -2421,7 +2421,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2450,7 +2450,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2460,7 +2460,7 @@ func TestMutableMapIterate(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 10
+		const mapCount = 10
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -2471,9 +2471,9 @@ func TestMutableMapIterate(t *testing.T) {
 		require.NoError(t, err)
 
 		r := 'a'
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := NewStringValue(strings.Repeat(string(r), 25))
 
@@ -2485,7 +2485,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2513,7 +2513,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2521,7 +2521,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate collision primitive values, 1 level", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -2534,9 +2534,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -2576,14 +2576,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision primitive values, 4 levels", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -2596,9 +2596,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -2641,14 +2641,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize = 15
+			mapCount = 15
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -2659,9 +2659,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := Uint64Value(i)
 
@@ -2685,7 +2685,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2724,7 +2724,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2732,7 +2732,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize = 35
+			mapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -2743,9 +2743,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := Uint64Value(i)
 
@@ -2769,7 +2769,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2808,7 +2808,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2816,9 +2816,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 1
-			mutatedChildMapSize = 5
+			mapCount             = 15
+			childMapCount        = 1
+			mutatedChildMapCount = 5
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -2829,15 +2829,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -2854,14 +2854,14 @@ func TestMutableMapIterate(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2877,13 +2877,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -2894,7 +2894,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -2903,7 +2903,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2911,9 +2911,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 35
-			childMapSize        = 1
-			mutatedChildMapSize = 5
+			mapCount             = 35
+			childMapCount        = 1
+			mutatedChildMapCount = 5
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -2924,15 +2924,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -2949,14 +2949,14 @@ func TestMutableMapIterate(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2972,13 +2972,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -2989,7 +2989,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -2998,7 +2998,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3006,9 +3006,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 10
-			mutatedChildMapSize = 1
+			mapCount             = 15
+			childMapCount        = 10
+			mutatedChildMapCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -3019,15 +3019,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -3044,14 +3044,14 @@ func TestMutableMapIterate(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3067,13 +3067,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j >= mutatedChildMapSize; j-- {
+			for j := childMapCount - 1; j >= mutatedChildMapCount; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -3084,7 +3084,7 @@ func TestMutableMapIterate(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3093,7 +3093,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3101,7 +3101,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate collision inlined container, 1 level", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -3114,9 +3114,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
@@ -3177,14 +3177,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision inlined container, 4 levels", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -3197,9 +3197,9 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
@@ -3263,14 +3263,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container", func(t *testing.T) {
 		const (
-			mapSize         = 15
+			mapCount        = 15
 			valueStringSize = 16
 		)
 
@@ -3284,10 +3284,10 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
 		i := uint64(0)
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := NewStringValue(randStr(r, valueStringSize))
 
@@ -3310,7 +3310,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 			keyValues[k] = mapValue{ck: cv}
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3348,7 +3348,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3384,16 +3384,16 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 1
-			mutatedChildMapSize = 35
+			mapCount             = 15
+			childMapCount        = 1
+			mutatedChildMapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -3404,15 +3404,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -3428,14 +3428,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3451,13 +3451,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -3468,7 +3468,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -3477,7 +3477,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3485,9 +3485,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 5
-			mutatedChildMapSize = 35
+			mapCount             = 15
+			childMapCount        = 5
+			mutatedChildMapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -3498,15 +3498,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -3522,14 +3522,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3545,13 +3545,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -3562,7 +3562,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -3571,7 +3571,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3579,9 +3579,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 35
-			mutatedChildMapSize = 1
+			mapCount             = 15
+			childMapCount        = 35
+			mutatedChildMapCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -3592,15 +3592,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -3616,14 +3616,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3639,13 +3639,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j > mutatedChildMapSize-1; j-- {
+			for j := childMapCount - 1; j > mutatedChildMapCount-1; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -3656,7 +3656,7 @@ func TestMutableMapIterate(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3665,7 +3665,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3673,9 +3673,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 35
-			mutatedChildMapSize = 10
+			mapCount             = 15
+			childMapCount        = 35
+			mutatedChildMapCount = 10
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -3686,15 +3686,15 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -3710,14 +3710,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3733,13 +3733,13 @@ func TestMutableMapIterate(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j > mutatedChildMapSize-1; j-- {
+			for j := childMapCount - 1; j > mutatedChildMapCount-1; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -3750,7 +3750,7 @@ func TestMutableMapIterate(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3759,7 +3759,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3793,7 +3793,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 15
+		const mapCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -3803,9 +3803,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -3816,7 +3816,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -3843,7 +3843,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3853,7 +3853,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 25
+		const mapCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -3863,9 +3863,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -3876,7 +3876,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 			keyValues[k] = v
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -3903,7 +3903,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3913,7 +3913,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 15
+		const mapCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -3923,9 +3923,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -3936,7 +3936,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -3965,7 +3965,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3975,7 +3975,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 25
+		const mapCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -3985,9 +3985,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -3998,7 +3998,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -4027,7 +4027,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4037,7 +4037,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 10
+		const mapCount = 10
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -4048,9 +4048,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		require.NoError(t, err)
 
 		r := 'a'
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := NewStringValue(strings.Repeat(string(r), 25))
 
@@ -4062,7 +4062,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -4090,7 +4090,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4098,7 +4098,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate collision primitive values, 1 level", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -4111,9 +4111,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -4152,14 +4152,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision primitive values, 4 levels", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -4172,9 +4172,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -4216,14 +4216,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize = 15
+			mapCount = 15
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -4234,9 +4234,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := Uint64Value(i)
 
@@ -4260,7 +4260,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4301,7 +4301,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4309,7 +4309,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize = 35
+			mapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -4320,9 +4320,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := Uint64Value(i)
 
@@ -4346,7 +4346,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4387,7 +4387,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4395,9 +4395,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 1
-			mutatedChildMapSize = 5
+			mapCount             = 15
+			childMapCount        = 1
+			mutatedChildMapCount = 5
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -4408,15 +4408,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -4433,14 +4433,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4458,13 +4458,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -4475,7 +4475,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -4484,7 +4484,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4492,9 +4492,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 35
-			childMapSize        = 1
-			mutatedChildMapSize = 5
+			mapCount             = 35
+			childMapCount        = 1
+			mutatedChildMapCount = 5
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -4505,15 +4505,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -4530,14 +4530,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4555,13 +4555,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -4572,7 +4572,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -4581,7 +4581,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4589,9 +4589,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 10
-			mutatedChildMapSize = 1
+			mapCount             = 15
+			childMapCount        = 10
+			mutatedChildMapCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -4602,15 +4602,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -4627,14 +4627,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4652,13 +4652,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j >= mutatedChildMapSize; j-- {
+			for j := childMapCount - 1; j >= mutatedChildMapCount; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -4669,7 +4669,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -4678,7 +4678,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4686,7 +4686,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate collision inlined container, 1 level", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -4699,9 +4699,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
@@ -4764,14 +4764,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision inlined container, 4 levels", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -4784,9 +4784,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
@@ -4851,14 +4851,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container", func(t *testing.T) {
 		const (
-			mapSize         = 15
+			mapCount        = 15
 			valueStringSize = 16
 		)
 
@@ -4872,10 +4872,10 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
 		i := uint64(0)
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := NewStringValue(randStr(r, valueStringSize))
 
@@ -4898,7 +4898,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			keyValues[k] = mapValue{ck: cv}
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4938,7 +4938,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4976,16 +4976,16 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 1
-			mutatedChildMapSize = 35
+			mapCount             = 15
+			childMapCount        = 1
+			mutatedChildMapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -4996,15 +4996,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -5020,14 +5020,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5045,13 +5045,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -5062,7 +5062,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -5071,7 +5071,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5079,9 +5079,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 5
-			mutatedChildMapSize = 35
+			mapCount             = 15
+			childMapCount        = 5
+			mutatedChildMapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -5092,15 +5092,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -5116,14 +5116,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5141,13 +5141,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -5158,7 +5158,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -5167,7 +5167,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5175,9 +5175,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 35
-			mutatedChildMapSize = 1
+			mapCount             = 15
+			childMapCount        = 35
+			mutatedChildMapCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -5188,15 +5188,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -5212,14 +5212,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5237,13 +5237,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j > mutatedChildMapSize-1; j-- {
+			for j := childMapCount - 1; j > mutatedChildMapCount-1; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -5254,7 +5254,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -5263,7 +5263,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5271,9 +5271,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 35
-			mutatedChildMapSize = 10
+			mapCount             = 15
+			childMapCount        = 35
+			mutatedChildMapCount = 10
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -5284,15 +5284,15 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -5308,14 +5308,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5333,13 +5333,13 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j > mutatedChildMapSize-1; j-- {
+			for j := childMapCount - 1; j > mutatedChildMapCount-1; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -5350,7 +5350,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -5359,7 +5359,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5393,7 +5393,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 15
+		const mapCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5403,9 +5403,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -5416,7 +5416,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5444,7 +5444,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5454,7 +5454,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 25
+		const mapCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5464,9 +5464,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -5477,7 +5477,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 			keyValues[k] = v
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5505,7 +5505,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5515,7 +5515,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 15
+		const mapCount = 15
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5525,9 +5525,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -5538,7 +5538,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5569,7 +5569,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5579,7 +5579,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 25
+		const mapCount = 25
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5589,9 +5589,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 
@@ -5602,7 +5602,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5632,7 +5632,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5642,7 +5642,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 10
+		const mapCount = 10
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -5653,9 +5653,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		require.NoError(t, err)
 
 		r := 'a'
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := NewStringValue(strings.Repeat(string(r), 25))
 
@@ -5667,7 +5667,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5696,7 +5696,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapSize, i)
+		require.Equal(t, mapCount, i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5704,7 +5704,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate collision primitive values, 1 level", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -5717,9 +5717,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -5760,14 +5760,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision primitive values, 4 levels", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -5780,9 +5780,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -5826,14 +5826,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize = 15
+			mapCount = 15
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -5844,9 +5844,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := Uint64Value(i)
 
@@ -5870,7 +5870,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5910,7 +5910,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5918,7 +5918,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize = 35
+			mapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -5929,9 +5929,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := Uint64Value(i)
 
@@ -5955,7 +5955,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5995,7 +5995,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6003,9 +6003,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 1
-			mutatedChildMapSize = 5
+			mapCount             = 15
+			childMapCount        = 1
+			mutatedChildMapCount = 5
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6016,15 +6016,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6041,14 +6041,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6065,13 +6065,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -6082,7 +6082,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6091,7 +6091,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6099,9 +6099,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 35
-			childMapSize        = 1
-			mutatedChildMapSize = 5
+			mapCount             = 35
+			childMapCount        = 1
+			mutatedChildMapCount = 5
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6112,15 +6112,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6137,14 +6137,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6161,13 +6161,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -6178,7 +6178,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6187,7 +6187,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6195,9 +6195,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 10
-			mutatedChildMapSize = 1
+			mapCount             = 15
+			childMapCount        = 10
+			mutatedChildMapCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6208,15 +6208,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6233,14 +6233,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6257,13 +6257,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j >= mutatedChildMapSize; j-- {
+			for j := childMapCount - 1; j >= mutatedChildMapCount; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -6274,7 +6274,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6283,7 +6283,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6291,7 +6291,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate collision inlined container, 1 level", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -6304,9 +6304,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
@@ -6368,14 +6368,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision inlined container, 4 levels", func(t *testing.T) {
 		const (
-			mapSize = 1024
+			mapCount = 1024
 		)
 
 		r := newRand(t)
@@ -6388,9 +6388,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
@@ -6455,14 +6455,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapSize))
+		require.Equal(t, i, uint64(mapCount))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container", func(t *testing.T) {
 		const (
-			mapSize         = 15
+			mapCount        = 15
 			valueStringSize = 16
 		)
 
@@ -6476,10 +6476,10 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
 		i := uint64(0)
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			ck := Uint64Value(0)
 			cv := NewStringValue(randStr(r, valueStringSize))
 
@@ -6502,7 +6502,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			keyValues[k] = mapValue{ck: cv}
 		}
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6541,7 +6541,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6578,16 +6578,16 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 1
-			mutatedChildMapSize = 35
+			mapCount             = 15
+			childMapCount        = 1
+			mutatedChildMapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6598,15 +6598,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6622,14 +6622,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6646,13 +6646,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -6663,7 +6663,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -6672,7 +6672,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6680,9 +6680,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 5
-			mutatedChildMapSize = 35
+			mapCount             = 15
+			childMapCount        = 5
+			mutatedChildMapCount = 35
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6693,15 +6693,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6717,14 +6717,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6741,13 +6741,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize; j < mutatedChildMapSize; j++ {
+			for j := childMapCount; j < mutatedChildMapCount; j++ {
 				childKey := Uint64Value(j)
 				childValue := Uint64Value(j)
 
@@ -6758,7 +6758,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -6767,7 +6767,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6775,9 +6775,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 35
-			mutatedChildMapSize = 1
+			mapCount             = 15
+			childMapCount        = 35
+			mutatedChildMapCount = 1
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6788,15 +6788,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6812,14 +6812,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6836,13 +6836,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j > mutatedChildMapSize-1; j-- {
+			for j := childMapCount - 1; j > mutatedChildMapCount-1; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -6853,7 +6853,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6862,7 +6862,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6870,9 +6870,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapSize             = 15
-			childMapSize        = 35
-			mutatedChildMapSize = 10
+			mapCount             = 15
+			childMapCount        = 35
+			mutatedChildMapCount = 10
 		)
 
 		typeInfo := testTypeInfo{42}
@@ -6883,15 +6883,15 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := 0; i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := 0; i < mapCount; i++ {
 
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
 			childMapValues := make(mapValue)
-			for j := 0; j < childMapSize; j++ {
+			for j := 0; j < childMapCount; j++ {
 				ck := Uint64Value(j)
 				cv := Uint64Value(j)
 
@@ -6907,14 +6907,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(compare, hashInputProvider, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6931,13 +6931,13 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapSize), childMap.Count())
+			require.Equal(t, uint64(childMapCount), childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(mapValue)
 			require.True(t, ok)
 
-			for j := childMapSize - 1; j > mutatedChildMapSize-1; j-- {
+			for j := childMapCount - 1; j > mutatedChildMapCount-1; j-- {
 				childKey := Uint64Value(j)
 
 				existingKeyStorable, existingValueStorable, err := childMap.Remove(compare, hashInputProvider, childKey)
@@ -6948,7 +6948,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapSize), childMap.Count())
+			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6957,7 +6957,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapSize), i)
+		require.Equal(t, uint64(mapCount), i)
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6967,7 +6967,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLevel int) {
 
 	const (
-		mapSize            = 1024
+		mapCount           = 1024
 		keyStringMaxSize   = 1024
 		valueStringMaxSize = 1024
 
@@ -6998,9 +6998,9 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 
 	digesterBuilder := &mockDigesterBuilder{}
 
-	keyValues := make(map[Value]Value, mapSize)
+	keyValues := make(map[Value]Value, mapCount)
 	i := 0
-	for len(keyValues) < mapSize {
+	for len(keyValues) < mapCount {
 		k := NewStringValue(randStr(r, r.Intn(keyStringMaxSize)))
 		if _, found := keyValues[k]; !found {
 			keyValues[k] = NewStringValue(randStr(r, r.Intn(valueStringMaxSize)))
@@ -7062,15 +7062,15 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 func testMapRandomHashCollision(t *testing.T, r *rand.Rand, maxDigestLevel int) {
 
 	const (
-		mapSize            = 1024
+		mapCount           = 1024
 		keyStringMaxSize   = 1024
 		valueStringMaxSize = 1024
 	)
 
 	digesterBuilder := &mockDigesterBuilder{}
 
-	keyValues := make(map[Value]Value, mapSize)
-	for len(keyValues) < mapSize {
+	keyValues := make(map[Value]Value, mapCount)
+	for len(keyValues) < mapCount {
 		k := NewStringValue(randStr(r, r.Intn(keyStringMaxSize)))
 
 		if _, found := keyValues[k]; !found {
@@ -7339,9 +7339,9 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapSize = 1
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		const mapCount = 1
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 			keyValues[k] = v
@@ -7413,10 +7413,10 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize-1; i++ {
+		for i := uint64(0); i < mapCount-1; i++ {
 			k := NewStringValue(strings.Repeat(string(r), 22))
 			v := NewStringValue(strings.Repeat(string(r), 22))
 			keyValues[k] = v
@@ -7436,7 +7436,7 @@ func TestMapDecodeV0(t *testing.T) {
 
 		keyValues[k] = arrayValue{Uint64Value(0)}
 
-		digests := []Digest{Digest(mapSize - 1), Digest((mapSize - 1) * 2)}
+		digests := []Digest{Digest(mapCount - 1), Digest((mapCount - 1) * 2)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: digests})
 
 		slabData := map[SlabID][]byte{
@@ -7614,9 +7614,9 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -7788,9 +7788,9 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapSize = 8
+		const mapCount = 8
 		keyValues := make(map[Value]Value)
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -8012,9 +8012,9 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapSize = 20
+		const mapCount = 20
 		keyValues := make(map[Value]Value)
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -8304,9 +8304,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 1
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		const mapCount = 1
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 			keyValues[k] = v
@@ -8319,7 +8319,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -8394,10 +8394,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize-1; i++ {
+		for i := uint64(0); i < mapCount-1; i++ {
 			k := NewStringValue(strings.Repeat(string(r), 22))
 			v := NewStringValue(strings.Repeat(string(r), 22))
 			keyValues[k] = v
@@ -8426,7 +8426,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		keyValues[k] = arrayValue{Uint64Value(0)}
 
-		digests := []Digest{Digest(mapSize - 1), Digest((mapSize - 1) * 2)}
+		digests := []Digest{Digest(mapCount - 1), Digest((mapCount - 1) * 2)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: digests})
 
 		// Insert nested array
@@ -8434,7 +8434,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -8629,10 +8629,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), childMapTypeInfo)
@@ -8659,7 +8659,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -8817,10 +8817,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			var ti TypeInfo
 			if i%2 == 0 {
@@ -8854,7 +8854,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -9007,10 +9007,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			// Create grand child map
 			gchildMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), childMapTypeInfo)
 			require.NoError(t, err)
@@ -9047,7 +9047,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: mapValue{gck: gcv}}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -9272,10 +9272,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			var gti TypeInfo
 			if i%2 == 0 {
 				gti = gchildMapTypeInfo2
@@ -9326,7 +9326,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: mapValue{gck: gcv}}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -9541,10 +9541,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), childMapTypeInfo)
@@ -9571,7 +9571,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 10}) // inlined maps index 2-9
@@ -10028,10 +10028,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			var ti TypeInfo
 			switch i % 4 {
@@ -10070,7 +10070,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 10}) // inlined maps index 2-9
@@ -10505,9 +10505,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -10521,7 +10521,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = v
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -10692,9 +10692,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 8
+		const mapCount = 8
 		keyValues := make(map[Value]Value)
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -10708,7 +10708,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = v
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -10929,9 +10929,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 20
+		const mapCount = 20
 		keyValues := make(map[Value]Value)
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 
@@ -10945,7 +10945,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = v
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -11158,10 +11158,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize-1; i++ {
+		for i := uint64(0); i < mapCount-1; i++ {
 			k := NewStringValue(strings.Repeat(string(r), 22))
 			v := NewStringValue(strings.Repeat(string(r), 22))
 			keyValues[k] = v
@@ -11198,7 +11198,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		v := childMap
 		keyValues[k] = expectedChildMapValues
 
-		digests := []Digest{Digest(mapSize - 1), Digest((mapSize - 1) * 2)}
+		digests := []Digest{Digest(mapCount - 1), Digest((mapCount - 1) * 2)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: digests})
 
 		// Insert child map
@@ -11206,7 +11206,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		// root slab (data slab) ID
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -11337,9 +11337,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize-1; i++ {
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount-1; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i * 2)
 			keyValues[k] = v
@@ -11384,11 +11384,11 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		k := Uint64Value(mapSize - 1)
+		k := Uint64Value(mapCount - 1)
 		v := childMap
 		keyValues[k] = mapValue{Uint64Value(0): expectedGChildMapValues}
 
-		digests := []Digest{Digest(mapSize - 1), Digest((mapSize - 1) * 2)}
+		digests := []Digest{Digest(mapCount - 1), Digest((mapCount - 1) * 2)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: digests})
 
 		// Insert child map
@@ -11396,7 +11396,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		// root slab (data slab) ID
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -11567,10 +11567,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 8
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 8
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize-1; i++ {
+		for i := uint64(0); i < mapCount-1; i++ {
 			k := NewStringValue(strings.Repeat(string(r), 22))
 			v := NewStringValue(strings.Repeat(string(r), 22))
 			keyValues[k] = v
@@ -11586,15 +11586,15 @@ func TestMapEncodeDecode(t *testing.T) {
 		}
 
 		// Create child array
-		const childArraySize = 5
+		const childArrayCount = 5
 
 		typeInfo2 := testTypeInfo{43}
 
 		childArray, err := NewArray(storage, address, typeInfo2)
 		require.NoError(t, err)
 
-		expectedChildValues := make([]Value, childArraySize)
-		for i := 0; i < childArraySize; i++ {
+		expectedChildValues := make([]Value, childArrayCount)
+		for i := 0; i < childArrayCount; i++ {
 			v := NewStringValue(strings.Repeat("b", 22))
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -11607,7 +11607,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		keyValues[k] = arrayValue(expectedChildValues)
 
-		digests := []Digest{Digest(mapSize - 1), Digest((mapSize - 1) * 2)}
+		digests := []Digest{Digest(mapCount - 1), Digest((mapCount - 1) * 2)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: digests})
 
 		// Insert nested array
@@ -11615,7 +11615,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -11819,10 +11819,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		r := 'a'
-		for i := uint64(0); i < mapSize-1; i++ {
+		for i := uint64(0); i < mapCount-1; i++ {
 			k := NewStringValue(strings.Repeat(string(r), 22))
 			v := NewStringValue(strings.Repeat(string(r), 22))
 			keyValues[k] = v
@@ -11844,15 +11844,15 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 
 		// Create grand child array
-		const gchildArraySize = 5
+		const gchildArrayCount = 5
 
 		gchildTypeInfo := testTypeInfo{44}
 
 		gchildArray, err := NewArray(storage, address, gchildTypeInfo)
 		require.NoError(t, err)
 
-		expectedGChildValues := make([]Value, gchildArraySize)
-		for i := 0; i < gchildArraySize; i++ {
+		expectedGChildValues := make([]Value, gchildArrayCount)
+		for i := 0; i < gchildArrayCount; i++ {
 			v := NewStringValue(strings.Repeat("b", 22))
 			err = gchildArray.Append(v)
 			require.NoError(t, err)
@@ -11869,7 +11869,7 @@ func TestMapEncodeDecode(t *testing.T) {
 
 		keyValues[k] = arrayValue{arrayValue(expectedGChildValues)}
 
-		digests := []Digest{Digest(mapSize - 1), Digest((mapSize - 1) * 2)}
+		digests := []Digest{Digest(mapCount - 1), Digest((mapCount - 1) * 2)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: digests})
 
 		// Insert child array to parent map
@@ -11877,7 +11877,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		// parent map root slab ID
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -12152,9 +12152,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 
 			// Create child map, composite with one field "uuid"
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), childMapTypeInfo)
@@ -12180,7 +12180,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = mapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12311,9 +12311,9 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			expectedChildMapVaues := mapValue{}
 
 			// Create child map, composite with one field "uuid"
@@ -12352,7 +12352,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapVaues
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12489,10 +12489,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		// fields are ordered differently because of different seed.
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			expectedChildMapValues := mapValue{}
 
 			// Create child map, composite with one field "uuid"
@@ -12531,7 +12531,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12670,10 +12670,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 3
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 3
+		keyValues := make(map[Value]Value, mapCount)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			expectedChildMapValues := mapValue{}
 
 			// Create child map
@@ -12725,7 +12725,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12925,10 +12925,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 2
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 2
+		keyValues := make(map[Value]Value, mapCount)
 		// fields are ordered differently because of different seed.
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			expectedChildMapValues := mapValue{}
 
 			// Create child map, composite with one field "uuid"
@@ -12969,7 +12969,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -13125,10 +13125,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapSize = 4
-		keyValues := make(map[Value]Value, mapSize)
+		const mapCount = 4
+		keyValues := make(map[Value]Value, mapCount)
 		// fields are ordered differently because of different seed.
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			expectedChildMapValues := mapValue{}
 
 			var ti TypeInfo
@@ -13174,7 +13174,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 
 		id1 := NewSlabID(address, SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -13384,7 +13384,7 @@ func TestMapEncodeDecodeRandomValues(t *testing.T) {
 
 func TestMapStoredValue(t *testing.T) {
 
-	const mapSize = 4096
+	const mapCount = 4096
 
 	r := newRand(t)
 
@@ -13392,9 +13392,9 @@ func TestMapStoredValue(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 	storage := newTestPersistentStorage(t)
 
-	keyValues := make(map[Value]Value, mapSize)
+	keyValues := make(map[Value]Value, mapCount)
 	i := 0
-	for len(keyValues) < mapSize {
+	for len(keyValues) < mapCount {
 		k := NewStringValue(randStr(r, 16))
 		keyValues[k] = Uint64Value(i)
 		i++
@@ -13468,7 +13468,7 @@ func TestMapPopIterate(t *testing.T) {
 	})
 
 	t.Run("root-dataslab", func(t *testing.T) {
-		const mapSize = 10
+		const mapCount = 10
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -13478,9 +13478,9 @@ func TestMapPopIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			key, value := Uint64Value(i), Uint64Value(i*10)
 			sortedKeys[i] = key
 			keyValues[key] = value
@@ -13490,7 +13490,7 @@ func TestMapPopIterate(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		err = storage.Commit()
 		require.NoError(t, err)
@@ -13499,7 +13499,7 @@ func TestMapPopIterate(t *testing.T) {
 
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
-		i := mapSize
+		i := mapCount
 		err = m.PopIterate(func(k, v Storable) {
 			i--
 
@@ -13519,14 +13519,14 @@ func TestMapPopIterate(t *testing.T) {
 	})
 
 	t.Run("root-metaslab", func(t *testing.T) {
-		const mapSize = 4096
+		const mapCount = 4096
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
 		i := 0
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, 16))
 			if _, found := keyValues[k]; !found {
 				sortedKeys[i] = k
@@ -13577,7 +13577,7 @@ func TestMapPopIterate(t *testing.T) {
 	t.Run("collision", func(t *testing.T) {
 		//MetaDataSlabCount:1 DataSlabCount:13 CollisionDataSlabCount:100
 
-		const mapSize = 1024
+		const mapCount = 1024
 
 		SetThreshold(512)
 		defer SetThreshold(1024)
@@ -13592,10 +13592,10 @@ func TestMapPopIterate(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		keyValues := make(map[Value]Value, mapSize)
-		sortedKeys := make([]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
+		sortedKeys := make([]Value, mapCount)
 		i := 0
-		for len(keyValues) < mapSize {
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, 16))
 
 			if _, found := keyValues[k]; !found {
@@ -13624,7 +13624,7 @@ func TestMapPopIterate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Iterate key value pairs
-		i = mapSize
+		i = mapCount
 		err = m.PopIterate(func(k Storable, v Storable) {
 			i--
 
@@ -13755,7 +13755,7 @@ func TestMapFromBatchData(t *testing.T) {
 	t.Run("root-dataslab", func(t *testing.T) {
 		SetThreshold(1024)
 
-		const mapSize = 10
+		const mapCount = 10
 
 		typeInfo := testTypeInfo{42}
 
@@ -13767,13 +13767,13 @@ func TestMapFromBatchData(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			storable, err := m.Set(compare, hashInputProvider, Uint64Value(i), Uint64Value(i*10))
 			require.NoError(t, err)
 			require.Nil(t, storable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -13817,7 +13817,7 @@ func TestMapFromBatchData(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 4096
+		const mapCount = 4096
 
 		typeInfo := testTypeInfo{42}
 
@@ -13829,13 +13829,13 @@ func TestMapFromBatchData(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			storable, err := m.Set(compare, hashInputProvider, Uint64Value(i), Uint64Value(i*10))
 			require.NoError(t, err)
 			require.Nil(t, storable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -13876,7 +13876,7 @@ func TestMapFromBatchData(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 10
+		const mapCount = 10
 
 		typeInfo := testTypeInfo{42}
 
@@ -13888,7 +13888,7 @@ func TestMapFromBatchData(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			storable, err := m.Set(compare, hashInputProvider, Uint64Value(i), Uint64Value(i*10))
 			require.NoError(t, err)
 			require.Nil(t, storable)
@@ -13900,7 +13900,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, storable)
 
-		require.Equal(t, uint64(mapSize+1), m.Count())
+		require.Equal(t, uint64(mapCount+1), m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -13941,7 +13941,7 @@ func TestMapFromBatchData(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 8
+		const mapCount = 8
 
 		typeInfo := testTypeInfo{42}
 
@@ -13953,7 +13953,7 @@ func TestMapFromBatchData(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			storable, err := m.Set(compare, hashInputProvider, Uint64Value(i), Uint64Value(i*10))
 			require.NoError(t, err)
 			require.Nil(t, storable)
@@ -13968,7 +13968,7 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, storable)
 
-		require.Equal(t, uint64(mapSize+1), m.Count())
+		require.Equal(t, uint64(mapCount+1), m.Count())
 		require.Equal(t, typeInfo, m.Type())
 
 		iter, err := m.ReadOnlyIterator()
@@ -14010,7 +14010,7 @@ func TestMapFromBatchData(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		const mapSize = 4096
+		const mapCount = 4096
 
 		r := newRand(t)
 
@@ -14024,7 +14024,7 @@ func TestMapFromBatchData(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		for m.Count() < mapSize {
+		for m.Count() < mapCount {
 			k := randomValue(r, int(MaxInlineMapElementSize()))
 			v := randomValue(r, int(MaxInlineMapElementSize()))
 
@@ -14032,7 +14032,7 @@ func TestMapFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -14042,7 +14042,7 @@ func TestMapFromBatchData(t *testing.T) {
 		digesterBuilder := NewDefaultDigesterBuilder()
 
 		var sortedKeys []Value
-		keyValues := make(map[Value]Value, mapSize)
+		keyValues := make(map[Value]Value, mapCount)
 
 		copied, err := NewMapFromBatchData(
 			storage,
@@ -14071,7 +14071,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 	t.Run("collision", func(t *testing.T) {
 
-		const mapSize = 1024
+		const mapCount = 1024
 
 		SetThreshold(512)
 		defer SetThreshold(1024)
@@ -14080,7 +14080,7 @@ func TestMapFromBatchData(t *testing.T) {
 		defer func() {
 			MaxCollisionLimitPerDigest = savedMaxCollisionLimitPerDigest
 		}()
-		MaxCollisionLimitPerDigest = mapSize / 2
+		MaxCollisionLimitPerDigest = mapCount / 2
 
 		typeInfo := testTypeInfo{42}
 
@@ -14094,7 +14094,7 @@ func TestMapFromBatchData(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			k, v := Uint64Value(i), Uint64Value(i*10)
 
@@ -14102,7 +14102,7 @@ func TestMapFromBatchData(t *testing.T) {
 			if i%2 == 0 {
 				digests[0] = 0
 			} else {
-				digests[0] = Digest(i % (mapSize / 2))
+				digests[0] = Digest(i % (mapCount / 2))
 			}
 			digests[1] = Digest(i)
 
@@ -14113,7 +14113,7 @@ func TestMapFromBatchData(t *testing.T) {
 			require.Nil(t, storable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -14238,7 +14238,7 @@ func TestMapNestedStorables(t *testing.T) {
 
 	t.Run("SomeValue", func(t *testing.T) {
 
-		const mapSize = 4096
+		const mapCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -14248,7 +14248,7 @@ func TestMapNestedStorables(t *testing.T) {
 		require.NoError(t, err)
 
 		keyValues := make(map[Value]Value)
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			ks := strings.Repeat("a", int(i))
 			k := SomeValue{Value: NewStringValue(ks)}
@@ -14268,7 +14268,7 @@ func TestMapNestedStorables(t *testing.T) {
 
 	t.Run("Array", func(t *testing.T) {
 
-		const mapSize = 4096
+		const mapCount = 4096
 
 		typeInfo := testTypeInfo{42}
 		storage := newTestPersistentStorage(t)
@@ -14278,7 +14278,7 @@ func TestMapNestedStorables(t *testing.T) {
 		require.NoError(t, err)
 
 		keyValues := make(map[Value]Value)
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 
 			// Create a child array with one element
 			childArray, err := NewArray(storage, address, typeInfo)
@@ -14344,7 +14344,7 @@ func TestMapString(t *testing.T) {
 	defer SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const mapSize = 3
+		const mapCount = 3
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := testTypeInfo{42}
@@ -14354,7 +14354,7 @@ func TestMapString(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []Digest{Digest(i)}})
@@ -14369,7 +14369,7 @@ func TestMapString(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const mapSize = 30
+		const mapCount = 30
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := testTypeInfo{42}
@@ -14379,7 +14379,7 @@ func TestMapString(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []Digest{Digest(i)}})
@@ -14400,7 +14400,7 @@ func TestMapSlabDump(t *testing.T) {
 	defer SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const mapSize = 3
+		const mapCount = 3
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := testTypeInfo{42}
@@ -14410,7 +14410,7 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []Digest{Digest(i)}})
@@ -14429,7 +14429,7 @@ func TestMapSlabDump(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const mapSize = 30
+		const mapCount = 30
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := testTypeInfo{42}
@@ -14439,7 +14439,7 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []Digest{Digest(i)}})
@@ -14460,7 +14460,7 @@ func TestMapSlabDump(t *testing.T) {
 	})
 
 	t.Run("inline collision", func(t *testing.T) {
-		const mapSize = 30
+		const mapCount = 30
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := testTypeInfo{42}
@@ -14470,7 +14470,7 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []Digest{Digest(i % 10)}})
@@ -14491,7 +14491,7 @@ func TestMapSlabDump(t *testing.T) {
 	})
 
 	t.Run("external collision", func(t *testing.T) {
-		const mapSize = 30
+		const mapCount = 30
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := testTypeInfo{42}
@@ -14501,7 +14501,7 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		for i := uint64(0); i < mapSize; i++ {
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []Digest{Digest(i % 2)}})
@@ -14583,7 +14583,7 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 	}()
 
 	t.Run("collision limit 0", func(t *testing.T) {
-		const mapSize = 1024
+		const mapCount = 1024
 
 		SetThreshold(256)
 		defer SetThreshold(1024)
@@ -14593,8 +14593,8 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 		MaxCollisionLimitPerDigest = uint32(0)
 
 		digesterBuilder := &mockDigesterBuilder{}
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -14620,10 +14620,10 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
 		// Insert elements exceeding collision limits
-		collisionKeyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
-			k := Uint64Value(mapSize + i)
-			v := Uint64Value(mapSize + i)
+		collisionKeyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
+			k := Uint64Value(mapCount + i)
+			v := Uint64Value(mapCount + i)
 			collisionKeyValues[k] = v
 
 			digests := []Digest{Digest(i)}
@@ -14657,7 +14657,7 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 	})
 
 	t.Run("collision limit > 0", func(t *testing.T) {
-		const mapSize = 1024
+		const mapCount = 1024
 
 		SetThreshold(256)
 		defer SetThreshold(1024)
@@ -14667,8 +14667,8 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 		MaxCollisionLimitPerDigest = uint32(7)
 
 		digesterBuilder := &mockDigesterBuilder{}
-		keyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
+		keyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
 			k := Uint64Value(i)
 			v := Uint64Value(i)
 			keyValues[k] = v
@@ -14694,10 +14694,10 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
 		// Insert elements exceeding collision limits
-		collisionKeyValues := make(map[Value]Value, mapSize)
-		for i := uint64(0); i < mapSize; i++ {
-			k := Uint64Value(mapSize + i)
-			v := Uint64Value(mapSize + i)
+		collisionKeyValues := make(map[Value]Value, mapCount)
+		for i := uint64(0); i < mapCount; i++ {
+			k := Uint64Value(mapCount + i)
+			v := Uint64Value(mapCount + i)
 			collisionKeyValues[k] = v
 
 			digests := []Digest{Digest(i % 128)}
@@ -14768,13 +14768,13 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
+			const mapCount = 3
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -14791,20 +14791,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
+			const mapCount = 3
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -14816,20 +14816,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 collision groups, 2 elements in each group.
-			const mapSize = 6
+			const mapCount = 6
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 2), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -14841,20 +14841,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision group, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -14865,20 +14865,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
+			const mapCount = 3
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -14898,12 +14898,12 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
-			m, values := createMapWithLongStringKey(t, storage, address, typeInfo, mapSize, useWrapperValue)
+			const mapCount = 3
+			m, values := createMapWithLongStringKey(t, storage, address, typeInfo, mapCount, useWrapperValue)
 
 			// parent map: 1 root data slab
 			// long string keys: 1 storable slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -14945,20 +14945,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 collision groups, 2 elements in each group.
-			const mapSize = 6
+			const mapCount = 6
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 2), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -14979,20 +14979,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision groups, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15013,20 +15013,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision groups, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15067,20 +15067,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
+			const mapCount = 3
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15100,12 +15100,12 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
-			m, values := createMapWithLongStringKey(t, storage, address, typeInfo, mapSize, useWrapperValue)
+			const mapCount = 3
+			m, values := createMapWithLongStringKey(t, storage, address, typeInfo, mapCount, useWrapperValue)
 
 			// parent map: 1 root data slab
 			// long string keys: 1 storable slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15147,20 +15147,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 collision groups, 2 elements in each group.
-			const mapSize = 6
+			const mapCount = 6
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 2), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15181,20 +15181,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision groups, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15215,20 +15215,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision groups, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15268,20 +15268,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
+			const mapCount = 3
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15303,12 +15303,12 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
-			m, values := createMapWithLongStringKey(t, storage, address, typeInfo, mapSize, useWrapperValue)
+			const mapCount = 3
+			m, values := createMapWithLongStringKey(t, storage, address, typeInfo, mapCount, useWrapperValue)
 
 			// parent map: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15352,20 +15352,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 collision groups, 2 elements in each group.
-			const mapSize = 6
+			const mapCount = 6
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 2), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15390,20 +15390,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision groups, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15431,20 +15431,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
 			// Create parent map with 3 external collision groups, 4 elements in the group.
-			const mapSize = 12
+			const mapCount = 12
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i / 4), Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab, 3 external collision group
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+3+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+3+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15485,20 +15485,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 3
+			const mapCount = 3
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 1+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 0, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15527,10 +15527,10 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 	runTest("root data slab with simple and composite values, unloading composite value", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
-			const mapSize = 3
+			const mapCount = 3
 
 			// Create a map with nested composite value at specified index
-			for childArrayIndex := 0; childArrayIndex < mapSize; childArrayIndex++ {
+			for childArrayIndex := 0; childArrayIndex < mapCount; childArrayIndex++ {
 				storage := newTestPersistentStorage(t)
 
 				m, values, childSlabID := createMapWithSimpleAndChildArrayValues(
@@ -15538,7 +15538,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					storage,
 					address,
 					typeInfo,
-					mapSize,
+					mapCount,
 					childArrayIndex,
 					func(i int) []Digest { return []Digest{Digest(i)} },
 					useWrapperValue,
@@ -15567,13 +15567,13 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -15590,20 +15590,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (2 levels): 1 root metadata slab, 3 data slabs
 			// composite values: 1 root data slab for each
-			require.Equal(t, 4+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 4+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15614,20 +15614,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (2 levels): 1 root metadata slab, 3 data slabs
 			// composite values : 1 root data slab for each
-			require.Equal(t, 4+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 4+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15647,20 +15647,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (2 levels): 1 root metadata slab, 3 data slabs
 			// composite values: 1 root data slab for each
-			require.Equal(t, 4+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 4+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15680,20 +15680,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (2 levels): 1 root metadata slab, 3 data slabs
 			// composite values: 1 root data slab for each
-			require.Equal(t, 4+mapSize, GetDeltasCount(storage))
+			require.Equal(t, 4+mapCount, GetDeltasCount(storage))
 			require.Equal(t, 1, getMapMetaDataSlabCount(storage))
 
 			testMapLoadedElements(t, m, values)
@@ -15716,10 +15716,10 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with simple and composite values, unload composite value", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
-			const mapSize = 20
+			const mapCount = 20
 
 			// Create a map with nested composite value at specified index
-			for childArrayIndex := 0; childArrayIndex < mapSize; childArrayIndex++ {
+			for childArrayIndex := 0; childArrayIndex < mapCount; childArrayIndex++ {
 				storage := newTestPersistentStorage(t)
 
 				m, values, childSlabID := createMapWithSimpleAndChildArrayValues(
@@ -15727,7 +15727,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					storage,
 					address,
 					typeInfo,
-					mapSize,
+					mapCount,
 					childArrayIndex,
 					func(i int) []Digest { return []Digest{Digest(i)} },
 					useWrapperValue,
@@ -15755,14 +15755,14 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -15802,14 +15802,14 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -15851,14 +15851,14 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 20
+			const mapCount = 20
 
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -15908,14 +15908,14 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 200
+			const mapCount = 200
 
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -15952,14 +15952,14 @@ func TestMapLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 200
+			const mapCount = 200
 
 			m, values := createMapWithSimpleValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
@@ -15993,20 +15993,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 500
+			const mapCount = 500
 			m, values, childSlabIDs := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+mapSize)
+			require.True(t, GetDeltasCount(storage) > 1+mapCount)
 			require.True(t, getMapMetaDataSlabCount(storage) > 1)
 
 			testMapLoadedElements(t, m, values)
@@ -16037,20 +16037,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 500
+			const mapCount = 500
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// composite values: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+mapSize)
+			require.True(t, GetDeltasCount(storage) > 1+mapCount)
 			require.True(t, getMapMetaDataSlabCount(storage) > 1)
 
 			testMapLoadedElements(t, m, values)
@@ -16125,20 +16125,20 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const mapSize = 500
+			const mapCount = 500
 			m, values, _ := createMapWithChildArrayValues(
 				t,
 				storage,
 				address,
 				typeInfo,
-				mapSize,
+				mapCount,
 				func(i int) []Digest { return []Digest{Digest(i)} },
 				useWrapperValue,
 			)
 
 			// parent map (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// composite values: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+mapSize)
+			require.True(t, GetDeltasCount(storage) > 1+mapCount)
 			require.True(t, getMapMetaDataSlabCount(storage) > 1)
 
 			testMapLoadedElements(t, m, values)
@@ -16390,7 +16390,7 @@ func createMapWithChildArrayValues(
 	newDigests func(i int) []Digest,
 	useWrapperValue bool,
 ) (*OrderedMap, [][2]Value, []SlabID) {
-	const childArraySize = 50
+	const childArrayCount = 50
 
 	// Use mockDigesterBuilder to guarantee element order.
 	digesterBuilder := &mockDigesterBuilder{}
@@ -16406,8 +16406,8 @@ func createMapWithChildArrayValues(
 		childArray, err := NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		expectedChildValues := make([]Value, childArraySize)
-		for j := 0; j < childArraySize; j++ {
+		expectedChildValues := make([]Value, childArrayCount)
+		for j := 0; j < childArrayCount; j++ {
 			v := Uint64Value(j)
 
 			err = childArray.Append(v)
@@ -16453,7 +16453,7 @@ func createMapWithSimpleAndChildArrayValues(
 	newDigests func(i int) []Digest,
 	useWrapperValue bool,
 ) (*OrderedMap, [][2]Value, SlabID) {
-	const childArraySize = 50
+	const childArrayCount = 50
 
 	digesterBuilder := &mockDigesterBuilder{}
 
@@ -16476,8 +16476,8 @@ func createMapWithSimpleAndChildArrayValues(
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
-			expectedChildValues := make([]Value, childArraySize)
-			for j := 0; j < childArraySize; j++ {
+			expectedChildValues := make([]Value, childArrayCount)
+			for j := 0; j < childArrayCount; j++ {
 				v := Uint64Value(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
@@ -16546,14 +16546,14 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		mapSize := 2
+		mapCount := 2
 		keyStringSize := 16                                 // Key size is less than max map key size.
 		valueStringSize := MaxInlineMapElementSize()/2 + 10 // Value size is more than half of max map element size.
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for len(keyValues) < mapSize {
+		keyValues := make(map[Value]Value, mapCount)
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, keyStringSize))
 			v := NewStringValue(randStr(r, int(valueStringSize)))
 			keyValues[k] = v
@@ -16584,14 +16584,14 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		mapSize := 1
+		mapCount := 1
 		keyStringSize := MaxInlineMapKeySize() - 2         // Key size is exactly max map key size (2 bytes is string encoding overhead).
 		valueStringSize := MaxInlineMapElementSize()/2 + 2 // Value size is more than half of max map element size (add 2 bytes to make it more than half).
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for len(keyValues) < mapSize {
+		keyValues := make(map[Value]Value, mapCount)
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, int(keyStringSize)))
 			v := NewStringValue(randStr(r, int(valueStringSize)))
 			keyValues[k] = v
@@ -16624,14 +16624,14 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 		SetThreshold(256)
 		defer SetThreshold(1024)
 
-		mapSize := 1
+		mapCount := 1
 		keyStringSize := MaxInlineMapKeySize() + 10         // key size is more than max map key size
 		valueStringSize := MaxInlineMapElementSize()/2 + 10 // value size is more than half of max map element size
 
 		r := newRand(t)
 
-		keyValues := make(map[Value]Value, mapSize)
-		for len(keyValues) < mapSize {
+		keyValues := make(map[Value]Value, mapCount)
+		for len(keyValues) < mapCount {
 			k := NewStringValue(randStr(r, int(keyStringSize)))
 			v := NewStringValue(randStr(r, int(valueStringSize)))
 			keyValues[k] = v
@@ -16673,14 +16673,14 @@ func TestMapID(t *testing.T) {
 
 func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {
 	const (
-		mapSize             = 3
+		mapCount            = 3
 		keyStringSize       = 16
 		initialStorableSize = 1
 		mutatedStorableSize = 5
 	)
 
-	keyValues := make(map[Value]*testMutableValue, mapSize)
-	for i := 0; i < mapSize; i++ {
+	keyValues := make(map[Value]*testMutableValue, mapCount)
+	for i := 0; i < mapCount; i++ {
 		k := Uint64Value(i)
 		v := newTestMutableValue(initialStorableSize)
 		keyValues[k] = v
@@ -16702,7 +16702,7 @@ func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {
 	require.True(t, IsMapRootDataSlab(m))
 
 	expectedElementSize := singleElementPrefixSize + digestSize + Uint64Value(0).ByteSize() + initialStorableSize
-	expectedMapRootDataSlabSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize + expectedElementSize*mapSize
+	expectedMapRootDataSlabSize := mapRootDataSlabPrefixSize + hkeyElementsPrefixSize + expectedElementSize*mapCount
 	require.Equal(t, expectedMapRootDataSlabSize, GetMapRootSlabByteSize(m))
 
 	err = VerifyMap(m, address, typeInfo, typeInfoComparator, hashInputProvider, true)
@@ -16720,7 +16720,7 @@ func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {
 	require.True(t, IsMapRootDataSlab(m))
 
 	expectedElementSize = singleElementPrefixSize + digestSize + Uint64Value(0).ByteSize() + mutatedStorableSize
-	expectedMapRootDataSlabSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize + expectedElementSize*mapSize
+	expectedMapRootDataSlabSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize + expectedElementSize*mapCount
 	require.Equal(t, expectedMapRootDataSlabSize, GetMapRootSlabByteSize(m))
 
 	err = VerifyMap(m, address, typeInfo, typeInfoComparator, hashInputProvider, true)
@@ -16736,7 +16736,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 
 	t.Run("parent is root data slab, with one child map", func(t *testing.T) {
 		const (
-			mapSize         = 1
+			mapCount        = 1
 			keyStringSize   = 9
 			valueStringSize = 4
 		)
@@ -16751,11 +16751,11 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
-		parentMap, expectedKeyValues := createMapWithEmptyChildMap(t, storage, address, typeInfo, mapSize, func() Value {
+		parentMap, expectedKeyValues := createMapWithEmptyChildMap(t, storage, address, typeInfo, mapCount, func() Value {
 			return NewStringValue(randStr(r, keyStringSize))
 		})
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
@@ -16796,7 +16796,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				// Test parent slab size
 				expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedInlinedMapSize
 				expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
-					expectedParentElementSize*mapSize
+					expectedParentElementSize*mapCount
 				require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -16837,7 +16837,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 
 			expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + SlabIDStorable(expectedSlabID).ByteSize()
 			expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
-				expectedParentElementSize*mapSize
+				expectedParentElementSize*mapCount
 			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -16876,21 +16876,21 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 
 				expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedInlinedMapSize
 				expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) +
-					expectedParentElementSize*mapSize
+					expectedParentElementSize*mapCount
 				require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 				testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 			}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 	})
 
 	t.Run("parent is root data slab, with two child maps", func(t *testing.T) {
 		const (
-			mapSize         = 2
+			mapCount        = 2
 			keyStringSize   = 9
 			valueStringSize = 4
 		)
@@ -16905,11 +16905,11 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
-		parentMap, expectedKeyValues := createMapWithEmptyChildMap(t, storage, address, typeInfo, mapSize, func() Value {
+		parentMap, expectedKeyValues := createMapWithEmptyChildMap(t, storage, address, typeInfo, mapCount, func() Value {
 			return NewStringValue(randStr(r, keyStringSize))
 		})
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
@@ -16999,7 +16999,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.Equal(t, 1+mapSize, getStoredDeltas(storage)) // There are >1 stored slab because child map is no longer inlined.
+		require.Equal(t, 1+mapCount, getStoredDeltas(storage)) // There are >1 stored slab because child map is no longer inlined.
 
 		// Remove one element from each child map which triggers standalone map slab becomes inlined slab again.
 		i = 0
@@ -17023,7 +17023,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 
 			delete(expectedChildMapValues, aKey)
 
-			require.Equal(t, 1+mapSize-1-i, getStoredDeltas(storage))
+			require.Equal(t, 1+mapCount-1-i, getStoredDeltas(storage))
 
 			i++
 
@@ -17084,14 +17084,14 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 	})
 
 	t.Run("parent is root metadata slab, with four child maps", func(t *testing.T) {
 		const (
-			mapSize         = 4
+			mapCount        = 4
 			keyStringSize   = 9
 			valueStringSize = 4
 		)
@@ -17106,11 +17106,11 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		storage := newTestPersistentStorage(t)
 		address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
-		parentMap, expectedKeyValues := createMapWithEmptyChildMap(t, storage, address, typeInfo, mapSize, func() Value {
+		parentMap, expectedKeyValues := createMapWithEmptyChildMap(t, storage, address, typeInfo, mapCount, func() Value {
 			return NewStringValue(randStr(r, keyStringSize))
 		})
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
@@ -17189,7 +17189,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 
 		// Parent map has one root data slab.
 		// Each child maps has one root data slab.
-		require.Equal(t, 1+mapSize, getStoredDeltas(storage)) // There are >1 stored slab because child map is no longer inlined.
+		require.Equal(t, 1+mapCount, getStoredDeltas(storage)) // There are >1 stored slab because child map is no longer inlined.
 		require.True(t, IsMapRootDataSlab(parentMap))
 
 		// Remove one element from each child map which triggers standalone map slab becomes inlined slab again.
@@ -17263,7 +17263,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			}
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		for _, child := range children {
 			require.Equal(t, uint64(0), child.m.Count())
 		}
@@ -17274,7 +17274,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		// Test parent map slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + expectedEmptyInlinedMapSize
 		expectedParentSize := uint32(mapRootDataSlabPrefixSize+hkeyElementsPrefixSize) + // standalone map data slab with 0 element
-			expectedParentElementSize*uint32(mapSize)
+			expectedParentElementSize*uint32(mapCount)
 		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 	})
 }
@@ -17286,7 +17286,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 
 	t.Run("parent is root data slab, one child map, one grand child map, changes to grand child map triggers child map slab to become standalone slab", func(t *testing.T) {
 		const (
-			mapSize         = 1
+			mapCount        = 1
 			keyStringSize   = 9
 			valueStringSize = 4
 		)
@@ -17306,16 +17306,16 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		// Create a parent map, with an inlined child map, with an inlined grand child map
-		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
+		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapCount, getKeyFunc)
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
-		require.Equal(t, mapSize, len(children))
+		require.Equal(t, mapCount, len(children))
 
 		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
@@ -17541,7 +17541,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 
 	t.Run("parent is root data slab, one child map, one grand child map, changes to grand child map triggers grand child array slab to become standalone slab", func(t *testing.T) {
 		const (
-			mapSize              = 1
+			mapCount             = 1
 			keyStringSize        = 9
 			valueStringSize      = 4
 			largeValueStringSize = 40
@@ -17564,16 +17564,16 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		// Create a parent map, with an inlined child map, with an inlined grand child map
-		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
+		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapCount, getKeyFunc)
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
-		require.Equal(t, mapSize, len(children))
+		require.Equal(t, mapCount, len(children))
 
 		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
@@ -17808,7 +17808,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 
 	t.Run("parent is root data slab, two child map, one grand child map each, changes to child map triggers child map slab to become standalone slab", func(t *testing.T) {
 		const (
-			mapSize         = 2
+			mapCount        = 2
 			keyStringSize   = 4
 			valueStringSize = 4
 		)
@@ -17829,16 +17829,16 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		// Create a parent map, with inlined child map, containing inlined grand child map
-		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
+		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapCount, getKeyFunc)
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
-		require.Equal(t, mapSize, len(children))
+		require.Equal(t, mapCount, len(children))
 
 		expectedParentSize := GetMapRootSlabByteSize(parentMap)
 
@@ -18038,11 +18038,11 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		require.True(t, IsMapRootDataSlab(parentMap))
-		require.Equal(t, 1+mapSize, getStoredDeltas(storage)) // There is 1+mapSize stored slab because all child maps are standalone.
+		require.Equal(t, 1+mapCount, getStoredDeltas(storage)) // There is 1+mapCount stored slab because all child maps are standalone.
 
 		// Test parent slab size
 		expectedParentSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
-			(singleElementPrefixSize+digestSize+encodedKeySize+slabIDStorableSize)*mapSize
+			(singleElementPrefixSize+digestSize+encodedKeySize+slabIDStorableSize)*mapCount
 		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
@@ -18113,7 +18113,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map and grand child map are inlined.
 
@@ -18187,7 +18187,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			require.Equal(t, uint64(1), childMap.Count())
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map and grand child map are inlined.
 
@@ -18196,7 +18196,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 
 	t.Run("parent is root metadata slab, with four child maps, each child map has grand child maps", func(t *testing.T) {
 		const (
-			mapSize         = 4
+			mapCount        = 4
 			keyStringSize   = 4
 			valueStringSize = 8
 		)
@@ -18217,16 +18217,16 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		}
 
 		// Create a parent map, with inlined child map, containing inlined grand child map
-		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapSize, getKeyFunc)
+		parentMap, expectedKeyValues := createMapWithEmpty2LevelChildMap(t, storage, address, typeInfo, mapCount, getKeyFunc)
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 		testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
-		require.Equal(t, mapSize, len(children))
+		require.Equal(t, mapCount, len(children))
 
 		// Insert 1 element to grand child map
 		// Both child map and grand child map are still inlined, but parent map's root slab is metadata slab.
@@ -18351,7 +18351,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 
 		require.False(t, parentMap.Inlined())
 		require.True(t, IsMapRootDataSlab(parentMap))
-		require.Equal(t, 1+mapSize, getStoredDeltas(storage))
+		require.Equal(t, 1+mapCount, getStoredDeltas(storage))
 
 		// Test parent slab size
 		expectedParentElementSize := singleElementPrefixSize + digestSize + encodedKeySize + slabIDStorableSize
@@ -18425,7 +18425,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.False(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 3, getStoredDeltas(storage))
 
@@ -18487,7 +18487,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			require.Equal(t, uint64(0), childMap.Count())
 		}
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.True(t, IsMapRootDataSlab(parentMap))
 		require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -18495,14 +18495,14 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 
 		expectedChildMapSize := uint32(inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize)
 		expectedParentMapSize = mapRootDataSlabPrefixSize + hkeyElementsPrefixSize +
-			(digestSize+singleElementPrefixSize+encodedKeySize+expectedChildMapSize)*uint32(mapSize)
+			(digestSize+singleElementPrefixSize+encodedKeySize+expectedChildMapSize)*uint32(mapCount)
 		require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 	})
 }
 
 func TestChildMapWhenParentMapIsModified(t *testing.T) {
 	const (
-		mapSize                     = 2
+		mapCount                    = 2
 		keyStringSize               = 4
 		valueStringSize             = 4
 		expectedEmptyInlinedMapSize = uint32(inlinedMapDataSlabPrefixSize + hkeyElementsPrefixSize) // 22
@@ -18527,7 +18527,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 	expectedKeyValues := make(map[Value]Value)
 
 	// Insert 2 child map with digest values of 1 and 3.
-	for i := 0; i < mapSize; i++ {
+	for i := 0; i < mapCount; i++ {
 		// Create child map
 		childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
@@ -18560,14 +18560,14 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 	}
 
-	require.Equal(t, uint64(mapSize), parentMap.Count())
+	require.Equal(t, uint64(mapCount), parentMap.Count())
 	require.True(t, IsMapRootDataSlab(parentMap))
 	require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child map is inlined.
 
 	testMap(t, storage, typeInfo, address, parentMap, expectedKeyValues, nil, true)
 
 	children := getInlinedChildMapsFromParentMap(t, address, parentMap)
-	require.Equal(t, mapSize, len(children))
+	require.Equal(t, mapCount, len(children))
 
 	var keysForNonChildMaps []Value
 
@@ -18682,7 +18682,7 @@ func createMapWithEmptyChildMap(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	mapSize int,
+	mapCount int,
 	getKey func() Value,
 ) (*OrderedMap, map[Value]Value) {
 
@@ -18694,7 +18694,7 @@ func createMapWithEmptyChildMap(
 
 	expectedKeyValues := make(map[Value]Value)
 
-	for i := 0; i < mapSize; i++ {
+	for i := 0; i < mapCount; i++ {
 		// Create child map
 		childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
@@ -18732,7 +18732,7 @@ func createMapWithEmpty2LevelChildMap(
 	storage SlabStorage,
 	address Address,
 	typeInfo TypeInfo,
-	mapSize int,
+	mapCount int,
 	getKey func() Value,
 ) (*OrderedMap, map[Value]Value) {
 
@@ -18744,7 +18744,7 @@ func createMapWithEmpty2LevelChildMap(
 
 	expectedKeyValues := make(map[Value]Value)
 
-	for i := 0; i < mapSize; i++ {
+	for i := 0; i < mapCount; i++ {
 		// Create child map
 		childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
@@ -18844,7 +18844,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -18854,7 +18854,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -18908,7 +18908,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -18918,7 +18918,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -18965,7 +18965,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -18975,7 +18975,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -19034,7 +19034,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -19044,7 +19044,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -19099,7 +19099,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -19109,7 +19109,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -19163,7 +19163,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -19173,7 +19173,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child array
 			childArray, err := NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -19220,7 +19220,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -19230,7 +19230,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -19289,7 +19289,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const mapSize = 2
+		const mapCount = 2
 
 		storage := newTestPersistentStorage(t)
 
@@ -19299,7 +19299,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 
 		expectedKeyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			// Create child map
 			childMap, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
@@ -19506,15 +19506,15 @@ func TestMapSetType(t *testing.T) {
 		m, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		mapSize := 10
-		for i := 0; i < mapSize; i++ {
+		mapCount := 10
+		for i := 0; i < mapCount; i++ {
 			v := Uint64Value(i)
 			existingStorable, err := m.Set(compare, hashInputProvider, v, v)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.Equal(t, typeInfo, m.Type())
 		require.True(t, IsMapRootDataSlab(m))
 
@@ -19523,7 +19523,7 @@ func TestMapSetType(t *testing.T) {
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, m.Type())
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
@@ -19539,15 +19539,15 @@ func TestMapSetType(t *testing.T) {
 		m, err := NewMap(storage, address, NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		mapSize := 10_000
-		for i := 0; i < mapSize; i++ {
+		mapCount := 10_000
+		for i := 0; i < mapCount; i++ {
 			v := Uint64Value(i)
 			existingStorable, err := m.Set(compare, hashInputProvider, v, v)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.Equal(t, typeInfo, m.Type())
 		require.False(t, IsMapRootDataSlab(m))
 
@@ -19556,7 +19556,7 @@ func TestMapSetType(t *testing.T) {
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, m.Type())
-		require.Equal(t, uint64(mapSize), m.Count())
+		require.Equal(t, uint64(mapCount), m.Count())
 		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
@@ -19623,19 +19623,19 @@ func TestMapSetType(t *testing.T) {
 
 		childMapSeed := childMap.Seed()
 
-		mapSize := 10_000
-		for i := 0; i < mapSize-1; i++ {
+		mapCount := 10_000
+		for i := 0; i < mapCount-1; i++ {
 			v := Uint64Value(i)
 			existingStorable, err := parentMap.Set(compare, hashInputProvider, v, v)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 		}
 
-		existingStorable, err := parentMap.Set(compare, hashInputProvider, Uint64Value(mapSize-1), childMap)
+		existingStorable, err := parentMap.Set(compare, hashInputProvider, Uint64Value(mapCount-1), childMap)
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapSize), parentMap.Count())
+		require.Equal(t, uint64(mapCount), parentMap.Count())
 		require.Equal(t, typeInfo, parentMap.Type())
 		require.False(t, IsMapRootDataSlab(parentMap))
 		require.False(t, parentMap.Inlined())
@@ -19658,7 +19658,7 @@ func TestMapSetType(t *testing.T) {
 		testExistingInlinedMapSetType(
 			t,
 			parentMap.SlabID(),
-			Uint64Value(mapSize-1),
+			Uint64Value(mapCount-1),
 			GetBaseStorage(storage),
 			newTypeInfo,
 			childMap.Count(),

--- a/map_wrappervalue_test.go
+++ b/map_wrappervalue_test.go
@@ -49,7 +49,7 @@ var newMapValueFunc = func(
 	t *testing.T,
 	address Address,
 	typeInfo TypeInfo,
-	mapSize int,
+	mapCount int,
 	newKey newKeyFunc,
 	newValue newValueFunc,
 ) newValueFunc {
@@ -59,7 +59,7 @@ var newMapValueFunc = func(
 
 		keyValues := make(map[Value]Value)
 
-		for i := 0; i < mapSize; i++ {
+		for i := 0; i < mapCount; i++ {
 			k, expectedK := newKey(storage)
 			v, expectedV := newValue(storage)
 
@@ -488,27 +488,27 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallMapSize = 10
-		largeMapSize = 512
+		smallMapCount = 10
+		largeMapCount = 512
 	)
 
-	mapSizeTestCases := []struct {
-		name    string
-		mapSize int
+	mapCountTestCases := []struct {
+		name     string
+		mapCount int
 	}{
-		{name: "small map", mapSize: smallMapSize},
-		{name: "large map", mapSize: largeMapSize},
+		{name: "small map", mapCount: smallMapCount},
+		{name: "large map", mapCount: largeMapCount},
 	}
 
 	testCases := newMapWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, mapSizeTestCase := range mapSizeTestCases {
+		for _, mapCountTestCase := range mapCountTestCases {
 
-			mapSize := mapSizeTestCase.mapSize
+			mapCount := mapCountTestCase.mapCount
 
-			name := mapSizeTestCase.name + " " + tc.name
+			name := mapCountTestCase.name + " " + tc.name
 			if tc.modifyName != "" {
 				name += "," + tc.modifyName
 			}
@@ -524,7 +524,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 
 				// Set WrapperValue
 				expectedValues := make(map[Value]Value)
-				for len(expectedValues) < mapSize {
+				for len(expectedValues) < mapCount {
 					k, expectedK := tc.newKey(storage)
 
 					if _, exists := expectedValues[expectedK]; exists {
@@ -540,7 +540,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[expectedK] = expectedV
 				}
 
-				require.Equal(t, uint64(mapSize), m.Count())
+				require.Equal(t, uint64(mapCount), m.Count())
 
 				testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -565,7 +565,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[key] = newExpectedV
 				}
 
-				require.Equal(t, uint64(mapSize), m.Count())
+				require.Equal(t, uint64(mapCount), m.Count())
 
 				testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -578,7 +578,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 
 				m2, err := NewMapWithRootID(storage2, rootSlabID, newBasicDigesterBuilder())
 				require.NoError(t, err)
-				require.Equal(t, uint64(mapSize), m2.Count())
+				require.Equal(t, uint64(mapCount), m2.Count())
 
 				// Test loaded map
 				testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
@@ -600,16 +600,16 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallMapSize = 10
-		largeMapSize = 512
+		smallMapCount = 10
+		largeMapCount = 512
 	)
 
-	mapSizeTestCases := []struct {
-		name    string
-		mapSize int
+	mapCountTestCases := []struct {
+		name     string
+		mapCount int
 	}{
-		{name: "small map", mapSize: smallMapSize},
-		{name: "large map", mapSize: largeMapSize},
+		{name: "small map", mapCount: smallMapCount},
+		{name: "large map", mapCount: largeMapCount},
 	}
 
 	modifyTestCases := []struct {
@@ -620,41 +620,41 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 		{name: "", needToModifyElement: false},
 	}
 
-	removeSizeTestCases := []struct {
+	removeTestCases := []struct {
 		name               string
 		removeAllElements  bool
 		removeElementCount int
 	}{
 		{name: "remove all elements", removeAllElements: true},
 		{name: "remove 1 element", removeElementCount: 1},
-		{name: fmt.Sprintf("remove %d element", smallMapSize/2), removeElementCount: smallMapSize / 2},
+		{name: fmt.Sprintf("remove %d element", smallMapCount/2), removeElementCount: smallMapCount / 2},
 	}
 
 	testCases := newMapWrapperValueTestCases(t, r, address, typeInfo)
 
 	for _, tc := range testCases {
 
-		for _, mapSizeTestCase := range mapSizeTestCases {
+		for _, mapCountTestCase := range mapCountTestCases {
 
 			for _, modifyTestCase := range modifyTestCases {
 
-				for _, removeSizeTestCase := range removeSizeTestCases {
+				for _, removeTestCase := range removeTestCases {
 
-					mapSize := mapSizeTestCase.mapSize
+					mapCount := mapCountTestCase.mapCount
 
 					needToModifyElement := modifyTestCase.needToModifyElement
 
-					removeSize := removeSizeTestCase.removeElementCount
-					if removeSizeTestCase.removeAllElements {
-						removeSize = mapSize
+					removeCount := removeTestCase.removeElementCount
+					if removeTestCase.removeAllElements {
+						removeCount = mapCount
 					}
 
-					name := mapSizeTestCase.name + " " + tc.name
+					name := mapCountTestCase.name + " " + tc.name
 					if modifyTestCase.needToModifyElement {
 						name += ", " + tc.modifyName
 					}
-					if removeSizeTestCase.name != "" {
-						name += ", " + removeSizeTestCase.name
+					if removeTestCase.name != "" {
+						name += ", " + removeTestCase.name
 					}
 
 					t.Run(name, func(t *testing.T) {
@@ -669,7 +669,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 						expectedValues := make(map[Value]Value)
 
 						// Set WrapperValue in map
-						for len(expectedValues) < mapSize {
+						for len(expectedValues) < mapCount {
 							k, expectedK := tc.newKey(storage)
 
 							if _, exists := expectedValues[expectedK]; exists {
@@ -685,7 +685,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 							expectedValues[expectedK] = expectedV
 						}
 
-						require.Equal(t, uint64(mapSize), m.Count())
+						require.Equal(t, uint64(mapCount), m.Count())
 
 						testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -711,7 +711,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 								expectedValues[key] = newExpectedV
 							}
 
-							require.Equal(t, uint64(mapSize), m.Count())
+							require.Equal(t, uint64(mapCount), m.Count())
 
 							testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 						}
@@ -722,7 +722,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 						}
 
 						// Remove random elements
-						for i := 0; i < removeSize; i++ {
+						for i := 0; i < removeCount; i++ {
 
 							removeKeyIndex := r.Intn(len(keys))
 							removeKey := keys[removeKeyIndex]
@@ -734,8 +734,8 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 							keys = append(keys[:removeKeyIndex], keys[removeKeyIndex+1:]...)
 						}
 
-						require.Equal(t, uint64(mapSize-removeSize), m.Count())
-						require.Equal(t, mapSize-removeSize, len(expectedValues))
+						require.Equal(t, uint64(mapCount-removeCount), m.Count())
+						require.Equal(t, mapCount-removeCount, len(expectedValues))
 
 						testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -748,7 +748,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 
 						m2, err := NewMapWithRootID(storage2, rootSlabID, newBasicDigesterBuilder())
 						require.NoError(t, err)
-						require.Equal(t, uint64(mapSize-removeSize), m2.Count())
+						require.Equal(t, uint64(mapCount-removeCount), m2.Count())
 
 						// Test loaded map
 						testMap(t, storage2, typeInfo, address, m2, expectedValues, nil, true)
@@ -769,16 +769,16 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallMapSize = 10
-		largeMapSize = 512
+		smallMapCount = 10
+		largeMapCount = 512
 	)
 
-	mapSizeTestCases := []struct {
-		name    string
-		mapSize int
+	mapCountTestCases := []struct {
+		name     string
+		mapCount int
 	}{
-		{name: "small map", mapSize: smallMapSize},
-		{name: "large map", mapSize: largeMapSize},
+		{name: "small map", mapCount: smallMapCount},
+		{name: "large map", mapCount: largeMapCount},
 	}
 
 	modifyTestCases := []struct {
@@ -793,7 +793,7 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		for _, mapSizeTestCase := range mapSizeTestCases[:1] {
+		for _, mapCountTestCase := range mapCountTestCases[:1] {
 
 			for _, modifyTestCase := range modifyTestCases {
 
@@ -802,11 +802,11 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 					continue
 				}
 
-				mapSize := mapSizeTestCase.mapSize
+				mapCount := mapCountTestCase.mapCount
 
 				testModifyElement := modifyTestCase.testModifyElement
 
-				name := mapSizeTestCase.name + " " + tc.name
+				name := mapCountTestCase.name + " " + tc.name
 				if modifyTestCase.testModifyElement {
 					name += ", " + tc.modifyName
 				}
@@ -821,7 +821,7 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 					expectedValues := make(map[Value]Value)
 
 					// Set WrapperValue to map
-					for len(expectedValues) < mapSize {
+					for len(expectedValues) < mapCount {
 						k, expectedK := tc.newKey(storage)
 
 						if _, exists := expectedValues[expectedK]; exists {
@@ -837,7 +837,7 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 						expectedValues[expectedK] = expectedV
 					}
 
-					require.Equal(t, uint64(mapSize), m.Count())
+					require.Equal(t, uint64(mapCount), m.Count())
 
 					testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -884,16 +884,16 @@ func TestMapWrapperValueIterate(t *testing.T) {
 	address := Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	const (
-		smallMapSize = 10
-		largeMapSize = 512
+		smallMapCount = 10
+		largeMapCount = 512
 	)
 
-	mapSizeTestCases := []struct {
-		name    string
-		mapSize int
+	mapCountTestCases := []struct {
+		name     string
+		mapCount int
 	}{
-		{name: "small map", mapSize: smallMapSize},
-		{name: "large map", mapSize: largeMapSize},
+		{name: "small map", mapCount: smallMapCount},
+		{name: "large map", mapCount: largeMapCount},
 	}
 
 	modifyTestCases := []struct {
@@ -908,7 +908,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		for _, mapSizeTestCase := range mapSizeTestCases[:1] {
+		for _, mapCountTestCase := range mapCountTestCases[:1] {
 
 			for _, modifyTestCase := range modifyTestCases {
 
@@ -919,11 +919,11 @@ func TestMapWrapperValueIterate(t *testing.T) {
 					continue
 				}
 
-				mapSize := mapSizeTestCase.mapSize
+				mapCount := mapCountTestCase.mapCount
 
 				testModifyElement := modifyTestCase.testModifyElement
 
-				name := mapSizeTestCase.name + " " + tc.name
+				name := mapCountTestCase.name + " " + tc.name
 				if modifyTestCase.testModifyElement {
 					name += ", " + tc.modifyName
 				}
@@ -938,7 +938,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 					expectedValues := make(map[Value]Value)
 
 					// Set WrapperValue in map
-					for len(expectedValues) < mapSize {
+					for len(expectedValues) < mapCount {
 						k, expectedK := tc.newKey(storage)
 
 						if _, exists := expectedValues[expectedK]; exists {
@@ -954,7 +954,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 						expectedValues[expectedK] = expectedV
 					}
 
-					require.Equal(t, uint64(mapSize), m.Count())
+					require.Equal(t, uint64(mapCount), m.Count())
 
 					testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -987,7 +987,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 						count++
 					}
 
-					require.Equal(t, uint64(mapSize), m.Count())
+					require.Equal(t, uint64(mapCount), m.Count())
 
 					testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 				})
@@ -1079,8 +1079,8 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 	// Retrieve wrapped child map, and then insert new elements to child map.
 	// Wrapped child map is expected to be unlined at the end of loop.
 
-	const childMapSize = 8
-	for i := 0; i <= childMapSize; i++ {
+	const childMapCount = 8
+	for i := 0; i <= childMapCount; i++ {
 		// Get element
 		element, err := m.Get(compare, hashInputProvider, Uint64Value(0))
 		require.NoError(t, err)
@@ -1123,8 +1123,8 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 	// Retrieve wrapped child map, and then remove elements from child map.
 	// Wrapped child map is expected to be inlined at the end of loop.
 
-	childMapSizeAfterRemoval := 2
-	removeCount := childMapSize - childMapSizeAfterRemoval
+	childMapCountAfterRemoval := 2
+	removeCount := childMapCount - childMapCountAfterRemoval
 
 	for i := 0; i < removeCount; i++ {
 		// Get element
@@ -1284,8 +1284,8 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild map, and then insert new elements to gchild map.
 	// Wrapped gchild map is expected to be unlined at the end of loop.
 
-	const gchildMapSize = 8
-	for i := 0; i < gchildMapSize; i++ {
+	const gchildMapCount = 8
+	for i := 0; i < gchildMapCount; i++ {
 		// Get element at level 1
 
 		elementAtLevel1, err := m.Get(compare, hashInputProvider, Uint64Value(0))
@@ -1347,8 +1347,8 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild map, and then remove elements from gchild map.
 	// Wrapped gchild map is expected to be inlined at the end of loop.
 
-	gchildMapSizeAfterRemoval := 2
-	removeCount := gchildMapSize - gchildMapSizeAfterRemoval
+	gchildMapCountAfterRemoval := 2
+	removeCount := gchildMapCount - gchildMapCountAfterRemoval
 
 	for i := 0; i < removeCount; i++ {
 		// Get elementAtLevel1
@@ -1414,8 +1414,8 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 
 	const (
-		minWriteOperationSize = 124
-		maxWriteOperationSize = 256
+		minWriteOperationCount = 124
+		maxWriteOperationCount = 256
 	)
 
 	r := newRand(t)
@@ -1472,17 +1472,17 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 	m, err := NewMap(storage, address, newBasicDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	actualMapSize := 0
+	actualMapCount := 0
 
 	t.Run("set and remove", func(t *testing.T) {
 		// Insert elements
 
 		var setCount int
-		for setCount < minWriteOperationSize {
-			setCount = r.Intn(maxWriteOperationSize + 1)
+		for setCount < minWriteOperationCount {
+			setCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualMapSize += setCount
+		actualMapCount += setCount
 
 		for i := 0; i < setCount; i++ {
 			k := Uint64Value(i)
@@ -1497,7 +1497,7 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 			expectedValues[k] = expected
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -1510,7 +1510,7 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 			removeCount = r.Intn(int(m.Count()) + 1)
 		}
 
-		actualMapSize -= removeCount
+		actualMapCount -= removeCount
 
 		// Remove elements
 
@@ -1529,7 +1529,7 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1561,8 +1561,8 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 
 	const (
-		minWriteOperationSize = 124
-		maxWriteOperationSize = 256
+		minWriteOperationCount = 124
+		maxWriteOperationCount = 256
 	)
 
 	r := newRand(t)
@@ -1607,17 +1607,17 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 	m, err := NewMap(storage, address, newBasicDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	actualMapSize := 0
+	actualMapCount := 0
 
 	t.Run("set and remove", func(t *testing.T) {
 		// Set elements
 
 		var setCount int
-		for setCount < minWriteOperationSize {
-			setCount = r.Intn(maxWriteOperationSize + 1)
+		for setCount < minWriteOperationCount {
+			setCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualMapSize += setCount
+		actualMapCount += setCount
 
 		for i := 0; i < setCount; i++ {
 			k := Uint64Value(i)
@@ -1630,7 +1630,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			expectedValues[k] = expected
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -1643,7 +1643,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			removeCount = r.Intn(int(m.Count()) + 1)
 		}
 
-		actualMapSize -= removeCount
+		actualMapCount -= removeCount
 
 		// Remove elements
 
@@ -1662,7 +1662,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1703,7 +1703,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			expectedValues[setKey] = modifiedExpectedValue
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -1716,7 +1716,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			removeCount = r.Intn(int(m.Count()))
 		}
 
-		actualMapSize -= removeCount
+		actualMapCount -= removeCount
 
 		// Remove more elements
 
@@ -1730,7 +1730,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1762,8 +1762,8 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 
 	const (
-		minWriteOperationSize = 124
-		maxWriteOperationSize = 256
+		minWriteOperationCount = 124
+		maxWriteOperationCount = 256
 	)
 
 	r := newRand(t)
@@ -1822,17 +1822,17 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 	m, err := NewMap(storage, address, newBasicDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	actualMapSize := 0
+	actualMapCount := 0
 
 	t.Run("set and remove", func(t *testing.T) {
 		// Insert elements
 
 		var setCount int
-		for setCount < minWriteOperationSize {
-			setCount = r.Intn(maxWriteOperationSize + 1)
+		for setCount < minWriteOperationCount {
+			setCount = r.Intn(maxWriteOperationCount + 1)
 		}
 
-		actualMapSize += setCount
+		actualMapCount += setCount
 
 		for i := 0; i < setCount; i++ {
 			k := Uint64Value(i)
@@ -1845,7 +1845,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			expectedValues[k] = expected
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -1856,7 +1856,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			removeCount = r.Intn(int(m.Count()) + 1)
 		}
 
-		actualMapSize -= removeCount
+		actualMapCount -= removeCount
 
 		keys := make([]Value, 0, m.Count())
 		err := m.IterateReadOnlyKeys(func(key Value) (resume bool, err error) {
@@ -1875,7 +1875,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1918,7 +1918,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			expectedValues[key] = modifiedExpectedValue
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -1929,7 +1929,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			removeCount = r.Intn(int(m.Count()))
 		}
 
-		actualMapSize -= removeCount
+		actualMapCount -= removeCount
 
 		for i := 0; i < removeCount; i++ {
 			index := r.Intn(len(keys))
@@ -1941,7 +1941,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapSize), m.Count())
+		require.Equal(t, uint64(actualMapCount), m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1978,15 +1978,15 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 
 	t.Run("modify level-1 wrapper map in {uint64: SomeValue({uint64: SomeValue(uint64)})}", func(t *testing.T) {
 		const (
-			mapSize      = 3
-			childMapSize = 2
+			mapCount      = 3
+			childMapCount = 2
 		)
 
 		typeInfo := testTypeInfo{42}
 
 		r := newRand(t)
 
-		createStorage := func(mapSize int) (
+		createStorage := func(mapCount int) (
 			_ BaseStorage,
 			rootSlabID SlabID,
 			expectedKeyValues map[Value]Value,
@@ -1998,7 +1998,7 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 					t,
 					address,
 					typeInfo,
-					mapSize,
+					mapCount,
 					newUint64KeyFunc(),
 					newWrapperValueFunc(
 						1,
@@ -2006,7 +2006,7 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 							t,
 							address,
 							typeInfo,
-							childMapSize,
+							childMapCount,
 							newUint64KeyFunc(),
 							newWrapperValueFunc(
 								1,
@@ -2027,8 +2027,8 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 
 		// Create a base storage with map in the format of
 		// {uint64: SomeValue({uint64: SomeValue(uint64)})}
-		baseStorage, rootSlabID, expectedKeyValues := createStorage(mapSize)
-		require.Equal(t, mapSize, len(expectedKeyValues))
+		baseStorage, rootSlabID, expectedKeyValues := createStorage(mapCount)
+		require.Equal(t, mapCount, len(expectedKeyValues))
 
 		keys := make([]Value, 0, len(expectedKeyValues))
 		for k := range expectedKeyValues {
@@ -2094,16 +2094,16 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 
 	t.Run("get and modify 2-level wrapper map in {uint64: SomeValue({uint64: SomeValue({uint64: SomeValue(uint64)})})}", func(t *testing.T) {
 		const (
-			mapSize       = 4
-			childMapSize  = 3
-			gchildMapSize = 2
+			mapCount       = 4
+			childMapCount  = 3
+			gchildMapCount = 2
 		)
 
 		typeInfo := testTypeInfo{42}
 
 		r := newRand(t)
 
-		createStorage := func(mapSize int) (
+		createStorage := func(mapCount int) (
 			_ BaseStorage,
 			rootSlabID SlabID,
 			expectedKeyValues map[Value]Value,
@@ -2115,7 +2115,7 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 					t,
 					address,
 					typeInfo,
-					mapSize,
+					mapCount,
 					newUint64KeyFunc(),
 					newWrapperValueFunc(
 						1,
@@ -2123,7 +2123,7 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 							t,
 							address,
 							typeInfo,
-							mapSize,
+							mapCount,
 							newUint64KeyFunc(),
 							newWrapperValueFunc(
 								1,
@@ -2131,7 +2131,7 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 									t,
 									address,
 									typeInfo,
-									childMapSize,
+									childMapCount,
 									newUint64KeyFunc(),
 									newWrapperValueFunc(
 										1,
@@ -2152,8 +2152,8 @@ func TestMapWrapperValueModifyExistingMap(t *testing.T) {
 
 		// Create a base storage with map in the format of
 		// {uint64: SomeValue({uint64: SomeValue({uint64: SomeValue(string)})})}
-		baseStorage, rootSlabID, expectedKeyValues := createStorage(mapSize)
-		require.Equal(t, mapSize, len(expectedKeyValues))
+		baseStorage, rootSlabID, expectedKeyValues := createStorage(mapCount)
+		require.Equal(t, mapCount, len(expectedKeyValues))
 
 		keys := make([]Value, 0, len(expectedKeyValues))
 		for k := range expectedKeyValues {


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

This PR renames variables in tests from `xxxSize` to `xxxCount` to reduce confusion.
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
