### PR TITLE
Split storage.go into multiple go files

### DIFF
--- a/slab_id.go
+++ b/slab_id.go
@@ -1,0 +1,147 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	SlabAddressLength = 8
+	SlabIndexLength   = 8
+	SlabIDLength      = SlabAddressLength + SlabIndexLength
+)
+
+// WARNING: Any changes to SlabID or its components (Address and SlabIndex)
+// require updates to ValueID definition and functions.
+type (
+	Address   [SlabAddressLength]byte
+	SlabIndex [SlabIndexLength]byte
+
+	// SlabID identifies slab in storage.
+	// SlabID should only be used to retrieve,
+	// store, and remove slab in storage.
+	SlabID struct {
+		address Address
+		index   SlabIndex
+	}
+)
+
+var (
+	AddressUndefined   = Address{}
+	SlabIndexUndefined = SlabIndex{}
+	SlabIDUndefined    = SlabID{}
+)
+
+// SlabIndex
+
+// Next returns new SlabIndex with index+1 value.
+// The caller is responsible for preventing overflow
+// by checking if the index value is valid before
+// calling this function.
+func (index SlabIndex) Next() SlabIndex {
+	i := binary.BigEndian.Uint64(index[:])
+
+	var next SlabIndex
+	binary.BigEndian.PutUint64(next[:], i+1)
+
+	return next
+}
+
+func SlabIndexToLedgerKey(ind SlabIndex) []byte {
+	return []byte(LedgerBaseStorageSlabPrefix + string(ind[:]))
+}
+
+// SlabID
+
+func NewSlabID(address Address, index SlabIndex) SlabID {
+	return SlabID{address, index}
+}
+
+func NewSlabIDFromRawBytes(b []byte) (SlabID, error) {
+	if len(b) < SlabIDLength {
+		return SlabID{}, NewSlabIDErrorf("incorrect slab ID buffer length %d", len(b))
+	}
+
+	var address Address
+	copy(address[:], b)
+
+	var index SlabIndex
+	copy(index[:], b[SlabAddressLength:])
+
+	return SlabID{address, index}, nil
+}
+
+func (id SlabID) ToRawBytes(b []byte) (int, error) {
+	if len(b) < SlabIDLength {
+		return 0, NewSlabIDErrorf("incorrect slab ID buffer length %d", len(b))
+	}
+	copy(b, id.address[:])
+	copy(b[SlabAddressLength:], id.index[:])
+	return SlabIDLength, nil
+}
+
+func (id SlabID) String() string {
+	return fmt.Sprintf(
+		"0x%x.%d",
+		binary.BigEndian.Uint64(id.address[:]),
+		binary.BigEndian.Uint64(id.index[:]),
+	)
+}
+
+func (id SlabID) AddressAsUint64() uint64 {
+	return binary.BigEndian.Uint64(id.address[:])
+}
+
+// Address returns the address of SlabID.
+func (id SlabID) Address() Address {
+	return id.address
+}
+
+func (id SlabID) IndexAsUint64() uint64 {
+	return binary.BigEndian.Uint64(id.index[:])
+}
+
+func (id SlabID) HasTempAddress() bool {
+	return id.address == AddressUndefined
+}
+
+func (id SlabID) Index() SlabIndex {
+	return id.index
+}
+
+func (id SlabID) Valid() error {
+	if id == SlabIDUndefined {
+		return NewSlabIDError("undefined slab ID")
+	}
+	if id.index == SlabIndexUndefined {
+		return NewSlabIDError("undefined slab index")
+	}
+	return nil
+}
+
+func (id SlabID) Compare(other SlabID) int {
+	result := bytes.Compare(id.address[:], other.address[:])
+	if result == 0 {
+		return bytes.Compare(id.index[:], other.index[:])
+	}
+	return result
+}

--- a/storage_health_check.go
+++ b/storage_health_check.go
@@ -1,0 +1,165 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree
+
+import "fmt"
+
+// CheckStorageHealth checks for the health of slab storage.
+// It traverses the slabs and checks these factors:
+// - All non-root slabs only has a single parent reference (no double referencing)
+// - Every child of a parent shares the same ownership (childSlabID.Address == parentSlabID.Address)
+// - The number of root slabs are equal to the expected number (skipped if expectedNumberOfRootSlabs is -1)
+// This should be used for testing purposes only, as it might be slow to process
+func CheckStorageHealth(storage SlabStorage, expectedNumberOfRootSlabs int) (map[SlabID]struct{}, error) {
+	parentOf := make(map[SlabID]SlabID)
+	leaves := make([]SlabID, 0)
+
+	slabIterator, err := storage.SlabIterator()
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to create slab iterator")
+	}
+
+	slabs := map[SlabID]Slab{}
+
+	for {
+		id, slab := slabIterator()
+		if id == SlabIDUndefined {
+			break
+		}
+
+		if _, ok := slabs[id]; ok {
+			return nil, NewFatalError(fmt.Errorf("duplicate slab %s", id))
+		}
+		slabs[id] = slab
+
+		atLeastOneExternalSlab := false
+		childStorables := slab.ChildStorables()
+
+		for len(childStorables) > 0 {
+
+			var next []Storable
+
+			for _, s := range childStorables {
+
+				if sids, ok := s.(SlabIDStorable); ok {
+					sid := SlabID(sids)
+					if _, found := parentOf[sid]; found {
+						return nil, NewFatalError(fmt.Errorf("two parents are captured for the slab %s", sid))
+					}
+					parentOf[sid] = id
+					atLeastOneExternalSlab = true
+				}
+
+				// This handles inlined slab because inlined slab is a child storable (s) and
+				// we traverse s.ChildStorables() for its inlined elements.
+				next = append(next, s.ChildStorables()...)
+			}
+
+			childStorables = next
+		}
+
+		if !atLeastOneExternalSlab {
+			leaves = append(leaves, id)
+		}
+	}
+
+	rootsMap := make(map[SlabID]struct{})
+	visited := make(map[SlabID]struct{})
+	var id SlabID
+	for _, leaf := range leaves {
+		id = leaf
+		if _, ok := visited[id]; ok {
+			return nil, NewFatalError(fmt.Errorf("at least two references found to the leaf slab %s", id))
+		}
+		visited[id] = struct{}{}
+		for {
+			parentID, found := parentOf[id]
+			if !found {
+				// we reach the root
+				rootsMap[id] = struct{}{}
+				break
+			}
+			visited[parentID] = struct{}{}
+
+			childSlab, ok, err := storage.Retrieve(id)
+			if !ok {
+				return nil, NewSlabNotFoundErrorf(id, "failed to get child slab")
+			}
+			if err != nil {
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to retrieve child slab %s", id))
+			}
+
+			parentSlab, ok, err := storage.Retrieve(parentID)
+			if !ok {
+				return nil, NewSlabNotFoundErrorf(id, "failed to get parent slab")
+			}
+			if err != nil {
+				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
+				return nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to retrieve parent slab %s", parentID))
+			}
+
+			childOwner := childSlab.SlabID().address
+			parentOwner := parentSlab.SlabID().address
+
+			if childOwner != parentOwner {
+				return nil, NewFatalError(
+					fmt.Errorf(
+						"parent and child are not owned by the same account: child.owner %s, parent.owner %s",
+						childOwner,
+						parentOwner,
+					))
+			}
+			id = parentID
+		}
+	}
+
+	if len(visited) != len(slabs) {
+
+		var unreachableID SlabID
+		var unreachableSlab Slab
+
+		for id, slab := range slabs {
+			if _, ok := visited[id]; !ok {
+				unreachableID = id
+				unreachableSlab = slab
+				break
+			}
+		}
+
+		return nil, NewFatalError(
+			fmt.Errorf(
+				"slab was not reachable from leaves: %s: %s",
+				unreachableID,
+				unreachableSlab,
+			))
+	}
+
+	if (expectedNumberOfRootSlabs >= 0) && (len(rootsMap) != expectedNumberOfRootSlabs) {
+		return nil, NewFatalError(
+			fmt.Errorf(
+				"number of root slabs doesn't match: expected %d, got %d",
+				expectedNumberOfRootSlabs,
+				len(rootsMap),
+			))
+	}
+
+	return rootsMap, nil
+}

--- a/value_id.go
+++ b/value_id.go
@@ -1,0 +1,59 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	ValueIDLength = SlabIDLength
+)
+
+// ValueID identifies an Array or OrderedMap. ValueID is consistent
+// independent of inlining status, while ValueID and SlabID are used
+// differently despite having the same size and content under the hood.
+// By contrast, SlabID is affected by inlining because it identifies
+// a slab in storage.  Given this, ValueID should be used for
+// resource tracking, etc.
+type ValueID [ValueIDLength]byte
+
+var emptyValueID = ValueID{}
+
+func (vid ValueID) equal(sid SlabID) bool {
+	return bytes.Equal(vid[:len(sid.address)], sid.address[:]) &&
+		bytes.Equal(vid[len(sid.address):], sid.index[:])
+}
+
+func (vid ValueID) String() string {
+	return fmt.Sprintf(
+		"0x%x.%d",
+		binary.BigEndian.Uint64(vid[:SlabAddressLength]),
+		binary.BigEndian.Uint64(vid[SlabAddressLength:]),
+	)
+}
+
+func slabIDToValueID(sid SlabID) ValueID {
+	var id ValueID
+	n := copy(id[:], sid.address[:])
+	copy(id[n:], sid.index[:])
+	return id
+}


### PR DESCRIPTION
Updates https://github.com/onflow/atree/issues/464

This change makes the code easier to read and maintain.

This PR splits storage.go into:
- slab_id.go
- storage.go
- storage_health_check.go
- value_id.go

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
