### PR TITLE
Refactor non-test code to use range loops 

### DIFF
--- a/array_data_slab.go
+++ b/array_data_slab.go
@@ -325,7 +325,7 @@ func (a *ArrayDataSlab) BorrowFromRight(slab Slab) error {
 	// Update right slab
 	// TODO: copy elements to front instead?
 	// NOTE: prevent memory leak
-	for i := uint32(0); i < rightStartIndex; i++ {
+	for i := range rightStartIndex {
 		rightSlab.elements[i] = nil
 	}
 	rightSlab.elements = rightSlab.elements[rightStartIndex:]
@@ -359,7 +359,7 @@ func (a *ArrayDataSlab) CanLendToLeft(size uint32) bool {
 		return false
 	}
 	lendSize := uint32(0)
-	for i := 0; i < len(a.elements); i++ {
+	for i := range a.elements {
 		lendSize += a.elements[i].ByteSize()
 		if a.header.size-lendSize < uint32(minThreshold) {
 			return false

--- a/array_data_slab_decode.go
+++ b/array_data_slab_decode.go
@@ -153,7 +153,7 @@ func newArrayDataSlabFromDataV0(
 	}
 
 	elements := make([]Storable, elemCount)
-	for i := 0; i < int(elemCount); i++ {
+	for i := range elements {
 		storable, err := decodeStorable(cborDec, id, nil)
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
@@ -260,7 +260,7 @@ func newArrayDataSlabFromDataV1(
 	}
 
 	elements := make([]Storable, elemCount)
-	for i := 0; i < int(elemCount); i++ {
+	for i := range elements {
 		storable, err := decodeStorable(cborDec, id, inlinedExtraData)
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
@@ -372,7 +372,7 @@ func DecodeInlinedArrayStorable(
 	size := uint32(inlinedArrayDataSlabPrefixSize)
 
 	elements := make([]Storable, elemCount)
-	for i := 0; i < int(elemCount); i++ {
+	for i := range elements {
 		storable, err := decodeStorable(dec, slabID, inlinedExtraData)
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.

--- a/array_metadata_slab_decode.go
+++ b/array_metadata_slab_decode.go
@@ -145,7 +145,7 @@ func newArrayMetaDataSlabFromDataV0(
 	totalCount := uint32(0)
 	offset := 0
 
-	for i := 0; i < int(childHeaderCount); i++ {
+	for i := range childrenHeaders {
 		slabID, err := NewSlabIDFromRawBytes(data[offset:])
 		if err != nil {
 			// Don't need to wrap because err is already categorized by NewSlabIDFromRawBytes().
@@ -259,7 +259,7 @@ func newArrayMetaDataSlabFromDataV1(
 	childrenCountSum := make([]uint32, childHeaderCount)
 	totalCount := uint32(0)
 
-	for i := 0; i < int(childHeaderCount); i++ {
+	for i := range childrenHeaders {
 		// Decode slab index
 		var index SlabIndex
 		copy(index[:], data[offset:])

--- a/compactmap_extradata.go
+++ b/compactmap_extradata.go
@@ -99,12 +99,12 @@ func newCompactMapExtraData(
 	}
 
 	hkeys := make([]Digest, digestCount)
-	for i := 0; i < digestCount; i++ {
+	for i := range hkeys {
 		hkeys[i] = Digest(binary.BigEndian.Uint64(digestBytes[i*digestSize:]))
 	}
 
 	keys := make([]ComparableStorable, keyCount)
-	for i := uint64(0); i < keyCount; i++ {
+	for i := range keys {
 		// Decode compact map key
 		key, err := decodeStorable(dec, SlabIDUndefined, nil)
 		if err != nil {
@@ -144,7 +144,7 @@ func (c *compactMapExtraData) Encode(enc *Encoder, encodeTypeInfo encodeTypeInfo
 		digests = make([]byte, totalDigestSize)
 	}
 
-	for i := 0; i < len(c.hkeys); i++ {
+	for i := range c.hkeys {
 		binary.BigEndian.PutUint64(digests[i*digestSize:], uint64(c.hkeys[i]))
 	}
 
@@ -210,7 +210,7 @@ type fieldNameSorter struct {
 
 func newFieldNameSorter(names []ComparableStorable) *fieldNameSorter {
 	index := make([]int, len(names))
-	for i := 0; i < len(names); i++ {
+	for i := range index {
 		index[i] = i
 	}
 	return &fieldNameSorter{

--- a/extradata.go
+++ b/extradata.go
@@ -74,7 +74,7 @@ func newInlinedExtraDataFromData(
 	}
 
 	inlinedTypeInfo := make([]TypeInfo, int(typeInfoCount))
-	for i := uint64(0); i < typeInfoCount; i++ {
+	for i := range inlinedTypeInfo {
 		inlinedTypeInfo[i], err = defaultDecodeTypeInfo(dec)
 		if err != nil {
 			return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode typeInfo")
@@ -94,7 +94,7 @@ func newInlinedExtraDataFromData(
 	}
 
 	inlinedExtraData := make([]ExtraData, extraDataCount)
-	for i := uint64(0); i < extraDataCount; i++ {
+	for i := range inlinedExtraData {
 		tagNum, err := dec.DecodeTagNumber()
 		if err != nil {
 			return nil, nil, NewDecodingError(err)

--- a/hash.go
+++ b/hash.go
@@ -129,7 +129,7 @@ func (bd *basicDigester) DigestPrefix(level uint) ([]Digest, error) {
 		return nil, NewHashLevelErrorf("cannot get digest < level %d: level must be [0, %d]", level, bd.Levels())
 	}
 	var prefix []Digest
-	for i := uint(0); i < level; i++ {
+	for i := range level {
 		d, err := bd.Digest(i)
 		if err != nil {
 			// Don't need to wrap error as external error because err is already categorized by basicDigester.Digest().

--- a/map_data_slab_decode.go
+++ b/map_data_slab_decode.go
@@ -359,7 +359,7 @@ func DecodeInlinedCompactMapStorable(
 	// Decode values
 	elementsSize := uint32(hkeyElementsPrefixSize)
 	elems := make([]element, elemCount)
-	for i := 0; i < int(elemCount); i++ {
+	for i := range elems {
 		value, err := decodeStorable(dec, slabID, inlinedExtraData)
 		if err != nil {
 			return nil, err

--- a/map_data_slab_encode.go
+++ b/map_data_slab_encode.go
@@ -319,7 +319,7 @@ func encodeCompactMapValues(
 	}
 
 	keyIndexes := make([]int, len(keys))
-	for i := 0; i < len(keys); i++ {
+	for i := range keyIndexes {
 		keyIndexes[i] = i
 	}
 

--- a/map_elements.go
+++ b/map_elements.go
@@ -141,12 +141,12 @@ func elementsStorables(elems elements, childStorables []Storable) []Storable {
 	switch v := elems.(type) {
 
 	case *hkeyElements:
-		for i := 0; i < len(v.elems); i++ {
+		for i := range v.elems {
 			childStorables = elementStorables(v.elems[i], childStorables)
 		}
 
 	case *singleElements:
-		for i := 0; i < len(v.elems); i++ {
+		for i := range v.elems {
 			childStorables = elementStorables(v.elems[i], childStorables)
 		}
 

--- a/map_elements_decode.go
+++ b/map_elements_decode.go
@@ -52,7 +52,7 @@ func newElementsFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDec
 
 	digestCount := len(digestBytes) / digestSize
 	hkeys := make([]Digest, digestCount)
-	for i := 0; i < digestCount; i++ {
+	for i := range hkeys {
 		hkeys[i] = Digest(binary.BigEndian.Uint64(digestBytes[i*digestSize:]))
 	}
 
@@ -71,7 +71,7 @@ func newElementsFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDec
 		// Decode elements
 		size := uint32(singleElementsPrefixSize)
 		elems := make([]*singleElement, elemCount)
-		for i := 0; i < int(elemCount); i++ {
+		for i := range elems {
 			elem, err := newSingleElementFromData(cborDec, decodeStorable, slabID, inlinedExtraData)
 			if err != nil {
 				// Don't need to wrap error as external error because err is already categorized by newSingleElementFromData().
@@ -97,7 +97,7 @@ func newElementsFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDec
 	// Decode elements
 	size := uint32(hkeyElementsPrefixSize)
 	elems := make([]element, elemCount)
-	for i := 0; i < int(elemCount); i++ {
+	for i := range elems {
 		elem, err := newElementFromData(cborDec, decodeStorable, slabID, inlinedExtraData)
 		if err != nil {
 			// Don't need to wrap error as external error because err is already categorized by newElementFromData().

--- a/map_elements_encode.go
+++ b/map_elements_encode.go
@@ -61,7 +61,7 @@ func (e *hkeyElements) Encode(enc *Encoder) error {
 	}
 
 	// Encode hkeys
-	for i := 0; i < len(e.hkeys); i++ {
+	for i := range e.hkeys {
 		binary.BigEndian.PutUint64(enc.Scratch[:], uint64(e.hkeys[i]))
 		err = enc.CBOR.EncodeRawBytes(enc.Scratch[:digestSize])
 		if err != nil {

--- a/map_elements_hashkey.go
+++ b/map_elements_hashkey.go
@@ -444,7 +444,7 @@ func (e *hkeyElements) Merge(elems elements) error {
 	e.size += rElems.Size() - hkeyElementsPrefixSize
 
 	// Set merged elements to nil to prevent memory leak
-	for i := 0; i < len(rElems.elems); i++ {
+	for i := range rElems.elems {
 		rElems.elems[i] = nil
 	}
 
@@ -603,7 +603,7 @@ func (e *hkeyElements) BorrowFromRight(re elements) error {
 	// Update right slab
 	// TODO: copy elements to front instead?
 	// NOTE: prevent memory leak
-	for i := 0; i < rightStartIndex; i++ {
+	for i := range rightStartIndex {
 		rightElements.elems[i] = nil
 	}
 	rightElements.hkeys = rightElements.hkeys[rightStartIndex:]
@@ -628,7 +628,7 @@ func (e *hkeyElements) CanLendToLeft(size uint32) bool {
 	}
 
 	lendSize := uint32(0)
-	for i := 0; i < len(e.elems); i++ {
+	for i := range e.elems {
 		lendSize += e.elems[i].Size() + digestSize
 		if e.Size()-lendSize < uint32(minSize) {
 			return false
@@ -696,7 +696,7 @@ func (e *hkeyElements) hasPointer() bool {
 func (e *hkeyElements) String() string {
 	var s []string
 
-	for i := 0; i < len(e.elems); i++ {
+	for i := range e.elems {
 		s = append(s, fmt.Sprintf("%d:%s", e.hkeys[i], e.elems[i].String()))
 	}
 

--- a/map_elements_nokey.go
+++ b/map_elements_nokey.go
@@ -118,7 +118,7 @@ func (e *singleElements) Set(
 	}
 
 	// linear search key and update value
-	for i := 0; i < len(e.elems); i++ {
+	for i := range e.elems {
 		elem := e.elems[i]
 
 		equal, err := comparator(storage, key, elem.key)
@@ -277,7 +277,7 @@ func (e *singleElements) Size() uint32 {
 func (e *singleElements) String() string {
 	var s []string
 
-	for i := 0; i < len(e.elems); i++ {
+	for i := range e.elems {
 		s = append(s, fmt.Sprintf(":%s", e.elems[i].String()))
 	}
 

--- a/map_metadata_slab_decode.go
+++ b/map_metadata_slab_decode.go
@@ -137,7 +137,7 @@ func newMapMetaDataSlabFromDataV0(
 	childrenHeaders := make([]MapSlabHeader, childHeaderCount)
 	offset := 0
 
-	for i := 0; i < int(childHeaderCount); i++ {
+	for i := range childrenHeaders {
 		slabID, err := NewSlabIDFromRawBytes(data[offset:])
 		if err != nil {
 			// Don't need to wrap error as external error because err is already categorized by NewSlabIDFromRawBytes().
@@ -249,7 +249,7 @@ func newMapMetaDataSlabFromDataV1(
 	// Decode child headers
 	childrenHeaders := make([]MapSlabHeader, childHeaderCount)
 
-	for i := 0; i < int(childHeaderCount); i++ {
+	for i := range childrenHeaders {
 		// Decode slab index
 		var index SlabIndex
 		copy(index[:], data[offset:])

--- a/storage.go
+++ b/storage.go
@@ -625,7 +625,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 	var wg sync.WaitGroup
 	wg.Add(numWorkers)
 
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go encoder(&wg, done, jobs, results)
 	}
 
@@ -643,7 +643,7 @@ func (s *PersistentSlabStorage) FastCommit(numWorkers int) error {
 	// we need to capture them inside a map
 	// again so we can apply them in order of keys
 	encSlabByID := make(map[SlabID][]byte, len(keysWithOwners))
-	for i := 0; i < len(keysWithOwners); i++ {
+	for range len(keysWithOwners) {
 		result := <-results
 		// if any error return
 		if result.err != nil {
@@ -825,7 +825,7 @@ func (s *PersistentSlabStorage) NondeterministicFastCommit(numWorkers int) error
 
 	// Launch workers to encode slabs
 	wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go encoder(&wg, done, jobs, results)
 	}
 
@@ -854,7 +854,7 @@ func (s *PersistentSlabStorage) NondeterministicFastCommit(numWorkers int) error
 	}
 
 	// Process encoded slabs
-	for i := 0; i < modifiedSlabCount; i++ {
+	for range modifiedSlabCount {
 		result := <-results
 
 		if result.err != nil {
@@ -1410,7 +1410,7 @@ func (s *PersistentSlabStorage) BatchPreload(ids []SlabID, numWorkers int) error
 
 	// Launch workers
 	wg.Add(numWorkers)
-	for i := 0; i < numWorkers; i++ {
+	for range numWorkers {
 		go decoder(&wg, done, jobs, results)
 	}
 
@@ -1441,7 +1441,7 @@ func (s *PersistentSlabStorage) BatchPreload(ids []SlabID, numWorkers int) error
 	}
 
 	// Process results
-	for i := 0; i < jobCount; i++ {
+	for range jobCount {
 		result := <-results
 
 		if result.err != nil {


### PR DESCRIPTION
Updates #464

Using range loops had pitfalls prior to Go 1.22, but we are using newer Go versions so we can use range loops now.

This PR refactors 3-clause for-loops in non-test code to improve maintainability by using:
- range over integers
- range over slices

[Go 1.22 release notes](https://tip.golang.org/doc/go1.22) states:

> Go 1.22 makes two changes to “for” loops.
>
> - Previously, the variables declared by a “for” loop were created once and updated by each iteration. In Go 1.22, each iteration of the loop creates new variables, to avoid accidental sharing bugs.
> 
> - “For” loops may now range over integers.

NOTE: Although this PR updates non-test code, it does not affect behavior of running code.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
