### PR TITLE
Use helper funcs to compute map byte sizes in tests

### DIFF
--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -2572,11 +2572,13 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 		// Set elements
 
 		var setCount int
-		if array.Count() <= 10 {
-			setCount = int(array.Count())
-		} else {
-			for setCount < int(array.Count())/2 {
-				setCount = r.Intn(int(array.Count()) + 1)
+		for setCount == 0 {
+			if array.Count() <= 10 {
+				setCount = int(array.Count())
+			} else {
+				for setCount < int(array.Count())/2 {
+					setCount = r.Intn(int(array.Count()) + 1)
+				}
 			}
 		}
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -497,3 +497,9 @@ func IsMapRootDataSlab(m *OrderedMap) bool {
 func GetMapRootSlabByteSize(m *OrderedMap) uint32 {
 	return GetMapRootSlab(m).ByteSize()
 }
+
+var (
+	slabIDStorableByteSize    = SlabIDStorable{}.ByteSize()
+	emptyInlinedArrayByteSize = ComputeInlinedArraySlabByteSize(nil)
+	emptyInlinedMapByteSize   = ComputeInlinedMapSlabByteSize(nil)
+)


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

This refactor simplifies tests and can reduce mistakes.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
