### PR TITLE
Use helper functions to compute array sizes in tests

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -103,3 +103,19 @@ func GetMutableValueNotifierValueID(v Value) (ValueID, error) {
 	}
 	return m.ValueID(), nil
 }
+
+func ComputeArrayRootDataSlabByteSize(storableByteSizes []uint32) uint32 {
+	slabSize := uint32(arrayRootDataSlabPrefixSize)
+	for _, storableByteSize := range storableByteSizes {
+		slabSize += storableByteSize
+	}
+	return slabSize
+}
+
+func ComputeInlinedArraySlabByteSize(storableByteSizes []uint32) uint32 {
+	slabSize := uint32(inlinedArrayDataSlabPrefixSize)
+	for _, storableByteSize := range storableByteSizes {
+		slabSize += storableByteSize
+	}
+	return slabSize
+}


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

This refactor simplifies tests and can reduce mistakes.



______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
