### PR TITLE
Bump to Go 1.23 and golangci-lint 1.63.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: ['1.22', '1.23']
+        go-version: ['1.23', '1.24']
 
     steps:
     - name: Install Go

--- a/.github/workflows/safer-golangci-lint.yml
+++ b/.github/workflows/safer-golangci-lint.yml
@@ -16,10 +16,10 @@ on:
     branches: [main, master]
 
 env:
-  GO_VERSION: '1.22'
-  GOLINTERS_VERSION: 1.56.2
+  GO_VERSION: '1.23'
+  GOLINTERS_VERSION: 1.63.4
   GOLINTERS_ARCH: linux-amd64
-  GOLINTERS_TGZ_DGST: e1c313fb5fc85a33890fdee5dbb1777d1f5829c84d655a47a55688f3aad5e501
+  GOLINTERS_TGZ_DGST: 01abb14a4df47b5ca585eff3c34b105023cba92ec34ff17212dbb83855581690
   GOLINTERS_TIMEOUT: 15m
   OPENSSL_DGST_CMD: openssl dgst -sha256 -r
   CURL_CMD: curl --proto =https --tlsv1.2 --location --silent --show-error --fail

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
     - unused
 
     # enable extra linters
-    - exportloopref
+    - copyloopvar
     - gocritic
     - gofmt
     - goimports

--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -336,7 +336,7 @@ func benchmarkArrayPopIterate(b *testing.B, initialArrayCount int) {
 			storable = s
 		})
 		if err != nil {
-			b.Errorf(err.Error())
+			b.Error(err.Error())
 		}
 	}
 

--- a/cmd/smoke/map.go
+++ b/cmd/smoke/map.go
@@ -382,7 +382,7 @@ func modifyMap(
 
 		// Compare old value from map with old value from elements
 		if (oldExpectedValue == nil) != (existingStorable == nil) {
-			return nil, 0, fmt.Errorf("Set returned storable %s != expected %s", existingStorable, oldExpectedValue)
+			return nil, 0, fmt.Errorf("set returned storable %s != expected %s", existingStorable, oldExpectedValue)
 		}
 
 		if existingStorable != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/onflow/atree
 
-go 1.17
+go 1.23
 
 require (
 	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f

--- a/storage.go
+++ b/storage.go
@@ -1580,7 +1580,7 @@ func (s *PersistentSlabStorage) GetAllChildReferences(id SlabID) (
 		return nil, nil, err
 	}
 	if !found {
-		return nil, nil, NewSlabNotFoundErrorf(id, fmt.Sprintf("failed to get root slab by id %s", id))
+		return nil, nil, NewSlabNotFoundErrorf(id, "failed to get root slab by id %s", id)
 	}
 	return s.getAllChildReferences(slab)
 }


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

Also updated `.golangci.yml` to replace deprecated `exportloopref` linter with `copyloopvar` (suggested by `golangci-lint` v1.63.4).

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
