### PR TITLE
Simplify and lint test code to improve maintainability and fix flakey test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,23 +3,23 @@
 linters:
   disable-all: true
   enable:
-    # enable default linters
-    - errcheck
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-
-    # enable extra linters
+    - asciicheck
+    - bidichk
     - copyloopvar
+    - errcheck
+    - forbidigo
     - gocritic
     - gofmt
     - goimports
+    - gosimple
+    - govet
+    - ineffassign
     - misspell
     - nilerr
+    - staticcheck
+    - typecheck
     - unconvert
+    - unused
 
 issues:
   max-issues-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
     - bidichk
     - copyloopvar
     - errcheck
-    - forbidigo
+    # - forbidigo # TODO: enable forbidigo after adding non-default settings
     - gocritic
     - gofmt
     - goimports

--- a/array.go
+++ b/array.go
@@ -886,8 +886,8 @@ func (a *Array) hasParentUpdater() bool {
 	return a.parentUpdater != nil
 }
 
-func (a *Array) getMutableElementIndexCount() int {
-	return len(a.mutableElementIndex)
+func (a *Array) getMutableElementIndexCount() uint64 {
+	return uint64(len(a.mutableElementIndex))
 }
 
 func (a *Array) getMutableElementIndex() map[ValueID]uint64 {

--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -233,8 +233,8 @@ func benchmarkArrayGet(b *testing.B, initialArrayCount, numberOfOps int) {
 
 	for range b.N {
 		for range numberOfOps {
-			index := r.Intn(int(array.Count()))
-			value, _ = array.Get(uint64(index))
+			index := getRandomArrayIndex(r, array)
+			value, _ = array.Get(index)
 		}
 	}
 
@@ -258,9 +258,9 @@ func benchmarkArrayInsert(b *testing.B, initialArrayCount, numberOfOps int) {
 		b.StartTimer()
 
 		for range numberOfOps {
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
-			_ = array.Insert(uint64(index), v)
+			_ = array.Insert(index, v)
 		}
 	}
 }
@@ -282,8 +282,8 @@ func benchmarkArrayRemove(b *testing.B, initialArrayCount, numberOfOps int) {
 		b.StartTimer()
 
 		for range numberOfOps {
-			index := r.Intn(int(array.Count()))
-			_, _ = array.Remove(uint64(index))
+			index := getRandomArrayIndex(r, array)
+			_, _ = array.Remove(index)
 		}
 	}
 }

--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -199,7 +199,7 @@ func setupArray(b *testing.B, r *rand.Rand, storage *atree.PersistentSlabStorage
 	require.NoError(b, err)
 
 	for range initialArrayCount {
-		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		v := randomValue(r, atree.MaxInlineArrayElementSize())
 		err := array.Append(v)
 		require.NoError(b, err)
 	}
@@ -259,7 +259,7 @@ func benchmarkArrayInsert(b *testing.B, initialArrayCount, numberOfOps int) {
 
 		for range numberOfOps {
 			index := r.Intn(int(array.Count()))
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			_ = array.Insert(uint64(index), v)
 		}
 	}

--- a/array_bench_test.go
+++ b/array_bench_test.go
@@ -199,7 +199,7 @@ func setupArray(b *testing.B, r *rand.Rand, storage *atree.PersistentSlabStorage
 	require.NoError(b, err)
 
 	for range initialArrayCount {
-		v := RandomValue(r)
+		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 		err := array.Append(v)
 		require.NoError(b, err)
 	}
@@ -259,7 +259,7 @@ func benchmarkArrayInsert(b *testing.B, initialArrayCount, numberOfOps int) {
 
 		for range numberOfOps {
 			index := r.Intn(int(array.Count()))
-			v := RandomValue(r)
+			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 			_ = array.Insert(uint64(index), v)
 		}
 	}

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -111,8 +111,8 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 	require.NoError(b, err)
 
 	for range numberOfElements {
-		ind := r.Intn(int(array.Count()))
-		storable, err := array.Remove(uint64(ind))
+		ind := getRandomArrayIndex(r, array)
+		storable, err := array.Remove(ind)
 		require.NoError(b, err)
 		totalRawDataSize -= storable.ByteSize()
 	}
@@ -126,7 +126,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 	require.NoError(b, err)
 
 	for range numberOfElements {
-		ind := r.Intn(int(array.Count()))
+		ind := getRandomArrayIndex(r, array)
 		v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
@@ -134,7 +134,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
 		totalRawDataSize += storable.ByteSize()
 
-		err = array.Insert(uint64(ind), v)
+		err = array.Insert(ind, v)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -147,8 +147,8 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 	require.NoError(b, err)
 
 	for range numberOfElements {
-		ind := r.Intn(int(array.Count()))
-		_, err := array.Get(uint64(ind))
+		ind := getRandomArrayIndex(r, array)
+		_, err := array.Get(ind)
 		require.NoError(b, err)
 	}
 	require.NoError(b, storage.Commit())
@@ -162,8 +162,8 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 	array, err = atree.NewArrayWithRootID(storage, arrayID)
 	require.NoError(b, err)
 
-	ind := r.Intn(int(array.Count()))
-	_, err = array.Get(uint64(ind))
+	ind := getRandomArrayIndex(r, array)
+	_, err = array.Get(ind)
 	require.NoError(b, err)
 
 	storageOverheadRatio := float64(baseStorage.Size()) / float64(totalRawDataSize)
@@ -215,11 +215,11 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOp
 	b.ResetTimer()
 
 	for range numberOfOps {
-		ind := r.Intn(int(array.Count()))
+		ind := getRandomArrayIndex(r, array)
 		// select opt
 		switch r.Intn(2) {
 		case 0: // remove
-			storable, err := array.Remove(uint64(ind))
+			storable, err := array.Remove(ind)
 			require.NoError(b, err)
 			totalRawDataSize -= storable.ByteSize()
 		case 1: // insert
@@ -230,7 +230,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOp
 
 			totalRawDataSize += storable.ByteSize()
 
-			err = array.Insert(uint64(ind), v)
+			err = array.Insert(ind, v)
 			require.NoError(b, err)
 		}
 	}

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -73,7 +73,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
 	// setup
 	for range initialArrayCount {
-		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		v := randomValue(r, atree.MaxInlineArrayElementSize())
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
 		totalRawDataSize += storable.ByteSize()
@@ -91,7 +91,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 	array, err = atree.NewArrayWithRootID(storage, arrayID)
 	require.NoError(b, err)
 	for range numberOfElements {
-		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -127,7 +127,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
 	for range numberOfElements {
 		ind := r.Intn(int(array.Count()))
-		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -201,7 +201,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOp
 
 	// setup
 	for range initialArrayCount {
-		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -223,7 +223,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOp
 			require.NoError(b, err)
 			totalRawDataSize -= storable.ByteSize()
 		case 1: // insert
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 			require.NoError(b, err)

--- a/array_benchmark_test.go
+++ b/array_benchmark_test.go
@@ -19,7 +19,6 @@
 package atree_test
 
 import (
-	"math/rand"
 	"testing"
 	"time"
 
@@ -50,22 +49,6 @@ func BenchmarkXXLArray(b *testing.B) { benchmarkArray(b, 10_000_000, opCount) }
 
 func BenchmarkXXXLArray(b *testing.B) { benchmarkArray(b, 100_000_000, opCount) }
 
-// TODO add nested arrays as class 5
-func RandomValue(r *rand.Rand) atree.Value {
-	switch r.Intn(4) {
-	case 0:
-		return test_utils.Uint8Value(r.Intn(255))
-	case 1:
-		return test_utils.Uint16Value(r.Intn(6535))
-	case 2:
-		return test_utils.Uint32Value(r.Intn(4294967295))
-	case 3:
-		return test_utils.Uint64Value(r.Intn(1844674407370955161))
-	default:
-		return test_utils.Uint8Value(r.Intn(255))
-	}
-}
-
 // BenchmarkArray benchmarks the performance of the atree array
 func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
@@ -90,7 +73,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
 	// setup
 	for range initialArrayCount {
-		v := RandomValue(r)
+		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
 		totalRawDataSize += storable.ByteSize()
@@ -108,7 +91,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 	array, err = atree.NewArrayWithRootID(storage, arrayID)
 	require.NoError(b, err)
 	for range numberOfElements {
-		v := RandomValue(r)
+		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -144,7 +127,7 @@ func benchmarkArray(b *testing.B, initialArrayCount, numberOfElements int) {
 
 	for range numberOfElements {
 		ind := r.Intn(int(array.Count()))
-		v := RandomValue(r)
+		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -218,7 +201,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOp
 
 	// setup
 	for range initialArrayCount {
-		v := RandomValue(r)
+		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 
 		storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 		require.NoError(b, err)
@@ -240,7 +223,7 @@ func benchmarkLongTermImpactOnMemory(b *testing.B, initialArrayCount, numberOfOp
 			require.NoError(b, err)
 			totalRawDataSize -= storable.ByteSize()
 		case 1: // insert
-			v := RandomValue(r)
+			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
 
 			storable, err := v.Storable(storage, array.Address(), atree.MaxInlineArrayElementSize())
 			require.NoError(b, err)

--- a/array_test.go
+++ b/array_test.go
@@ -2463,7 +2463,7 @@ func TestArraySetRandomValues(t *testing.T) {
 
 	for i := range expectedValues {
 		oldValue := expectedValues[i]
-		newValue := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		newValue := randomValue(r, atree.MaxInlineArrayElementSize())
 		expectedValues[i] = newValue
 
 		existingStorable, err := array.Set(uint64(i), newValue)
@@ -2497,7 +2497,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := len(expectedValues) - 1; i >= 0; i-- {
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			expectedValues[i] = v
 
 			err := array.Insert(0, v)
@@ -2522,7 +2522,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			expectedValues[i] = v
 
 			err := array.Insert(uint64(i), v)
@@ -2548,7 +2548,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range arrayCount {
 			k := r.Intn(i + 1)
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			copy(expectedValues[k+1:], expectedValues[k:])
 			expectedValues[k] = v
@@ -2580,7 +2580,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 	expectedValues := make([]atree.Value, arrayCount)
 	// Insert n random values into array
 	for i := range expectedValues {
-		v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+		v := randomValue(r, atree.MaxInlineArrayElementSize())
 		expectedValues[i] = v
 
 		err := array.Insert(uint64(i), v)
@@ -2647,7 +2647,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 		switch nextOp {
 
 		case ArrayAppendOp:
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			expectedValues = append(expectedValues, v)
 
 			err := array.Append(v)
@@ -2655,7 +2655,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 
 		case ArraySetOp:
 			k := r.Intn(int(array.Count()))
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			oldV := expectedValues[k]
 
@@ -2675,7 +2675,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 
 		case ArrayInsertOp:
 			k := r.Intn(int(array.Count() + 1))
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			if k == int(array.Count()) {
 				expectedValues = append(expectedValues, v)
@@ -4896,7 +4896,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := randomValue(r, int(atree.MaxInlineArrayElementSize()))
+			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			expectedValues[i] = v
 
 			err := array.Append(v)

--- a/array_test.go
+++ b/array_test.go
@@ -96,7 +96,7 @@ func _testArray(
 
 	// Verify array elements
 	for i, expected := range expectedValues {
-		actual, err := array.Get(uint64(i))
+		actual, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 
 		testValueEqual(t, expected, actual)
@@ -165,7 +165,7 @@ func _testArray(
 
 	// Verify decoded array elements
 	for i, expected := range expectedValues {
-		actual, err := decodedArray.Get(uint64(i))
+		actual, err := decodedArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 
 		testValueEqual(t, expected, actual)
@@ -178,7 +178,7 @@ func _testArray(
 
 		stats, err := atree.GetArrayStats(array)
 		require.NoError(t, err)
-		require.Equal(t, stats.SlabCount(), uint64(storage.Count()))
+		require.Equal(t, stats.SlabCount(), uint64(storage.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		if len(expectedValues) == 0 {
 			// Verify slab count for empty array
@@ -197,7 +197,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 	atree.SetThreshold(256)
 	defer atree.SetThreshold(1024)
 
-	const arrayCount = 4096
+	const arrayCount = uint64(4096)
 
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 	storage := newTestPersistentStorage(t)
@@ -208,7 +208,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 
 	expectedValues := make([]atree.Value, arrayCount)
 	for i := range expectedValues {
-		v := test_utils.Uint64Value(i)
+		v := test_utils.NewUint64ValueFromInteger(i)
 		expectedValues[i] = v
 		err := array.Append(v)
 		require.NoError(t, err)
@@ -230,7 +230,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 func TestArraySetAndGet(t *testing.T) {
 
 	t.Run("new elements with similar bytesize", func(t *testing.T) {
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -241,7 +241,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -251,10 +251,10 @@ func TestArraySetAndGet(t *testing.T) {
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
-			newValue := test_utils.Uint64Value(i * 10)
+			newValue := test_utils.NewUint64ValueFromInteger(i * 10)
 			expectedValues[i] = newValue
 
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -273,7 +273,7 @@ func TestArraySetAndGet(t *testing.T) {
 		// When elements are overwritten with values from math.MaxUint64-49 to math.MaxUint64,
 		// array tree is 2 levels, with 1 metadata slab, and 2 data slabs.
 
-		const arrayCount = 50
+		const arrayCount = uint64(50)
 
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
@@ -287,7 +287,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -297,10 +297,10 @@ func TestArraySetAndGet(t *testing.T) {
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
-			newValue := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1)
+			newValue := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			expectedValues[i] = newValue
 
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -320,7 +320,7 @@ func TestArraySetAndGet(t *testing.T) {
 		// When elements are overwritten with values from 0-49,
 		// array tree will be 1 level, with 0 metadata slab, and 1 data slab (root).
 
-		const arrayCount = 50
+		const arrayCount = uint64(50)
 
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
@@ -334,7 +334,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1)
+			v := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -344,10 +344,10 @@ func TestArraySetAndGet(t *testing.T) {
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
-			newValue := test_utils.Uint64Value(i)
+			newValue := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = newValue
 
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -360,7 +360,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 	t.Run("index out of bounds", func(t *testing.T) {
 
-		const arrayCount = 1024
+		const arrayCount = uint64(1024)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -371,7 +371,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -401,7 +401,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("insert-first", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -412,7 +412,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := len(expectedValues) - 1; i >= 0; i-- {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Insert(0, v)
 			require.NoError(t, err)
@@ -423,7 +423,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("insert-last", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -434,7 +434,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Insert(array.Count(), v)
 			require.NoError(t, err)
@@ -445,7 +445,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("insert", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -478,7 +478,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 	t.Run("index out of bounds", func(t *testing.T) {
 
-		const arrayCount = 1024
+		const arrayCount = uint64(1024)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -489,7 +489,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -517,7 +517,7 @@ func TestArrayRemove(t *testing.T) {
 
 	t.Run("remove-first", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -528,7 +528,7 @@ func TestArrayRemove(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -536,7 +536,7 @@ func TestArrayRemove(t *testing.T) {
 
 		require.True(t, test_utils.CompareTypeInfo(typeInfo, array.Type()))
 		require.Equal(t, address, array.Address())
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		remainingArrayCount := uint64(len(expectedValues))
 
@@ -568,7 +568,7 @@ func TestArrayRemove(t *testing.T) {
 
 	t.Run("remove-last", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -579,7 +579,7 @@ func TestArrayRemove(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -587,7 +587,7 @@ func TestArrayRemove(t *testing.T) {
 
 		require.True(t, test_utils.CompareTypeInfo(typeInfo, array.Type()))
 		require.Equal(t, address, array.Address())
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		for i := len(expectedValues) - 1; i >= 0; i-- {
 			existingStorable, err := array.Remove(uint64(i))
@@ -603,7 +603,7 @@ func TestArrayRemove(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, uint64(i), array.Count())
+			require.Equal(t, uint64(i), array.Count()) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			if i%256 == 0 {
 				testArray(t, storage, typeInfo, address, array, expectedValues[:i], false)
@@ -615,7 +615,7 @@ func TestArrayRemove(t *testing.T) {
 
 	t.Run("remove", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -626,7 +626,7 @@ func TestArrayRemove(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -634,13 +634,13 @@ func TestArrayRemove(t *testing.T) {
 
 		require.True(t, test_utils.CompareTypeInfo(typeInfo, array.Type()))
 		require.Equal(t, address, array.Address())
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		// Remove every other elements
 		for i := range arrayCount / 2 {
 			v := expectedValues[i]
 
-			existingStorable, err := array.Remove(uint64(i))
+			existingStorable, err := array.Remove(i)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(array.Storage)
@@ -663,14 +663,14 @@ func TestArrayRemove(t *testing.T) {
 			}
 		}
 
-		require.Equal(t, arrayCount/2, len(expectedValues))
+		require.Equal(t, arrayCount/2, uint64(len(expectedValues)))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
 
 	t.Run("index out of bounds", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -681,7 +681,7 @@ func TestArrayRemove(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -724,7 +724,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -745,14 +745,14 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arrayCount), i)
+		require.Equal(t, arrayCount, i)
 	})
 
 	t.Run("set", func(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -767,7 +767,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		}
 
 		for i := range arrayCount {
-			existingStorable, err := array.Set(uint64(i), test_utils.Uint64Value(i))
+			existingStorable, err := array.Set(i, test_utils.Uint64Value(i))
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -782,14 +782,14 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arrayCount), i)
+		require.Equal(t, arrayCount, i)
 	})
 
 	t.Run("insert", func(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -815,14 +815,14 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arrayCount), i)
+		require.Equal(t, arrayCount, i)
 	})
 
 	t.Run("remove", func(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -852,7 +852,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(arrayCount/2), i)
+		require.Equal(t, arrayCount/2, i)
 	})
 
 	t.Run("stop", func(t *testing.T) {
@@ -864,13 +864,13 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			err := array.Append(test_utils.Uint64Value(i))
 			require.NoError(t, err)
 		}
 
-		i := 0
+		i := uint64(0)
 		err = array.IterateReadOnly(func(_ atree.Value) (bool, error) {
 			if i == arrayCount/2 {
 				return false, nil
@@ -891,7 +891,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			err := array.Append(test_utils.Uint64Value(i))
 			require.NoError(t, err)
@@ -899,7 +899,7 @@ func TestReadOnlyArrayIterate(t *testing.T) {
 
 		testErr := errors.New("test")
 
-		i := 0
+		i := uint64(0)
 		err = array.IterateReadOnly(func(_ atree.Value) (bool, error) {
 			if i == arrayCount/2 {
 				return false, testErr
@@ -1015,7 +1015,7 @@ func TestMutateElementFromReadOnlyArrayIterator(t *testing.T) {
 		require.True(t, childArray.Inlined())
 
 		// Inserting elements into childArray so it can't be inlined
-		for i := 0; childArray.Inlined(); i++ {
+		for i := uint64(0); childArray.Inlined(); i++ {
 			v := test_utils.Uint64Value(i)
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -1058,7 +1058,7 @@ func TestMutateElementFromReadOnlyArrayIterator(t *testing.T) {
 		require.True(t, childArray.Inlined())
 
 		// Inserting elements into childArray so it can't be inlined
-		for i := 0; childArray.Inlined(); i++ {
+		for i := uint64(0); childArray.Inlined(); i++ {
 			v := test_utils.Uint64Value(i)
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -1112,7 +1112,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 15
+		const arrayCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1123,7 +1123,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			err = array.Append(v)
 			require.NoError(t, err)
 
@@ -1131,13 +1131,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			require.Equal(t, test_utils.Uint64Value(i), v)
 
 			// Mutate primitive array elements by overwritting existing elements of similar byte size.
 			newValue := test_utils.Uint64Value(i * 2)
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(i, newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -1161,7 +1161,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 1024
+		const arrayCount = uint64(1024)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1172,7 +1172,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			err = array.Append(v)
 			require.NoError(t, err)
 
@@ -1180,13 +1180,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			require.Equal(t, test_utils.Uint64Value(i), v)
 
 			// Mutate primitive array elements by overwritting existing elements with elements of similar size.
 			newValue := test_utils.Uint64Value(i * 2)
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(i, newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -1210,7 +1210,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 15
+		const arrayCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1231,7 +1231,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		r = rune('a')
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			require.Equal(t, test_utils.NewStringValue(string(r)), v)
@@ -1239,7 +1239,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			// Mutate primitive array elements by overwritting existing elements with larger elements.
 			// Larger elements causes slabs to split.
 			newValue := test_utils.NewStringValue(strings.Repeat(string(r), 25))
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(i, newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -1264,7 +1264,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 200
+		const arrayCount = uint64(200)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1285,7 +1285,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		r = rune('a')
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			require.Equal(t, test_utils.NewStringValue(string(r)), v)
@@ -1293,7 +1293,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			// Mutate primitive array elements by overwritting existing elements with larger elements.
 			// Larger elements causes slabs to split.
 			newValue := test_utils.NewStringValue(strings.Repeat(string(r), 25))
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(i, newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -1318,7 +1318,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 80
+		const arrayCount = uint64(80)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1339,7 +1339,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		r = rune('a')
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			require.Equal(t, test_utils.NewStringValue(strings.Repeat(string(r), 25)), v)
@@ -1347,7 +1347,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			// Mutate primitive array elements by overwritting existing elements with smaller elements.
 			// Smaller elements causes slabs to merge.
 			newValue := test_utils.NewStringValue(string(r))
-			existingStorable, err := array.Set(uint64(i), newValue)
+			existingStorable, err := array.Set(i, newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -1372,7 +1372,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 15
+		const arrayCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1386,7 +1386,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			childArray, err := atree.NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			err = childArray.Append(v)
 			require.NoError(t, err)
 
@@ -1397,7 +1397,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
@@ -1432,7 +1432,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 25
+		const arrayCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -1446,7 +1446,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			childArray, err := atree.NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			err = childArray.Append(v)
 			require.NoError(t, err)
 
@@ -1457,7 +1457,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
@@ -1493,9 +1493,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 15
-			childArrayCount        = 1
-			mutatedChildArrayCount = 4
+			arrayCount             = uint64(15)
+			childArrayCount        = uint64(1)
+			mutatedChildArrayCount = uint64(4)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1512,7 +1512,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.NewUint64ValueFromInteger(j + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1526,11 +1526,11 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
@@ -1546,7 +1546,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, newElement)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1567,9 +1567,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 25
-			childArrayCount        = 1
-			mutatedChildArrayCount = 4
+			arrayCount             = uint64(25)
+			childArrayCount        = uint64(1)
+			mutatedChildArrayCount = uint64(4)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1586,7 +1586,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.NewUint64ValueFromInteger(j + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1600,11 +1600,11 @@ func TestMutableArrayIterate(t *testing.T) {
 		}
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
@@ -1620,7 +1620,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, newElement)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1641,9 +1641,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 10
-			childArrayCount        = 10
-			mutatedChildArrayCount = 1
+			arrayCount             = uint64(10)
+			childArrayCount        = uint64(10)
+			mutatedChildArrayCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1660,7 +1660,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.Uint64Value(uint64(j) + i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1675,18 +1675,18 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
 			require.True(t, ok)
 
 			for j := childArrayCount - 1; j > mutatedChildArrayCount-1; j-- {
-				existingStorble, err := childArray.Remove(uint64(j))
+				existingStorble, err := childArray.Remove(j)
 				require.NoError(t, err)
 
 				existingValue, err := existingStorble.StoredValue(storage)
@@ -1694,7 +1694,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				require.Equal(t, test_utils.Uint64Value(i+j), existingValue)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues[:mutatedChildArrayCount]
@@ -1715,9 +1715,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 2
-			childArrayCount        = 1
-			mutatedChildArrayCount = 50
+			arrayCount             = uint64(2)
+			childArrayCount        = uint64(1)
+			mutatedChildArrayCount = uint64(50)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1734,7 +1734,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.NewUint64ValueFromInteger(j + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1749,11 +1749,11 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
@@ -1768,7 +1768,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, v)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1790,9 +1790,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 10
-			childArrayCount        = 10
-			mutatedChildArrayCount = 50
+			arrayCount             = uint64(10)
+			childArrayCount        = uint64(10)
+			mutatedChildArrayCount = uint64(50)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1810,7 +1810,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.NewUint64ValueFromInteger(j + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1825,11 +1825,11 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.False(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
@@ -1844,7 +1844,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				expectedChildArrayValues = append(expectedChildArrayValues, v)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues
@@ -1865,9 +1865,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 2
-			childArrayCount        = 50
-			mutatedChildArrayCount = 1
+			arrayCount             = uint64(2)
+			childArrayCount        = uint64(50)
+			mutatedChildArrayCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1885,7 +1885,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.NewUint64ValueFromInteger(j + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1900,18 +1900,18 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
 			require.True(t, ok)
 
 			for j := childArrayCount - 1; j > mutatedChildArrayCount-1; j-- {
-				existingStorable, err := childArray.Remove(uint64(j))
+				existingStorable, err := childArray.Remove(j)
 				require.NoError(t, err)
 
 				value, err := existingStorable.StoredValue(storage)
@@ -1919,7 +1919,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				require.Equal(t, test_utils.Uint64Value(i+j), value)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues[:1]
@@ -1941,9 +1941,9 @@ func TestMutableArrayIterate(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			arrayCount             = 4
-			childArrayCount        = 50
-			mutatedChildArrayCount = 25
+			arrayCount             = uint64(4)
+			childArrayCount        = uint64(50)
+			mutatedChildArrayCount = uint64(25)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -1961,7 +1961,7 @@ func TestMutableArrayIterate(t *testing.T) {
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(j + i)
+				v := test_utils.NewUint64ValueFromInteger(j + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -1976,18 +1976,18 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.True(t, IsArrayRootDataSlab(array))
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(v atree.Value) (bool, error) {
 			childArray, ok := v.(*atree.Array)
 			require.True(t, ok)
-			require.Equal(t, uint64(childArrayCount), childArray.Count())
+			require.Equal(t, childArrayCount, childArray.Count())
 			require.False(t, childArray.Inlined())
 
 			expectedChildArrayValues, ok := expectedValues[i].(test_utils.ExpectedArrayValue)
 			require.True(t, ok)
 
 			for j := childArrayCount - 1; j >= mutatedChildArrayCount; j-- {
-				existingStorable, err := childArray.Remove(uint64(j))
+				existingStorable, err := childArray.Remove(j)
 				require.NoError(t, err)
 
 				value, err := existingStorable.StoredValue(storage)
@@ -1995,7 +1995,7 @@ func TestMutableArrayIterate(t *testing.T) {
 				require.Equal(t, test_utils.Uint64Value(i+j), value)
 			}
 
-			require.Equal(t, uint64(mutatedChildArrayCount), childArray.Count())
+			require.Equal(t, mutatedChildArrayCount, childArray.Count())
 			require.True(t, childArray.Inlined())
 
 			expectedValues[i] = expectedChildArrayValues[:mutatedChildArrayCount]
@@ -2021,13 +2021,13 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			err := array.Append(test_utils.Uint64Value(i))
 			require.NoError(t, err)
 		}
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(_ atree.Value) (bool, error) {
 			if i == arrayCount/2 {
 				return false, nil
@@ -2048,7 +2048,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			err := array.Append(test_utils.Uint64Value(i))
 			require.NoError(t, err)
@@ -2056,7 +2056,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		testErr := errors.New("test")
 
-		i := 0
+		i := uint64(0)
 		err = array.Iterate(func(_ atree.Value) (bool, error) {
 			if i == arrayCount/2 {
 				return false, testErr
@@ -2124,7 +2124,7 @@ func testArrayIterateRange(t *testing.T, array *atree.Array, expectedValues test
 		for endIndex := startIndex; endIndex <= count; endIndex++ {
 			i = uint64(0)
 			err = array.IterateReadOnlyRange(startIndex, endIndex, func(v atree.Value) (bool, error) {
-				testValueEqual(t, v, expectedValues[int(startIndex+i)])
+				testValueEqual(t, v, expectedValues[startIndex+i])
 				i++
 				return true, nil
 			})
@@ -2148,7 +2148,7 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 	})
 
 	t.Run("dataslab as root", func(t *testing.T) {
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 
 		storage := newTestPersistentStorage(t)
 
@@ -2157,7 +2157,7 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			value := test_utils.Uint64Value(i)
+			value := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = value
 			err := array.Append(value)
 			require.NoError(t, err)
@@ -2170,7 +2170,7 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 1024
+		const arrayCount = uint64(1024)
 
 		storage := newTestPersistentStorage(t)
 
@@ -2179,7 +2179,7 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			value := test_utils.Uint64Value(i)
+			value := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = value
 			err := array.Append(value)
 			require.NoError(t, err)
@@ -2189,7 +2189,7 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 
 		storage := newTestPersistentStorage(t)
 
@@ -2222,7 +2222,7 @@ func TestReadOnlyArrayIterateRange(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			err := array.Append(test_utils.Uint64Value(i))
 			require.NoError(t, err)
@@ -2274,7 +2274,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 15
+		const arrayCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -2288,7 +2288,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 			childArray, err := atree.NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			err = childArray.Append(v)
 			require.NoError(t, err)
 
@@ -2301,7 +2301,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 
 		sizeBeforeMutation := GetArrayRootSlabByteSize(array)
 
-		i := 0
+		i := uint64(0)
 		startIndex := uint64(1)
 		endIndex := array.Count() - 2
 		newElement := test_utils.Uint64Value(0)
@@ -2314,7 +2314,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 			err := childArray.Append(newElement)
 			require.NoError(t, err)
 
-			index := int(startIndex) + i
+			index := startIndex + i
 			expectedChildArrayValues, ok := expectedValues[index].(test_utils.ExpectedArrayValue)
 			require.True(t, ok)
 
@@ -2323,19 +2323,19 @@ func TestMutableArrayIterateRange(t *testing.T) {
 
 			i++
 
-			require.Equal(t, GetArrayRootSlabByteSize(array), sizeBeforeMutation+uint32(i)*newElement.ByteSize())
+			require.Equal(t, GetArrayRootSlabByteSize(array), sizeBeforeMutation+uint32(i)*newElement.ByteSize()) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, endIndex-startIndex, uint64(i))
+		require.Equal(t, endIndex-startIndex, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
 		testArray(t, storage, typeInfo, address, array, expectedValues, false)
 	})
 
 	t.Run("stop", func(t *testing.T) {
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 
 		storage := newTestPersistentStorage(t)
 
@@ -2368,7 +2368,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			err := array.Append(test_utils.Uint64Value(i))
 			require.NoError(t, err)
@@ -2400,7 +2400,7 @@ func TestArrayRootSlabID(t *testing.T) {
 	atree.SetThreshold(256)
 	defer atree.SetThreshold(1024)
 
-	const arrayCount = 4096
+	const arrayCount = uint64(4096)
 
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 	storage := newTestPersistentStorage(t)
@@ -2421,7 +2421,7 @@ func TestArrayRootSlabID(t *testing.T) {
 
 	require.True(t, test_utils.CompareTypeInfo(typeInfo, array.Type()))
 	require.Equal(t, address, array.Address())
-	require.Equal(t, uint64(arrayCount), array.Count())
+	require.Equal(t, arrayCount, array.Count())
 
 	// Remove elements
 	for i := range arrayCount {
@@ -2442,7 +2442,7 @@ func TestArraySetRandomValues(t *testing.T) {
 	atree.SetThreshold(256)
 	defer atree.SetThreshold(1024)
 
-	const arrayCount = 4096
+	const arrayCount = uint64(4096)
 
 	r := newRand(t)
 
@@ -2455,7 +2455,7 @@ func TestArraySetRandomValues(t *testing.T) {
 
 	expectedValues := make([]atree.Value, arrayCount)
 	for i := range expectedValues {
-		v := test_utils.Uint64Value(i)
+		v := test_utils.NewUint64ValueFromInteger(i)
 		expectedValues[i] = v
 		err := array.Append(v)
 		require.NoError(t, err)
@@ -2466,7 +2466,7 @@ func TestArraySetRandomValues(t *testing.T) {
 		newValue := randomValue(r, atree.MaxInlineArrayElementSize())
 		expectedValues[i] = newValue
 
-		existingStorable, err := array.Set(uint64(i), newValue)
+		existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 
 		existingValue, err := existingStorable.StoredValue(storage)
@@ -2484,7 +2484,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 	t.Run("insert-first", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		r := newRand(t)
 
@@ -2509,7 +2509,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 	t.Run("insert-last", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		r := newRand(t)
 
@@ -2525,7 +2525,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			expectedValues[i] = v
 
-			err := array.Insert(uint64(i), v)
+			err := array.Insert(uint64(i), v) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 		}
 
@@ -2534,7 +2534,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 	t.Run("insert-random", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		r := newRand(t)
 
@@ -2547,13 +2547,13 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range arrayCount {
-			k := r.Intn(i + 1)
+			k := r.Intn(int(i + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			copy(expectedValues[k+1:], expectedValues[k:])
 			expectedValues[k] = v
 
-			err := array.Insert(uint64(k), v)
+			err := array.Insert(uint64(k), v) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 		}
 
@@ -2566,7 +2566,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 	atree.SetThreshold(256)
 	defer atree.SetThreshold(1024)
 
-	const arrayCount = 4096
+	const arrayCount = uint64(4096)
 
 	r := newRand(t)
 
@@ -2583,7 +2583,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 		v := randomValue(r, atree.MaxInlineArrayElementSize())
 		expectedValues[i] = v
 
-		err := array.Insert(uint64(i), v)
+		err := array.Insert(uint64(i), v) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 	}
 
@@ -2674,10 +2674,10 @@ func testArrayAppendSetInsertRemoveRandomValues(
 			}
 
 		case ArrayInsertOp:
-			k := r.Intn(int(array.Count() + 1))
+			k := getRandomUint64InRange(r, 0, array.Count()+1)
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
-			if k == int(array.Count()) {
+			if k == array.Count() {
 				expectedValues = append(expectedValues, v)
 			} else {
 				expectedValues = append(expectedValues, nil)
@@ -2685,7 +2685,7 @@ func testArrayAppendSetInsertRemoveRandomValues(
 				expectedValues[k] = v
 			}
 
-			err := array.Insert(uint64(k), v)
+			err := array.Insert(k, v)
 			require.NoError(t, err)
 
 		case ArrayRemoveOp:
@@ -2739,7 +2739,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("small array", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		childTypeInfo := test_utils.NewSimpleTypeInfo(43)
@@ -2755,7 +2755,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			childArray, err := atree.NewArray(storage, address, childTypeInfo)
 			require.NoError(t, err)
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -2775,7 +2775,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("big array", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 		const childArrayCount = 40
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -2816,7 +2816,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("small map", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		childArayTypeInfo := test_utils.NewSimpleTypeInfo(43)
@@ -2831,8 +2831,8 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			childMap, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), childArayTypeInfo)
 			require.NoError(t, err)
 
-			k := test_utils.Uint64Value(i)
-			v := test_utils.Uint64Value(i * 2)
+			k := test_utils.NewUint64ValueFromInteger(i)
+			v := test_utils.NewUint64ValueFromInteger(i * 2)
 			storable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 			require.NoError(t, err)
 			require.Nil(t, storable)
@@ -2850,7 +2850,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 
 	t.Run("big map", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		nestedTypeInfo := test_utils.NewSimpleTypeInfo(43)
@@ -2866,7 +2866,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			childMap, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), nestedTypeInfo)
 			require.NoError(t, err)
 
-			const childMapCount = 25
+			const childMapCount = uint64(25)
 			expectedChildMapValues := test_utils.ExpectedMapValue{}
 			for j := range childMapCount {
 				k := test_utils.Uint64Value(j)
@@ -2992,7 +2992,7 @@ func TestArrayDecodeV0(t *testing.T) {
 		arrayDataSlabID2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 3})
 		childArraySlabID := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 4})
 
-		const arrayCount = 20
+		const arrayCount = uint64(20)
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
 			var v atree.Value
@@ -3211,7 +3211,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 18
+		const arrayCount = uint64(18)
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
 			v := test_utils.NewStringValue(strings.Repeat("a", 22))
@@ -3325,10 +3325,10 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			childArray, err := atree.NewArray(storage, address, childTypeInfo)
 			require.NoError(t, err)
@@ -3405,10 +3405,10 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			var ti atree.TypeInfo
 			if i == 0 {
@@ -3494,10 +3494,10 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			gchildArray, err := atree.NewArray(storage, address, typeInfo2)
 			require.NoError(t, err)
@@ -3587,10 +3587,10 @@ func TestArrayEncodeDecode(t *testing.T) {
 		parentArray, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			var ti atree.TypeInfo
 			if i == 0 {
@@ -3698,7 +3698,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 20
+		const arrayCount = uint64(20)
 		expectedValues := make([]atree.Value, 0, arrayCount)
 		for range arrayCount - 2 {
 			v := test_utils.NewStringValue(strings.Repeat("a", 22))
@@ -3709,7 +3709,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, v)
 		}
 
-		for i := range 2 {
+		for i := range uint64(2) {
 			childArray, err := atree.NewArray(storage, address, typeInfo2)
 			require.NoError(t, err)
 
@@ -3723,7 +3723,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, test_utils.ExpectedArrayValue{v})
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -3842,7 +3842,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 20
+		const arrayCount = uint64(20)
 		expectedValues := make([]atree.Value, 0, arrayCount)
 		for range arrayCount - 2 {
 			v := test_utils.NewStringValue(strings.Repeat("a", 22))
@@ -3853,7 +3853,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, v)
 		}
 
-		for i := range 2 {
+		for i := range uint64(2) {
 			var ti atree.TypeInfo
 			if i == 0 {
 				ti = typeInfo3
@@ -3875,7 +3875,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, test_utils.ExpectedArrayValue{v})
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -3995,7 +3995,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 20
+		const arrayCount = uint64(20)
 		expectedValues := make([]atree.Value, 0, arrayCount)
 		for range arrayCount - 1 {
 			v := test_utils.NewStringValue(strings.Repeat("a", 22))
@@ -4006,7 +4006,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			expectedValues = append(expectedValues, v)
 		}
 
-		const childArrayCount = 5
+		const childArrayCount = uint64(5)
 
 		childArray, err := atree.NewArray(storage, address, typeInfo2)
 		require.NoError(t, err)
@@ -4024,8 +4024,8 @@ func TestArrayEncodeDecode(t *testing.T) {
 
 		expectedValues = append(expectedValues, test_utils.ExpectedArrayValue(expectedChildArrayValues))
 
-		require.Equal(t, uint64(arrayCount), array.Count())
-		require.Equal(t, uint64(childArrayCount), childArray.Count())
+		require.Equal(t, arrayCount, array.Count())
+		require.Equal(t, childArrayCount, childArray.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -4158,7 +4158,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 20
+		const arrayCount = uint64(20)
 		expectedValues := make([]atree.Value, 0, arrayCount)
 		for range arrayCount - 1 {
 			v := test_utils.NewStringValue(strings.Repeat("a", 22))
@@ -4197,7 +4197,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 			test_utils.ExpectedArrayValue(expectedGChildArrayValues),
 		})
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 		require.Equal(t, uint64(1), childArray.Count())
 		require.Equal(t, uint64(5), gchildArray.Count())
 
@@ -4455,11 +4455,11 @@ func TestArrayStringElement(t *testing.T) {
 
 	t.Run("inline", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		r := newRand(t)
 
-		stringSize := int(atree.MaxInlineArrayElementSize() - 3)
+		stringSize := int(atree.MaxInlineArrayElementSize() - 3) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
@@ -4488,11 +4488,11 @@ func TestArrayStringElement(t *testing.T) {
 
 	t.Run("external slab", func(t *testing.T) {
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		r := newRand(t)
 
-		stringSize := int(atree.MaxInlineArrayElementSize() + 512)
+		stringSize := int(atree.MaxInlineArrayElementSize() + 512) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
@@ -4516,13 +4516,13 @@ func TestArrayStringElement(t *testing.T) {
 
 		stats, err := atree.GetArrayStats(array)
 		require.NoError(t, err)
-		require.Equal(t, uint64(arrayCount), stats.StorableSlabCount)
+		require.Equal(t, arrayCount, stats.StorableSlabCount)
 	})
 }
 
 func TestArrayStoredValue(t *testing.T) {
 
-	const arrayCount = 4096
+	const arrayCount = uint64(4096)
 
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -4533,7 +4533,7 @@ func TestArrayStoredValue(t *testing.T) {
 
 	expectedValues := make([]atree.Value, arrayCount)
 	for i := range expectedValues {
-		v := test_utils.Uint64Value(i)
+		v := test_utils.NewUint64ValueFromInteger(i)
 		expectedValues[i] = v
 		err := array.Append(v)
 		require.NoError(t, err)
@@ -4594,7 +4594,7 @@ func TestArrayPopIterate(t *testing.T) {
 
 	t.Run("root-dataslab", func(t *testing.T) {
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -4605,13 +4605,13 @@ func TestArrayPopIterate(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		i := 0
+		i := uint64(0)
 		err = array.PopIterate(func(v atree.Storable) {
 			vv, err := v.StoredValue(storage)
 			require.NoError(t, err)
@@ -4628,7 +4628,7 @@ func TestArrayPopIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -4639,13 +4639,13 @@ func TestArrayPopIterate(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		i := 0
+		i := uint64(0)
 		err = array.PopIterate(func(v atree.Storable) {
 			vv, err := v.StoredValue(storage)
 			require.NoError(t, err)
@@ -4692,7 +4692,7 @@ func TestArrayFromBatchData(t *testing.T) {
 
 	t.Run("root-dataslab", func(t *testing.T) {
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		array, err := atree.NewArray(
@@ -4703,13 +4703,13 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4735,7 +4735,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -4747,13 +4747,13 @@ func TestArrayFromBatchData(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4778,7 +4778,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 36
+		const arrayCount = uint64(36)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -4791,7 +4791,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		var expectedValues []atree.Value
 		var v atree.Value
 
-		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2)))
+		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		expectedValues = append(expectedValues, v)
 
 		err = array.Insert(0, v)
@@ -4805,7 +4805,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4830,7 +4830,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 36
+		const arrayCount = uint64(36)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -4849,7 +4849,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2)))
+		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		expectedValues = append(expectedValues, nil)
 		copy(expectedValues[25+1:], expectedValues[25:])
 		expectedValues[25] = v
@@ -4857,7 +4857,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		err = array.Insert(25, v)
 		require.NoError(t, err)
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4882,7 +4882,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const arrayCount = 4096
+		const arrayCount = uint64(4096)
 
 		r := newRand(t)
 
@@ -4903,7 +4903,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 
 		iter, err := array.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -4945,17 +4945,17 @@ func TestArrayFromBatchData(t *testing.T) {
 		var expectedValues []atree.Value
 		var v atree.Value
 
-		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2)))
+		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		expectedValues = append(expectedValues, v)
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2)))
+		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		expectedValues = append(expectedValues, v)
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2)))
+		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		expectedValues = append(expectedValues, v)
 		err = array.Append(v)
 		require.NoError(t, err)
@@ -4986,7 +4986,7 @@ func TestArrayNestedStorables(t *testing.T) {
 
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 
-	const arrayCount = 1024 * 4
+	const arrayCount = uint64(1024 * 4)
 
 	storage := newTestPersistentStorage(t)
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -5019,12 +5019,12 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	array, err := atree.NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	const arrayCount = 2
+	const arrayCount = uint64(2)
 
 	expectedValues := make([]atree.Value, arrayCount)
 	for i := range expectedValues {
 		// String length is atree.MaxInlineArrayElementSize - 3 to account for string encoding overhead.
-		v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-3)))
+		v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-3))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		expectedValues[i] = v
 
 		err = array.Append(v)
@@ -5047,7 +5047,7 @@ func TestArrayString(t *testing.T) {
 	defer atree.SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const arrayCount = 6
+		const arrayCount = uint64(6)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5066,7 +5066,7 @@ func TestArrayString(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const arrayCount = 120
+		const arrayCount = uint64(120)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5090,7 +5090,7 @@ func TestArraySlabDump(t *testing.T) {
 	defer atree.SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const arrayCount = 6
+		const arrayCount = uint64(6)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5113,7 +5113,7 @@ func TestArraySlabDump(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const arrayCount = 120
+		const arrayCount = uint64(120)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5147,7 +5147,7 @@ func TestArraySlabDump(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		err = array.Append(test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()))))
+		err = array.Append(test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize())))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 
 		want := []string{
@@ -5214,7 +5214,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
@@ -5229,12 +5229,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 			array, expectedValues, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5245,12 +5245,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 			require.True(t, len(expectedValues) == len(childSlabIDs))
 
@@ -5270,12 +5270,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5296,12 +5296,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5325,12 +5325,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5358,7 +5358,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root data slab with simple and composite values, unload composite element", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
-			const arrayCount = 3
+			const arrayCount = uint64(3)
 
 			// Create an array with nested composite value at specified index
 			for childArrayIndex := range arrayCount {
@@ -5389,7 +5389,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 20
+			const arrayCount = uint64(20)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
@@ -5404,12 +5404,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 20
+			const arrayCount = uint64(20)
 			array, expectedValues, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5420,12 +5420,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 20
+			const arrayCount = uint64(20)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 			require.True(t, len(expectedValues) == len(childSlabIDs))
 
@@ -5445,12 +5445,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 20
+			const arrayCount = uint64(20)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5471,12 +5471,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 20
+			const arrayCount = uint64(20)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, GetDeltasCount(storage))
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5499,7 +5499,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 	runTest("root metadata slab with simple and composite values, unload composite element", func(useWrapperValue bool) func(t *testing.T) {
 		return func(t *testing.T) {
-			const arrayCount = 20
+			const arrayCount = uint64(20)
 
 			// Create an array with composite value at specified index.
 			for childArrayIndex := range arrayCount {
@@ -5530,7 +5530,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 30
+			const arrayCount = uint64(30)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (2 levels): 1 root metadata slab, 3 data slabs
@@ -5564,7 +5564,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 30
+			const arrayCount = uint64(30)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (2 levels): 1 root metadata slab, 3 data slabs
@@ -5598,7 +5598,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 30
+			const arrayCount = uint64(30)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (2 levels): 1 root metadata slab, 3 data slabs
@@ -5637,7 +5637,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 250
+			const arrayCount = uint64(250)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, 2 non-root metadata slabs, n data slabs
@@ -5668,7 +5668,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 		return func(t *testing.T) {
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 250
+			const arrayCount = uint64(250)
 			array, expectedValues := createArrayWithSimpleValues(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, 2 child metadata slabs, n data slabs
@@ -5700,12 +5700,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 500
+			const arrayCount = uint64(500)
 			array, expectedValues, childSlabIDs := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+arrayCount)
+			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5738,12 +5738,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 500
+			const arrayCount = uint64(500)
 			array, expectedValues, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+arrayCount)
+			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5813,12 +5813,12 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			storage := newTestPersistentStorage(t)
 
-			const arrayCount = 500
+			const arrayCount = uint64(500)
 			array, expectedValues, _ := createArrayWithChildArrays(t, storage, address, typeInfo, arrayCount, useWrapperValue)
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, GetDeltasCount(storage) > 1+arrayCount)
+			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5973,7 +5973,7 @@ func createArrayWithSimpleValues(
 	storage atree.SlabStorage,
 	address atree.Address,
 	typeInfo atree.TypeInfo,
-	arrayCount int,
+	arrayCount uint64,
 	useWrapperValue bool,
 ) (*atree.Array, []atree.Value) {
 
@@ -6007,7 +6007,7 @@ func createArrayWithChildArrays(
 	storage atree.SlabStorage,
 	address atree.Address,
 	typeInfo atree.TypeInfo,
-	arrayCount int,
+	arrayCount uint64,
 	useWrapperValue bool,
 ) (*atree.Array, test_utils.ExpectedArrayValue, []atree.SlabID) {
 	const childArrayCount = 50
@@ -6026,7 +6026,7 @@ func createArrayWithChildArrays(
 
 		expectedChildArrayValues := make([]atree.Value, childArrayCount)
 		for j := range expectedChildArrayValues {
-			v := test_utils.Uint64Value(j)
+			v := test_utils.NewUint64ValueFromInteger(j)
 			err = childArray.Append(v)
 			require.NoError(t, err)
 
@@ -6057,8 +6057,8 @@ func createArrayWithSimpleAndChildArrayValues(
 	storage atree.SlabStorage,
 	address atree.Address,
 	typeInfo atree.TypeInfo,
-	arrayCount int,
-	compositeValueIndex int,
+	arrayCount uint64,
+	compositeValueIndex uint64,
 	useWrapperValue bool,
 ) (*atree.Array, []atree.Value, atree.SlabID) {
 	const childArrayCount = 50
@@ -6073,14 +6073,14 @@ func createArrayWithSimpleAndChildArrayValues(
 	r := 'a'
 	for i := range expectedValues {
 
-		if compositeValueIndex == i {
+		if compositeValueIndex == uint64(i) { //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			// Create child array with one element
 			childArray, err := atree.NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
 
 			expectedChildArrayValues := make([]atree.Value, childArrayCount)
 			for j := range expectedChildArrayValues {
-				v := test_utils.Uint64Value(j)
+				v := test_utils.NewUint64ValueFromInteger(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -6193,7 +6193,7 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 		mv := expectedValues[i]
 		mv.UpdateStorableSize(mutatedStorableSize)
 
-		existingStorable, err := array.Set(uint64(i), mv)
+		existingStorable, err := array.Set(uint64(i), mv) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 		require.NotNil(t, existingStorable)
 	}
@@ -6213,7 +6213,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 	defer atree.SetThreshold(1024)
 
 	t.Run("parent is root data slab, with one child array", func(t *testing.T) {
-		const arrayCount = 1
+		const arrayCount = uint64(1)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -6222,8 +6222,8 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Create an array with empty child array as element.
 		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -6255,10 +6255,10 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		vSize := v.ByteSize()
 
 		// Appending 10 elements to child array so that inlined child array reaches max inlined size as array element.
-		for i := range 10 {
+		for i := range uint64(10) {
 			err = childArray.Append(v)
 			require.NoError(t, err)
-			require.Equal(t, uint64(i+1), childArray.Count())
+			require.Equal(t, i+1, childArray.Count())
 
 			expectedChildValues = append(expectedChildValues, v)
 			expectedValues[0] = expectedChildValues
@@ -6269,7 +6269,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, valueID, childArray.ValueID())              // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent slab size
@@ -6277,7 +6277,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6296,14 +6296,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedSlabID, childArray.SlabID()) // Storage ID is the same bytewise as value ID.
 		require.Equal(t, valueID, childArray.ValueID())       // atree.Value ID is unchanged
 
-		expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+		expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 		require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 		expectedParentSize = atree.ComputeArrayRootDataSlabByteSize([]uint32{slabIDStorableByteSize})
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6321,24 +6321,24 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, atree.SlabIDUndefined, childArray.SlabID())
 			require.Equal(t, valueID, childArray.ValueID()) // value ID is unchanged
 
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			expectedParentSize := atree.ComputeArrayRootDataSlabByteSize([]uint32{expectedInlinedSize})
 			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		require.Equal(t, uint64(0), childArray.Count())
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 	})
 
 	t.Run("parent is root data slab, with two child arrays", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -6347,7 +6347,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Create an array with empty child array as element.
 		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
 		// Test parent slab size with 2 empty inlined child arrays
@@ -6360,7 +6360,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6370,7 +6370,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i))
+			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -6391,14 +6391,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		vSize := v.ByteSize()
 
 		// Appending 10 elements to child array so that inlined child array reaches max inlined size as array element.
-		for i := range 10 {
+		for i := range uint64(10) {
 			for j, child := range children {
 				childArray := child.array
 				childValueID := child.valueID
 
 				err := childArray.Append(v)
 				require.NoError(t, err)
-				require.Equal(t, uint64(i+1), childArray.Count())
+				require.Equal(t, i+1, childArray.Count())
 
 				expectedChildValues, ok := expectedValues[j].(test_utils.ExpectedArrayValue)
 				require.True(t, ok)
@@ -6412,7 +6412,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 				// Test inlined child slab size
-				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent slab size
@@ -6420,7 +6420,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, atree.ComputeArrayRootDataSlabByteSize(storableByteSizes), GetArrayRootSlabByteSize(parentArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6450,14 +6450,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedSlabID, childArray.SlabID()) // Storage ID is the same bytewise as value ID.
 			require.Equal(t, childValueID, childArray.ValueID())  // atree.Value ID is unchanged
 
-			expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			storableByteSizes[i] = slabIDStorableByteSize
 			require.Equal(t, atree.ComputeArrayRootDataSlabByteSize(storableByteSizes), GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6485,14 +6485,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, atree.SlabIDUndefined, childArray.SlabID())
 			require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			storableByteSizes[i] = expectedInlinedSize
 			require.Equal(t, atree.ComputeArrayRootDataSlabByteSize(storableByteSizes), GetArrayRootSlabByteSize(parentArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6519,14 +6519,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, atree.SlabIDUndefined, childArray.SlabID())
 				require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
-				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				storableByteSizes[j] = expectedInlinedSize
 				require.Equal(t, atree.ComputeArrayRootDataSlabByteSize(storableByteSizes), GetArrayRootSlabByteSize(parentArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6535,11 +6535,11 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		for _, child := range children {
 			require.Equal(t, uint64(0), child.array.Count())
 		}
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 	})
 
 	t.Run("parent is root metadata slab, with four child arrays", func(t *testing.T) {
-		const arrayCount = 4
+		const arrayCount = uint64(4)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -6548,7 +6548,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Create an array with empty child array as element.
 		parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -6558,7 +6558,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6568,7 +6568,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i))
+			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -6589,14 +6589,14 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		vSize := v.ByteSize()
 
 		// Appending 10 elements to child array so that inlined child array reaches max inlined size as array element.
-		for i := range 10 {
+		for i := range uint64(10) {
 			for j, child := range children {
 				childArray := child.array
 				childValueID := child.valueID
 
 				err := childArray.Append(v)
 				require.NoError(t, err)
-				require.Equal(t, uint64(i+1), childArray.Count())
+				require.Equal(t, i+1, childArray.Count())
 
 				expectedChildValues, ok := expectedValues[j].(test_utils.ExpectedArrayValue)
 				require.True(t, ok)
@@ -6609,11 +6609,11 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 				// Test inlined child slab size
-				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6643,17 +6643,17 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedSlabID, childArray.SlabID()) // Storage ID is the same bytewise as value ID.
 			require.Equal(t, childValueID, childArray.ValueID())  // atree.Value ID is unchanged
 
-			expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		// Parent array has one data slab and all child arrays are not inlined.
-		require.Equal(t, 1+arrayCount, getStoredDeltas(storage))
+		require.Equal(t, 1+arrayCount, uint64(getStoredDeltas(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove one element from child array which triggers standalone array slab becomes inlined slab again.
@@ -6675,11 +6675,11 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, atree.SlabIDUndefined, childArray.SlabID())
 			require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test parent array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6710,11 +6710,11 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, atree.SlabIDUndefined, childArray.SlabID())
 				require.Equal(t, childValueID, childArray.ValueID()) // value ID is unchanged
 
-				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+				expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 				require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test parent array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -6728,7 +6728,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		for _, child := range children {
 			require.Equal(t, uint64(0), child.array.Count())
 		}
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 	})
 }
 
@@ -6738,7 +6738,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 	defer atree.SetThreshold(1024)
 
 	t.Run("parent is root data slab, one child array, one grand child array, changes to grand child array triggers child array slab to become standalone slab", func(t *testing.T) {
-		const arrayCount = 1
+		const arrayCount = uint64(1)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -6747,7 +6747,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Create an array with empty child array as element, which has empty child array.
 		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -6758,7 +6758,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6795,10 +6795,10 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		vSize := v.ByteSize()
 
 		// Appending 8 elements to grand child array so that inlined grand child array reaches max inlined size as array element.
-		for i := range 8 {
+		for i := range uint64(8) {
 			err = gchildArray.Append(v)
 			require.NoError(t, err)
-			require.Equal(t, uint64(i+1), gchildArray.Count())
+			require.Equal(t, i+1, gchildArray.Count())
 			require.Equal(t, uint64(1), childArray.Count())
 
 			expectedChildValues, ok := expectedValues[0].(test_utils.ExpectedArrayValue)
@@ -6823,7 +6823,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			// Test inlined grand child slab size
 
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
@@ -6835,9 +6835,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -6868,7 +6868,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 		// Test inlined grand child slab size
-		expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+		expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 		require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 		expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSize([]uint32{expectedInlinedGrandChildSize})
@@ -6878,9 +6878,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6911,7 +6911,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID()) // value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
@@ -6923,20 +6923,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		require.Equal(t, uint64(0), gchildArray.Count())
 		require.Equal(t, uint64(1), childArray.Count())
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 	})
 
 	t.Run("parent is root data slab, one child array, one grand child array, changes to grand child array triggers grand child array slab to become standalone slab", func(t *testing.T) {
-		const arrayCount = 1
+		const arrayCount = uint64(1)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -6945,7 +6945,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Create an array with empty child array as element, which has empty child array.
 		parentArray, expectedValues := createArrayWithEmpty2LevelChildArray(t, storage, address, typeInfo, arrayCount)
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -6956,7 +6956,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -6993,10 +6993,10 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		vSize := v.ByteSize()
 
 		// Appending 8 elements to grand child array so that inlined grand child array reaches max inlined size as array element.
-		for i := range 8 {
+		for i := range uint64(8) {
 			err = gchildArray.Append(v)
 			require.NoError(t, err)
-			require.Equal(t, uint64(i+1), gchildArray.Count())
+			require.Equal(t, i+1, gchildArray.Count())
 			require.Equal(t, uint64(1), childArray.Count())
 
 			expectedChildValues, ok := expectedValues[0].(test_utils.ExpectedArrayValue)
@@ -7020,7 +7020,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
@@ -7032,9 +7032,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7067,9 +7067,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, gValueID, gchildArray.ValueID())      // atree.Value ID is unchanged
 
 		// Test inlined grand child slab size
-		storableByteSizes := make([]uint32, int(gchildArray.Count()))
+		storableByteSizes := make([]uint32, int(gchildArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		storableByteSizes[0] = largeValueSize
-		for i := 1; i < int(gchildArray.Count()); i++ {
+		for i := 1; i < len(storableByteSizes); i++ {
 			storableByteSizes[i] = vSize
 		}
 		expectedInlinedGrandChildSize := atree.ComputeArrayRootDataSlabByteSize(storableByteSizes)
@@ -7082,9 +7082,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7114,7 +7114,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID()) // value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
@@ -7126,20 +7126,20 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		require.Equal(t, uint64(0), gchildArray.Count())
 		require.Equal(t, uint64(1), childArray.Count())
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 	})
 
 	t.Run("parent is root data slab, two child array, one grand child array each, changes to child array triggers child array slab to become standalone slab", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -7177,7 +7177,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			expectedValues[i] = test_utils.ExpectedArrayValue{test_utils.ExpectedArrayValue{v}}
 		}
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -7188,7 +7188,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7201,7 +7201,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		children := make([]arrayInfo, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i))
+			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -7236,7 +7236,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		// Appending 7 elements to child array so that inlined child array reaches max inlined size as array element.
-		for i := range 7 {
+		for i := range uint64(7) {
 			for j, child := range children {
 				childArray := child.array
 				valueID := child.valueID
@@ -7245,7 +7245,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				err := childArray.Append(v)
 				require.NoError(t, err)
-				require.Equal(t, uint64(i+2), childArray.Count())
+				require.Equal(t, i+2, childArray.Count())
 
 				expectedChildValues, ok := expectedValues[j].(test_utils.ExpectedArrayValue)
 				require.True(t, ok)
@@ -7270,7 +7270,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined child slab size
 				gchildArraySize := atree.ComputeInlinedArraySlabByteSize([]uint32{vSize})
-				childStorableByteSizes := make([]uint32, int(childArray.Count()))
+				childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				for k := range childStorableByteSizes {
 					var size uint32
 					if k == 0 {
@@ -7288,9 +7288,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7325,21 +7325,21 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
-			childStorableByteSizes := make([]uint32, int(childArray.Count()))
+			childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			childStorableByteSizes[0] = expectedInlinedGrandChildSize
-			for i := 1; i < int(childArray.Count()); i++ {
+			for i := 1; i < len(childStorableByteSizes); i++ {
 				childStorableByteSizes[i] = vSize
 			}
 			expectedStandaloneSlabSize := atree.ComputeArrayRootDataSlabByteSize(childStorableByteSizes)
 			require.Equal(t, expectedStandaloneSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7380,13 +7380,13 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
-			childStorableByteSizes := make([]uint32, int(childArray.Count()))
+			childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			childStorableByteSizes[0] = expectedInlinedGrandChildSize
-			for i := 1; i < int(childArray.Count()); i++ {
+			for i := 1; i < len(childStorableByteSizes); i++ {
 				childStorableByteSizes[i] = vSize
 			}
 			expectedInlinedChildSize := atree.ComputeInlinedArraySlabByteSize(childStorableByteSizes)
@@ -7395,9 +7395,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			storableByteSizes[i] = expectedInlinedChildSize
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7437,13 +7437,13 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, gValueID, gchildArray.ValueID()) // value ID is unchanged
 
 				// Test inlined grand child slab size
-				expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+				expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
-				childStorableByteSizes := make([]uint32, int(childArray.Count()))
+				childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				childStorableByteSizes[0] = expectedInlinedGrandChildSize
-				for i := 1; i < int(childArray.Count()); i++ {
+				for i := 1; i < len(childStorableByteSizes); i++ {
 					childStorableByteSizes[i] = vSize
 				}
 				expectedInlinedChildSize := atree.ComputeInlinedArraySlabByteSize(childStorableByteSizes)
@@ -7454,9 +7454,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7466,11 +7466,11 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, uint64(1), child.child.array.Count())
 			require.Equal(t, uint64(1), child.array.Count())
 		}
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 	})
 
 	t.Run("parent is root metadata slab, with four child arrays, each child array has grand child arrays", func(t *testing.T) {
-		const arrayCount = 4
+		const arrayCount = uint64(4)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -7504,7 +7504,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			expectedValues[i] = test_utils.ExpectedArrayValue{test_utils.ExpectedArrayValue{}}
 		}
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.True(t, IsArrayRootDataSlab(parentArray))
 		require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -7514,7 +7514,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 		// Test parent array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7527,7 +7527,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		children := make([]arrayInfo, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i))
+			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -7562,7 +7562,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		// Appending 6 elements to grand child array so that parent array root slab is metadata slab.
-		for i := range 6 {
+		for i := range uint64(6) {
 			for j, child := range children {
 				childArray := child.array
 				valueID := child.valueID
@@ -7571,7 +7571,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				err := gchildArray.Append(v)
 				require.NoError(t, err)
-				require.Equal(t, uint64(i+1), gchildArray.Count())
+				require.Equal(t, i+1, gchildArray.Count())
 
 				expectedChildValues, ok := expectedValues[j].(test_utils.ExpectedArrayValue)
 				require.True(t, ok)
@@ -7595,7 +7595,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 				// Test inlined grand child slab size
-				expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+				expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
@@ -7603,9 +7603,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7643,16 +7643,16 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			expectedInlinedChildSlabSize := atree.ComputeInlinedArraySlabByteSize([]uint32{expectedInlinedGrandChildSize})
 			require.Equal(t, expectedInlinedChildSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7696,22 +7696,22 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 			// Test standalone grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			expectedStandaloneChildSlabSize := atree.ComputeArrayRootDataSlabByteSize([]uint32{expectedInlinedGrandChildSize})
 			require.Equal(t, expectedStandaloneChildSlabSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
 
 		// Parent array has one root data slab, 4 grand child array with standalone root data slab.
-		require.Equal(t, 1+arrayCount, getStoredDeltas(storage))
+		require.Equal(t, 1+arrayCount, uint64(getStoredDeltas(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove elements from grand child array to trigger child array inlined again.
@@ -7747,7 +7747,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, gValueID, gchildArray.ValueID())             // atree.Value ID is unchanged
 
 			// Test inlined grand child slab size
-			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
@@ -7755,9 +7755,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7801,7 +7801,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, gValueID, gchildArray.ValueID()) // value ID is unchanged
 
 				// Test inlined grand child slab size
-				expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(gchildArray.Count()))
+				expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
@@ -7809,9 +7809,9 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, expectedInlinedChildSize, GetArrayRootSlabByteSize(childArray))
 
 				// Test array's mutableElementIndex
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(gchildArray)) <= gchildArray.Count())
-				require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
+				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 			}
@@ -7821,7 +7821,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, uint64(0), child.child.array.Count())
 			require.Equal(t, uint64(1), child.array.Count())
 		}
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.Equal(t, 1, getStoredDeltas(storage))
 
 		gchildArraySize = emptyInlinedArrayByteSize
@@ -7833,7 +7833,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 
-	const arrayCount = 2
+	const arrayCount = uint64(2)
 
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 	storage := newTestPersistentStorage(t)
@@ -7842,7 +7842,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 	// Create an array with empty child array as element.
 	parentArray, expectedValues := createArrayWithEmptyChildArray(t, storage, address, typeInfo, arrayCount)
 
-	require.Equal(t, uint64(arrayCount), parentArray.Count())
+	require.Equal(t, arrayCount, parentArray.Count())
 	require.True(t, IsArrayRootDataSlab(parentArray))
 	require.Equal(t, 1, getStoredDeltas(storage)) // There is only 1 stored slab because child array is inlined.
 
@@ -7852,7 +7852,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 	require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
 	// Test array's mutableElementIndex
-	require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+	require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 	testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -7863,7 +7863,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 	}, arrayCount)
 
 	for i := range children {
-		e, err := parentArray.Get(uint64(i))
+		e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.NoError(t, err)
 		require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -7899,7 +7899,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			childArray := child.array
 			childValueID := child.valueID
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			vSize := v.ByteSize()
 
 			err := childArray.Append(v)
@@ -7919,12 +7919,12 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7942,7 +7942,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			childArray := child.array
 			childValueID := child.valueID
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			vSize := v.ByteSize()
 
 			err := childArray.Append(v)
@@ -7964,12 +7964,12 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -7986,7 +7986,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			childArray := child.array
 			childValueID := child.valueID
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			vSize := v.ByteSize()
 
 			err := childArray.Append(v)
@@ -8004,12 +8004,12 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -8029,7 +8029,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			childArray := child.array
 			childValueID := child.valueID
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			vSize := v.ByteSize()
 
 			err := childArray.Append(v)
@@ -8049,12 +8049,12 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -8072,7 +8072,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			childArray := child.array
 			childValueID := child.valueID
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			vSize := v.ByteSize()
 
 			err := childArray.Append(v)
@@ -8094,12 +8094,12 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -8116,7 +8116,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			childArray := child.array
 			childValueID := child.valueID
 
-			v := test_utils.Uint64Value(i)
+			v := test_utils.NewUint64ValueFromInteger(i)
 			vSize := v.ByteSize()
 
 			err := childArray.Append(v)
@@ -8134,12 +8134,12 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.Equal(t, childValueID, childArray.ValueID())         // atree.Value ID is unchanged
 
 			// Test inlined child slab size
-			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, int(childArray.Count()))
+			expectedInlinedSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, childArray.Count())
 			require.Equal(t, expectedInlinedSize, GetArrayRootSlabByteSize(childArray))
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(childArray)) <= childArray.Count())
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 		}
@@ -8151,7 +8151,7 @@ func createArrayWithEmptyChildArray(
 	storage atree.SlabStorage,
 	address atree.Address,
 	typeInfo atree.TypeInfo,
-	arrayCount int,
+	arrayCount uint64,
 ) (*atree.Array, []atree.Value) {
 
 	// Create parent array
@@ -8179,7 +8179,7 @@ func createArrayWithEmpty2LevelChildArray(
 	storage atree.SlabStorage,
 	address atree.Address,
 	typeInfo atree.TypeInfo,
-	arrayCount int,
+	arrayCount uint64,
 ) (*atree.Array, []atree.Value) {
 
 	// Create parent array
@@ -8226,7 +8226,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8262,13 +8262,13 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child array value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8286,14 +8286,14 @@ func TestArraySetReturnedValue(t *testing.T) {
 			expectedValues[i] = test_utils.Uint64Value(0)
 
 			// Test array's mutableElementIndex
-			require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 		}
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8322,13 +8322,13 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child array value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8347,13 +8347,13 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8375,11 +8375,9 @@ func TestArraySetReturnedValue(t *testing.T) {
 			expectedValues[i] = expectedChildValues
 
 			// Insert into child map until child map is not inlined
-			j := 0
-			for {
+			for j := uint64(0); ; j++ {
 				k := test_utils.Uint64Value(j)
 				v := test_utils.NewStringValue(strings.Repeat("a", 10))
-				j++
 
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
@@ -8394,13 +8392,13 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child map value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8419,13 +8417,13 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8440,7 +8438,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 			childMap, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
-			k := test_utils.Uint64Value(i)
+			k := test_utils.NewUint64ValueFromInteger(i)
 
 			err = parentArray.Append(childMap)
 			require.NoError(t, err)
@@ -8459,13 +8457,13 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
 		// Overwrite existing child map value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8484,7 +8482,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 	})
@@ -8495,7 +8493,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8531,7 +8529,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8553,13 +8551,13 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, atree.GetArrayMutableElementIndexCount(parentArray))
+		require.Equal(t, uint64(0), atree.GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8588,7 +8586,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8610,13 +8608,13 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, atree.GetArrayMutableElementIndexCount(parentArray))
+		require.Equal(t, uint64(0), atree.GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8638,11 +8636,10 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 			expectedValues[i] = expectedChildValues
 
 			// Insert into child map until child map is not inlined
-			j := 0
-			for {
+
+			for j := uint64(0); ; j++ {
 				k := test_utils.Uint64Value(j)
 				v := test_utils.NewStringValue(strings.Repeat("a", 10))
-				j++
 
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
@@ -8657,7 +8654,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8679,13 +8676,13 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, atree.GetArrayMutableElementIndexCount(parentArray))
+		require.Equal(t, uint64(0), atree.GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const arrayCount = 2
+		const arrayCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -8700,7 +8697,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 			childMap, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 			require.NoError(t, err)
 
-			k := test_utils.Uint64Value(i)
+			k := test_utils.NewUint64ValueFromInteger(i)
 
 			err = parentArray.Append(childMap)
 			require.NoError(t, err)
@@ -8719,7 +8716,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.True(t, uint64(atree.GetArrayMutableElementIndexCount(parentArray)) <= parentArray.Count())
+		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
 		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
 
@@ -8741,7 +8738,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		}
 
 		// Test array's mutableElementIndex
-		require.Equal(t, 0, atree.GetArrayMutableElementIndexCount(parentArray))
+		require.Equal(t, uint64(0), atree.GetArrayMutableElementIndexCount(parentArray))
 
 		testEmptyArray(t, storage, typeInfo, address, parentArray)
 	})
@@ -8895,14 +8892,14 @@ func TestArraySetType(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10
+		const arrayCount = uint64(10)
 		for i := range arrayCount {
 			v := test_utils.Uint64Value(i)
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 		require.Equal(t, typeInfo, array.Type())
 		require.True(t, IsArrayRootDataSlab(array))
 
@@ -8923,14 +8920,14 @@ func TestArraySetType(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10_000
+		const arrayCount = uint64(10_000)
 		for i := range arrayCount {
 			v := test_utils.Uint64Value(i)
 			err := array.Append(v)
 			require.NoError(t, err)
 		}
 
-		require.Equal(t, uint64(arrayCount), array.Count())
+		require.Equal(t, arrayCount, array.Count())
 		require.Equal(t, typeInfo, array.Type())
 		require.False(t, IsArrayRootDataSlab(array))
 
@@ -8984,7 +8981,7 @@ func TestArraySetType(t *testing.T) {
 		parentArray, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		const arrayCount = 10_000
+		const arrayCount = uint64(10_000)
 		for i := range arrayCount - 1 {
 			v := test_utils.Uint64Value(i)
 			err := parentArray.Append(v)
@@ -8997,7 +8994,7 @@ func TestArraySetType(t *testing.T) {
 		err = parentArray.Append(childArray)
 		require.NoError(t, err)
 
-		require.Equal(t, uint64(arrayCount), parentArray.Count())
+		require.Equal(t, arrayCount, parentArray.Count())
 		require.Equal(t, typeInfo, parentArray.Type())
 		require.False(t, IsArrayRootDataSlab(parentArray))
 		require.False(t, parentArray.Inlined())
@@ -9060,7 +9057,7 @@ func testExistingArraySetType(
 func testExistingInlinedArraySetType(
 	t *testing.T,
 	parentID atree.SlabID,
-	inlinedChildIndex int,
+	inlinedChildIndex uint64,
 	baseStorage atree.BaseStorage,
 	expectedTypeInfo test_utils.SimpleTypeInfo,
 	expectedCount uint64,
@@ -9074,7 +9071,7 @@ func testExistingInlinedArraySetType(
 	parentArray, err := atree.NewArrayWithRootID(storage, parentID)
 	require.NoError(t, err)
 
-	element, err := parentArray.Get(uint64(inlinedChildIndex))
+	element, err := parentArray.Get(inlinedChildIndex)
 	require.NoError(t, err)
 
 	childArray, ok := element.(*atree.Array)
@@ -9100,7 +9097,7 @@ func testExistingInlinedArraySetType(
 	parentArray2, err := atree.NewArrayWithRootID(storage2, parentID)
 	require.NoError(t, err)
 
-	element2, err := parentArray2.Get(uint64(inlinedChildIndex))
+	element2, err := parentArray2.Get(inlinedChildIndex)
 	require.NoError(t, err)
 
 	childArray2, ok := element2.(*atree.Array)

--- a/array_test.go
+++ b/array_test.go
@@ -5898,7 +5898,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 					count := slabInfoToBeRemoved.count
 
-					// Update startIndex for subsequence metadata and data slabs.
+					// Update startIndex for subsequent metadata and data slabs.
 					for _, slabInfo := range nonrootMetadataSlabInfos[metadataSlabIndex+1:] {
 						slabInfo.startIndex -= count
 
@@ -5911,7 +5911,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 					nonrootMetadataSlabInfos = nonrootMetadataSlabInfos[:len(nonrootMetadataSlabInfos)-1]
 
 				case dataSlabType:
-					// Unload data slab at randome index.
+					// Unload data slab at random index.
 					metadataSlabIndex := r.Intn(len(nonrootMetadataSlabInfos))
 
 					metaSlabInfo := nonrootMetadataSlabInfos[metadataSlabIndex]
@@ -5925,7 +5925,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 					count := slabInfoToBeRemoved.count
 
-					// Update startIndex for subsequence data slabs.
+					// Update startIndex for subsequent data slabs.
 					for _, slabInfo := range metaSlabInfo.children[dataSlabIndex+1:] {
 						slabInfo.startIndex -= count
 					}
@@ -5935,7 +5935,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 					metaSlabInfo.count -= count
 
-					// Update startIndex for all subsequence metadata slabs.
+					// Update startIndex for all subsequent metadata slabs.
 					for _, slabInfo := range nonrootMetadataSlabInfos[metadataSlabIndex+1:] {
 						slabInfo.startIndex -= count
 
@@ -7634,7 +7634,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 			require.True(t, gchildArray.Inlined())
 			require.True(t, childArray.Inlined())
-			require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because parent root slab is metdata.
+			require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because parent root slab is metadata.
 
 			require.Equal(t, atree.SlabIDUndefined, childArray.SlabID()) // Storage ID is the same bytewise as value ID.
 			require.Equal(t, valueID, childArray.ValueID())              // atree.Value ID is unchanged

--- a/array_test.go
+++ b/array_test.go
@@ -2591,9 +2591,9 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 
 	// Remove n elements at random index
 	for range arrayCount {
-		k := r.Intn(int(array.Count()))
+		k := getRandomArrayIndex(r, array)
 
-		existingStorable, err := array.Remove(uint64(k))
+		existingStorable, err := array.Remove(k)
 		require.NoError(t, err)
 
 		existingValue, err := existingStorable.StoredValue(storage)
@@ -2654,14 +2654,14 @@ func testArrayAppendSetInsertRemoveRandomValues(
 			require.NoError(t, err)
 
 		case ArraySetOp:
-			k := r.Intn(int(array.Count()))
+			k := getRandomArrayIndex(r, array)
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			oldV := expectedValues[k]
 
 			expectedValues[k] = v
 
-			existingStorable, err := array.Set(uint64(k), v)
+			existingStorable, err := array.Set(k, v)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -2689,9 +2689,9 @@ func testArrayAppendSetInsertRemoveRandomValues(
 			require.NoError(t, err)
 
 		case ArrayRemoveOp:
-			k := r.Intn(int(array.Count()))
+			k := getRandomArrayIndex(r, array)
 
-			existingStorable, err := array.Remove(uint64(k))
+			existingStorable, err := array.Remove(k)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)

--- a/array_test.go
+++ b/array_test.go
@@ -96,7 +96,7 @@ func _testArray(
 
 	// Verify array elements
 	for i, expected := range expectedValues {
-		actual, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		actual, err := array.Get(uint64(i))
 		require.NoError(t, err)
 
 		testValueEqual(t, expected, actual)
@@ -165,7 +165,7 @@ func _testArray(
 
 	// Verify decoded array elements
 	for i, expected := range expectedValues {
-		actual, err := decodedArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		actual, err := decodedArray.Get(uint64(i))
 		require.NoError(t, err)
 
 		testValueEqual(t, expected, actual)
@@ -178,7 +178,7 @@ func _testArray(
 
 		stats, err := atree.GetArrayStats(array)
 		require.NoError(t, err)
-		require.Equal(t, stats.SlabCount(), uint64(storage.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, stats.SlabCount(), uint64(storage.Count()))
 
 		if len(expectedValues) == 0 {
 			// Verify slab count for empty array
@@ -254,7 +254,7 @@ func TestArraySetAndGet(t *testing.T) {
 			newValue := test_utils.NewUint64ValueFromInteger(i * 10)
 			expectedValues[i] = newValue
 
-			existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := array.Set(uint64(i), newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -297,10 +297,10 @@ func TestArraySetAndGet(t *testing.T) {
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
-			newValue := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			newValue := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1)
 			expectedValues[i] = newValue
 
-			existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := array.Set(uint64(i), newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -334,7 +334,7 @@ func TestArraySetAndGet(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
-			v := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.Uint64Value(math.MaxUint64 - arrayCount + uint64(i) + 1)
 			expectedValues[i] = v
 			err := array.Append(v)
 			require.NoError(t, err)
@@ -347,7 +347,7 @@ func TestArraySetAndGet(t *testing.T) {
 			newValue := test_utils.NewUint64ValueFromInteger(i)
 			expectedValues[i] = newValue
 
-			existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := array.Set(uint64(i), newValue)
 			require.NoError(t, err)
 
 			existingValue, err := existingStorable.StoredValue(storage)
@@ -603,7 +603,7 @@ func TestArrayRemove(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			require.Equal(t, uint64(i), array.Count()) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, uint64(i), array.Count())
 
 			if i%256 == 0 {
 				testArray(t, storage, typeInfo, address, array, expectedValues[:i], false)
@@ -1660,7 +1660,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 			expectedValue := make(test_utils.ExpectedArrayValue, childArrayCount)
 			for j := range expectedValue {
-				v := test_utils.Uint64Value(uint64(j) + i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				v := test_utils.Uint64Value(uint64(j) + i)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -2323,7 +2323,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 
 			i++
 
-			require.Equal(t, GetArrayRootSlabByteSize(array), sizeBeforeMutation+uint32(i)*newElement.ByteSize()) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, GetArrayRootSlabByteSize(array), sizeBeforeMutation+uint32(i)*newElement.ByteSize())
 
 			return true, nil
 		})
@@ -2466,7 +2466,7 @@ func TestArraySetRandomValues(t *testing.T) {
 		newValue := randomValue(r, atree.MaxInlineArrayElementSize())
 		expectedValues[i] = newValue
 
-		existingStorable, err := array.Set(uint64(i), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		existingStorable, err := array.Set(uint64(i), newValue)
 		require.NoError(t, err)
 
 		existingValue, err := existingStorable.StoredValue(storage)
@@ -2525,7 +2525,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
 			expectedValues[i] = v
 
-			err := array.Insert(uint64(i), v) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			err := array.Insert(uint64(i), v)
 			require.NoError(t, err)
 		}
 
@@ -2547,13 +2547,13 @@ func TestArrayInsertRandomValues(t *testing.T) {
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range arrayCount {
-			k := r.Intn(int(i + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := r.Intn(int(i + 1))
 			v := randomValue(r, atree.MaxInlineArrayElementSize())
 
 			copy(expectedValues[k+1:], expectedValues[k:])
 			expectedValues[k] = v
 
-			err := array.Insert(uint64(k), v) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			err := array.Insert(uint64(k), v)
 			require.NoError(t, err)
 		}
 
@@ -2583,7 +2583,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 		v := randomValue(r, atree.MaxInlineArrayElementSize())
 		expectedValues[i] = v
 
-		err := array.Insert(uint64(i), v) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		err := array.Insert(uint64(i), v)
 		require.NoError(t, err)
 	}
 
@@ -4459,7 +4459,7 @@ func TestArrayStringElement(t *testing.T) {
 
 		r := newRand(t)
 
-		stringSize := int(atree.MaxInlineArrayElementSize() - 3) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		stringSize := int(atree.MaxInlineArrayElementSize() - 3)
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
@@ -4492,7 +4492,7 @@ func TestArrayStringElement(t *testing.T) {
 
 		r := newRand(t)
 
-		stringSize := int(atree.MaxInlineArrayElementSize() + 512) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		stringSize := int(atree.MaxInlineArrayElementSize() + 512)
 
 		expectedValues := make([]atree.Value, arrayCount)
 		for i := range expectedValues {
@@ -4791,7 +4791,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		var expectedValues []atree.Value
 		var v atree.Value
 
-		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2)))
 		expectedValues = append(expectedValues, v)
 
 		err = array.Insert(0, v)
@@ -4849,7 +4849,7 @@ func TestArrayFromBatchData(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v = test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()-2)))
 		expectedValues = append(expectedValues, nil)
 		copy(expectedValues[25+1:], expectedValues[25:])
 		expectedValues[25] = v
@@ -4945,17 +4945,17 @@ func TestArrayFromBatchData(t *testing.T) {
 		var expectedValues []atree.Value
 		var v atree.Value
 
-		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2)))
 		expectedValues = append(expectedValues, v)
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2)))
 		expectedValues = append(expectedValues, v)
 		err = array.Append(v)
 		require.NoError(t, err)
 
-		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v = test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-2)))
 		expectedValues = append(expectedValues, v)
 		err = array.Append(v)
 		require.NoError(t, err)
@@ -5024,7 +5024,7 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	expectedValues := make([]atree.Value, arrayCount)
 	for i := range expectedValues {
 		// String length is atree.MaxInlineArrayElementSize - 3 to account for string encoding overhead.
-		v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-3))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineArrayElementSize()-3)))
 		expectedValues[i] = v
 
 		err = array.Append(v)
@@ -5147,7 +5147,7 @@ func TestArraySlabDump(t *testing.T) {
 		array, err := atree.NewArray(storage, address, typeInfo)
 		require.NoError(t, err)
 
-		err = array.Append(test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize())))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		err = array.Append(test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineArrayElementSize()))))
 		require.NoError(t, err)
 
 		want := []string{
@@ -5234,7 +5234,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5250,7 +5250,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 			require.True(t, len(expectedValues) == len(childSlabIDs))
 
@@ -5275,7 +5275,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5301,7 +5301,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5330,7 +5330,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root data slab
 			// nested composite elements: 1 root data slab for each
-			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 1+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 0, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5409,7 +5409,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5425,7 +5425,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 			require.True(t, len(expectedValues) == len(childSlabIDs))
 
@@ -5450,7 +5450,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5476,7 +5476,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array: 1 root metadata slab, 2 data slabs
 			// nested composite value element: 1 root data slab for each
-			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.Equal(t, 3+arrayCount, uint64(GetDeltasCount(storage)))
 			require.Equal(t, 1, getArrayMetaDataSlabCount(storage))
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5705,7 +5705,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount)
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5743,7 +5743,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount)
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -5818,7 +5818,7 @@ func TestArrayLoadedValueIterator(t *testing.T) {
 
 			// parent array (3 levels): 1 root metadata slab, n non-root metadata slabs, n data slabs
 			// nested composite elements: 1 root data slab for each
-			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			require.True(t, uint64(GetDeltasCount(storage)) > 1+arrayCount)
 			require.True(t, getArrayMetaDataSlabCount(storage) > 1)
 
 			testArrayLoadedElements(t, array, expectedValues)
@@ -6073,7 +6073,7 @@ func createArrayWithSimpleAndChildArrayValues(
 	r := 'a'
 	for i := range expectedValues {
 
-		if compositeValueIndex == uint64(i) { //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		if compositeValueIndex == uint64(i) {
 			// Create child array with one element
 			childArray, err := atree.NewArray(storage, address, typeInfo)
 			require.NoError(t, err)
@@ -6193,7 +6193,7 @@ func TestSlabSizeWhenResettingMutableStorable(t *testing.T) {
 		mv := expectedValues[i]
 		mv.UpdateStorableSize(mutatedStorableSize)
 
-		existingStorable, err := array.Set(uint64(i), mv) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		existingStorable, err := array.Set(uint64(i), mv)
 		require.NoError(t, err)
 		require.NotNil(t, existingStorable)
 	}
@@ -6370,7 +6370,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -6568,7 +6568,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -6653,7 +6653,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		// Parent array has one data slab and all child arrays are not inlined.
-		require.Equal(t, 1+arrayCount, uint64(getStoredDeltas(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, 1+arrayCount, uint64(getStoredDeltas(storage)))
 		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove one element from child array which triggers standalone array slab becomes inlined slab again.
@@ -7067,7 +7067,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.Equal(t, gValueID, gchildArray.ValueID())      // atree.Value ID is unchanged
 
 		// Test inlined grand child slab size
-		storableByteSizes := make([]uint32, int(gchildArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		storableByteSizes := make([]uint32, int(gchildArray.Count()))
 		storableByteSizes[0] = largeValueSize
 		for i := 1; i < len(storableByteSizes); i++ {
 			storableByteSizes[i] = vSize
@@ -7201,7 +7201,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		children := make([]arrayInfo, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -7270,7 +7270,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 
 				// Test inlined child slab size
 				gchildArraySize := atree.ComputeInlinedArraySlabByteSize([]uint32{vSize})
-				childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				childStorableByteSizes := make([]uint32, int(childArray.Count()))
 				for k := range childStorableByteSizes {
 					var size uint32
 					if k == 0 {
@@ -7328,7 +7328,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			expectedInlinedGrandChildSize := atree.ComputeInlinedArraySlabByteSizeWithFixSizedElement(vSize, gchildArray.Count())
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
-			childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childStorableByteSizes := make([]uint32, int(childArray.Count()))
 			childStorableByteSizes[0] = expectedInlinedGrandChildSize
 			for i := 1; i < len(childStorableByteSizes); i++ {
 				childStorableByteSizes[i] = vSize
@@ -7384,7 +7384,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 			// Test inlined child slab size
-			childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childStorableByteSizes := make([]uint32, int(childArray.Count()))
 			childStorableByteSizes[0] = expectedInlinedGrandChildSize
 			for i := 1; i < len(childStorableByteSizes); i++ {
 				childStorableByteSizes[i] = vSize
@@ -7441,7 +7441,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.Equal(t, expectedInlinedGrandChildSize, GetArrayRootSlabByteSize(gchildArray))
 
 				// Test inlined child slab size
-				childStorableByteSizes := make([]uint32, int(childArray.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				childStorableByteSizes := make([]uint32, int(childArray.Count()))
 				childStorableByteSizes[0] = expectedInlinedGrandChildSize
 				for i := 1; i < len(childStorableByteSizes); i++ {
 					childStorableByteSizes[i] = vSize
@@ -7527,7 +7527,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		children := make([]arrayInfo, arrayCount)
 
 		for i := range children {
-			e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			e, err := parentArray.Get(uint64(i))
 			require.NoError(t, err)
 			require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -7711,7 +7711,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		}
 
 		// Parent array has one root data slab, 4 grand child array with standalone root data slab.
-		require.Equal(t, 1+arrayCount, uint64(getStoredDeltas(storage))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, 1+arrayCount, uint64(getStoredDeltas(storage)))
 		require.True(t, IsArrayRootDataSlab(parentArray))
 
 		// Remove elements from grand child array to trigger child array inlined again.
@@ -7863,7 +7863,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 	}, arrayCount)
 
 	for i := range children {
-		e, err := parentArray.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		e, err := parentArray.Get(uint64(i))
 		require.NoError(t, err)
 		require.Equal(t, 1, getStoredDeltas(storage))
 
@@ -8268,7 +8268,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		// Overwrite existing child array value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8328,7 +8328,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		// Overwrite existing child array value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8398,7 +8398,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		// Overwrite existing child map value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 
@@ -8463,7 +8463,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 
 		// Overwrite existing child map value
 		for i := range expectedValues {
-			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := parentArray.Set(uint64(i), test_utils.Uint64Value(0))
 			require.NoError(t, err)
 			require.NotNil(t, existingStorable)
 

--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -1886,7 +1886,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 		minRemoveCount := int(array.Count()) / 2
 		maxRemoveCount := int(array.Count()) / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()) + 1)
+			removeCount = r.Intn(int(array.Count()))
 		}
 
 		actualArrayCount -= removeCount
@@ -1954,7 +1954,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 		minRemoveCount := int(array.Count()) / 2
 		maxRemoveCount := int(array.Count()) / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()) + 1)
+			removeCount = r.Intn(int(array.Count()))
 		}
 
 		actualArrayCount -= removeCount
@@ -2175,7 +2175,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 		minRemoveCount := int(array.Count()) / 2
 		maxRemoveCount := int(array.Count()) / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()) + 1)
+			removeCount = r.Intn(int(array.Count()))
 		}
 
 		actualArrayCount -= removeCount
@@ -2242,7 +2242,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 		minRemoveCount := int(array.Count()) / 2
 		maxRemoveCount := int(array.Count()) / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()) + 1)
+			removeCount = r.Intn(int(array.Count()))
 		}
 
 		actualArrayCount -= removeCount
@@ -2482,7 +2482,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		var removeCount int
 		for removeCount < int(array.Count())/2 {
-			removeCount = r.Intn(int(array.Count()) + 1)
+			removeCount = r.Intn(int(array.Count()))
 		}
 
 		actualArrayCount -= removeCount
@@ -2547,7 +2547,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		var removeCount int
 		for removeCount < int(array.Count())/2 {
-			removeCount = r.Intn(int(array.Count()) + 1)
+			removeCount = r.Intn(int(array.Count()))
 		}
 
 		actualArrayCount -= removeCount

--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -533,7 +533,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
-					v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					v, err := array.Get(uint64(i))
 					require.NoError(t, err)
 
 					expected := expectedValues[i]
@@ -645,7 +645,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
-					v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					v, err := array.Get(uint64(i))
 					require.NoError(t, err)
 
 					expected := expectedValues[i]
@@ -772,7 +772,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
-					v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					v, err := array.Get(uint64(i))
 					require.NoError(t, err)
 
 					expected := expectedValues[i]
@@ -916,7 +916,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 						// Retrieve and modify WrapperValue from array
 						if needToModifyElement {
 							for i := range expectedValues {
-								v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+								v, err := array.Get(uint64(i))
 								require.NoError(t, err)
 
 								expected := expectedValues[i]
@@ -1096,7 +1096,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 						// Retrieve and modify WrapperValue from array
 						if needToModifyElement {
 							for i := range expectedValues {
-								v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+								v, err := array.Get(uint64(i))
 								require.NoError(t, err)
 
 								expected := expectedValues[i]
@@ -1884,7 +1884,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		actualArrayCount -= removeCount
 
-		removeIndex := getRandomArrayIndexes(r, array, int(removeCount)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		removeIndex := getRandomArrayIndexes(r, array, int(removeCount))
 
 		sort.Sort(sort.Reverse(uint64Slice(removeIndex)))
 
@@ -1989,7 +1989,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 			index := getRandomArrayIndex(r, array)
 
-			testSetElementInArray(t, storage, array, int(index), v, expectedValues[index]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			testSetElementInArray(t, storage, array, int(index), v, expectedValues[index])
 
 			expectedValues[index] = expected
 
@@ -2154,7 +2154,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		actualArrayCount -= removeCount
 
-		removeIndex := getRandomArrayIndexes(r, array, int(removeCount)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		removeIndex := getRandomArrayIndexes(r, array, int(removeCount))
 
 		sort.Sort(sort.Reverse(uint64Slice(removeIndex)))
 
@@ -2227,7 +2227,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		// Remove more elements
 
-		for i := 1; i < int(removeCount); i++ { //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		for i := 1; i < int(removeCount); i++ {
 			index := getRandomArrayIndex(r, array)
 
 			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
@@ -2444,7 +2444,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		actualArrayCount -= removeCount
 
-		removeIndex := getRandomArrayIndexes(r, array, int(removeCount)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		removeIndex := getRandomArrayIndexes(r, array, int(removeCount))
 
 		sort.Sort(sort.Reverse(uint64Slice(removeIndex)))
 
@@ -2945,7 +2945,7 @@ func testArrayMutableElementIndex(t *testing.T, v atree.Value) {
 }
 
 func testSetElementInArray(t *testing.T, storage atree.SlabStorage, array *atree.Array, index int, newValue atree.Value, expected atree.Value) {
-	existingStorable, err := array.Set(uint64(index), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+	existingStorable, err := array.Set(uint64(index), newValue)
 	require.NoError(t, err)
 	require.NotNil(t, existingStorable)
 

--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -20,7 +20,6 @@ package atree_test
 
 import (
 	"fmt"
-	"math"
 	"math/rand"
 	"runtime"
 	"sort"
@@ -487,7 +486,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -526,7 +525,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 					expectedValues[i] = expectedV
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -534,7 +533,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
-					v, err := array.Get(uint64(i))
+					v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					require.NoError(t, err)
 
 					expected := expectedValues[i]
@@ -548,13 +547,13 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 					require.NoError(t, err)
 
 					if tc.mustSetModifiedElementInArray {
-						testSetElementInArray(t, storage, array, uint64(i), newV, expected)
+						testSetElementInArray(t, storage, array, i, newV, expected)
 					}
 
 					expectedValues[i] = newExpectedV
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -569,7 +568,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 				array2, err := atree.NewArrayWithRootID(storage2, arraySlabID)
 				require.NoError(t, err)
-				require.Equal(t, uint64(arrayCount), array2.Count())
+				require.Equal(t, arrayCount, array2.Count())
 
 				// Test loaded array
 				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -599,7 +598,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -638,7 +637,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 					expectedValues[i] = expectedV
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -646,7 +645,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
-					v, err := array.Get(uint64(i))
+					v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					require.NoError(t, err)
 
 					expected := expectedValues[i]
@@ -660,13 +659,13 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 					require.NoError(t, err)
 
 					if tc.mustSetModifiedElementInArray {
-						testSetElementInArray(t, storage, array, uint64(i), newV, expected)
+						testSetElementInArray(t, storage, array, i, newV, expected)
 					}
 
 					expectedValues[i] = newExpectedV
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -681,7 +680,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 				array2, err := atree.NewArrayWithRootID(storage2, arraySlabID)
 				require.NoError(t, err)
-				require.Equal(t, uint64(arrayCount), array2.Count())
+				require.Equal(t, arrayCount, array2.Count())
 
 				// Test loaded array
 				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -711,7 +710,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -750,7 +749,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[i] = expectedV
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -760,12 +759,12 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 				for i := range expectedValues {
 					v, expected := tc.newElement(storage)
 
-					testSetElementInArray(t, storage, array, uint64(i), v, expectedValues[i])
+					testSetElementInArray(t, storage, array, i, v, expectedValues[i])
 
 					expectedValues[i] = expected
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -773,7 +772,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
-					v, err := array.Get(uint64(i))
+					v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					require.NoError(t, err)
 
 					expected := expectedValues[i]
@@ -787,13 +786,13 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 					require.NoError(t, err)
 
 					if tc.mustSetModifiedElementInArray {
-						testSetElementInArray(t, storage, array, uint64(i), newV, expected)
+						testSetElementInArray(t, storage, array, i, newV, expected)
 					}
 
 					expectedValues[i] = newExpectedV
 				}
 
-				require.Equal(t, uint64(arrayCount), array.Count())
+				require.Equal(t, arrayCount, array.Count())
 
 				testArrayMutableElementIndex(t, array)
 
@@ -808,7 +807,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				array2, err := atree.NewArrayWithRootID(storage2, arraySlabID)
 				require.NoError(t, err)
-				require.Equal(t, uint64(arrayCount), array2.Count())
+				require.Equal(t, arrayCount, array2.Count())
 
 				// Test loaded array
 				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -837,7 +836,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -854,7 +853,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 	removeTestCases := []struct {
 		name               string
 		removeAllElements  bool
-		removeElementCount int
+		removeElementCount uint64
 	}{
 		{name: "remove all elements", removeAllElements: true},
 		{name: "remove 1 element", removeElementCount: 1},
@@ -908,7 +907,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 							expectedValues[i] = expectedV
 						}
 
-						require.Equal(t, uint64(arrayCount), array.Count())
+						require.Equal(t, arrayCount, array.Count())
 
 						testArrayMutableElementIndex(t, array)
 
@@ -917,7 +916,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 						// Retrieve and modify WrapperValue from array
 						if needToModifyElement {
 							for i := range expectedValues {
-								v, err := array.Get(uint64(i))
+								v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 								require.NoError(t, err)
 
 								expected := expectedValues[i]
@@ -931,13 +930,13 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 								require.NoError(t, err)
 
 								if tc.mustSetModifiedElementInArray {
-									testSetElementInArray(t, storage, array, uint64(i), newV, expected)
+									testSetElementInArray(t, storage, array, i, newV, expected)
 								}
 
 								expectedValues[i] = newExpectedV
 							}
 
-							require.Equal(t, uint64(arrayCount), array.Count())
+							require.Equal(t, arrayCount, array.Count())
 
 							testArrayMutableElementIndex(t, array)
 
@@ -947,15 +946,15 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 						// Remove random elements
 						for range removeCount {
 
-							removeIndex := r.Intn(int(array.Count()))
+							removeIndex := getRandomArrayIndex(r, array)
 
-							testRemoveElementFromArray(t, storage, array, uint64(removeIndex), expectedValues[removeIndex])
+							testRemoveElementFromArray(t, storage, array, removeIndex, expectedValues[removeIndex])
 
 							expectedValues = append(expectedValues[:removeIndex], expectedValues[removeIndex+1:]...)
 						}
 
-						require.Equal(t, uint64(arrayCount-removeCount), array.Count())
-						require.Equal(t, arrayCount-removeCount, len(expectedValues))
+						require.Equal(t, arrayCount-removeCount, array.Count())
+						require.Equal(t, arrayCount-removeCount, uint64(len(expectedValues)))
 
 						testArrayMutableElementIndex(t, array)
 
@@ -970,7 +969,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 
 						array2, err := atree.NewArrayWithRootID(storage2, arraySlabID)
 						require.NoError(t, err)
-						require.Equal(t, uint64(arrayCount-removeCount), array2.Count())
+						require.Equal(t, arrayCount-removeCount, array2.Count())
 
 						// Test loaded array
 						testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -1001,7 +1000,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -1018,7 +1017,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 	removeTestCases := []struct {
 		name               string
 		removeAllElements  bool
-		removeElementCount int
+		removeElementCount uint64
 	}{
 		{name: "remove all elements", removeAllElements: true},
 		{name: "remove 1 element", removeElementCount: 1},
@@ -1073,7 +1072,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 							expectedValues[i] = expectedV
 						}
 
-						require.Equal(t, uint64(arrayCount), array.Count())
+						require.Equal(t, arrayCount, array.Count())
 
 						testArrayMutableElementIndex(t, array)
 
@@ -1083,12 +1082,12 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 						for i := range expectedValues {
 							v, expectedV := tc.newElement(storage)
 
-							testSetElementInArray(t, storage, array, uint64(i), v, expectedValues[i])
+							testSetElementInArray(t, storage, array, i, v, expectedValues[i])
 
 							expectedValues[i] = expectedV
 						}
 
-						require.Equal(t, uint64(arrayCount), array.Count())
+						require.Equal(t, arrayCount, array.Count())
 
 						testArrayMutableElementIndex(t, array)
 
@@ -1097,7 +1096,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 						// Retrieve and modify WrapperValue from array
 						if needToModifyElement {
 							for i := range expectedValues {
-								v, err := array.Get(uint64(i))
+								v, err := array.Get(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 								require.NoError(t, err)
 
 								expected := expectedValues[i]
@@ -1111,13 +1110,13 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 								require.NoError(t, err)
 
 								if tc.mustSetModifiedElementInArray {
-									testSetElementInArray(t, storage, array, uint64(i), newV, expected)
+									testSetElementInArray(t, storage, array, i, newV, expected)
 								}
 
 								expectedValues[i] = newExpectedV
 							}
 
-							require.Equal(t, uint64(arrayCount), array.Count())
+							require.Equal(t, arrayCount, array.Count())
 
 							testArrayMutableElementIndex(t, array)
 
@@ -1127,15 +1126,15 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 						// Remove random elements
 						for range removeCount {
 
-							removeIndex := r.Intn(int(array.Count()))
+							removeIndex := getRandomArrayIndex(r, array)
 
-							testRemoveElementFromArray(t, storage, array, uint64(removeIndex), expectedValues[removeIndex])
+							testRemoveElementFromArray(t, storage, array, removeIndex, expectedValues[removeIndex])
 
 							expectedValues = append(expectedValues[:removeIndex], expectedValues[removeIndex+1:]...)
 						}
 
-						require.Equal(t, uint64(arrayCount-removeCount), array.Count())
-						require.Equal(t, arrayCount-removeCount, len(expectedValues))
+						require.Equal(t, arrayCount-removeCount, array.Count())
+						require.Equal(t, arrayCount-removeCount, uint64(len(expectedValues)))
 
 						testArrayMutableElementIndex(t, array)
 
@@ -1150,7 +1149,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 						array2, err := atree.NewArrayWithRootID(storage2, arraySlabID)
 						require.NoError(t, err)
-						require.Equal(t, uint64(arrayCount-removeCount), array2.Count())
+						require.Equal(t, arrayCount-removeCount, array2.Count())
 
 						// Test loaded array
 						testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
@@ -1177,7 +1176,7 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -1232,7 +1231,7 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 						expectedValues[i] = expectedV
 					}
 
-					require.Equal(t, uint64(arrayCount), array.Count())
+					require.Equal(t, arrayCount, array.Count())
 
 					testArrayMutableElementIndex(t, array)
 
@@ -1289,7 +1288,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 
 	arrayCountTestCases := []struct {
 		name       string
-		arrayCount int
+		arrayCount uint64
 	}{
 		{name: "small array", arrayCount: smallArrayCount},
 		{name: "large array", arrayCount: largeArrayCount},
@@ -1346,7 +1345,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 						expectedValues[i] = expectedV
 					}
 
-					require.Equal(t, uint64(arrayCount), array.Count())
+					require.Equal(t, arrayCount, array.Count())
 
 					testArrayMutableElementIndex(t, array)
 
@@ -1381,7 +1380,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 						count++
 					}
 
-					require.Equal(t, uint64(arrayCount), array.Count())
+					require.Equal(t, arrayCount, array.Count())
 
 					testArrayMutableElementIndex(t, array)
 
@@ -1465,7 +1464,7 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 	// Retrieve wrapped child array, and then append new elements to child array.
 	// Wrapped child array is expected to be unlined at the end of loop.
 
-	const childArrayCount = 32
+	const childArrayCount = uint64(32)
 	for i := range childArrayCount {
 		// Get element
 		element, err := array.Get(0)
@@ -1495,8 +1494,8 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 
 		expectedValues[0] = test_utils.NewExpectedWrapperValue(expectedWrappedArray)
 
-		require.Equal(t, uint64(i+1), wrappedArray.Count())
-		require.Equal(t, i+1, len(expectedWrappedArray))
+		require.Equal(t, i+1, wrappedArray.Count())
+		require.Equal(t, i+1, uint64(len(expectedWrappedArray)))
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1508,7 +1507,7 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 	// Retrieve wrapped child array, and then remove elements to child array.
 	// Wrapped child array is expected to be inlined at the end of loop.
 
-	childArrayCountAfterRemoval := 2
+	childArrayCountAfterRemoval := uint64(2)
 	removeCount := childArrayCount - childArrayCountAfterRemoval
 
 	for range removeCount {
@@ -1660,7 +1659,7 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild array, and then append new elements to gchild array.
 	// Wrapped gchild array is expected to be unlined at the end of loop.
 
-	const gchildArrayCount = 32
+	const gchildArrayCount = uint64(32)
 	for i := range gchildArrayCount {
 		// Get element at level 1
 
@@ -1711,8 +1710,8 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 			test_utils.ExpectedArrayValue{
 				test_utils.NewExpectedWrapperValue(expectedWrappedArrayAtLevel2)})
 
-		require.Equal(t, uint64(i+1), wrappedArrayAtLevel2.Count())
-		require.Equal(t, i+1, len(expectedWrappedArrayAtLevel2))
+		require.Equal(t, i+1, wrappedArrayAtLevel2.Count())
+		require.Equal(t, i+1, uint64(len(expectedWrappedArrayAtLevel2)))
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1724,7 +1723,7 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild array, and then remove elements from gchild array.
 	// Wrapped gchild array is expected to be inlined at the end of loop.
 
-	gchildArrayCountAfterRemoval := 2
+	gchildArrayCountAfterRemoval := uint64(2)
 	removeCount := gchildArrayCount - gchildArrayCountAfterRemoval
 
 	for range removeCount {
@@ -1851,16 +1850,13 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 	array, err := atree.NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	actualArrayCount := 0
+	actualArrayCount := uint64(0)
 
 	t.Run("append and remove", func(t *testing.T) {
 
 		// Append elements
 
-		var appendCount int
-		for appendCount < minWriteOperationCount {
-			appendCount = r.Intn(maxWriteOperationCount + 1)
-		}
+		appendCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualArrayCount += appendCount
 
@@ -1874,7 +1870,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = append(expectedValues, expected)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1882,26 +1878,23 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		// Remove at least half of elements
 
-		var removeCount int
-		minRemoveCount := int(array.Count()) / 2
-		maxRemoveCount := int(array.Count()) / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count() / 4 * 3
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
-		removeIndex := getRandomUniquePositiveNumbers(r, int(array.Count()), removeCount)
+		removeIndex := getRandomArrayIndexes(r, array, int(removeCount)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
-		sort.Sort(sort.Reverse(sort.IntSlice(removeIndex)))
+		sort.Sort(sort.Reverse(uint64Slice(removeIndex)))
 
 		for _, index := range removeIndex {
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1911,26 +1904,23 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 	t.Run("insert and remove", func(t *testing.T) {
 		// Insert elements
 
-		var insertCount int
-		for insertCount < minWriteOperationCount {
-			insertCount = r.Intn(maxWriteOperationCount + 1)
-		}
+		insertCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualArrayCount += insertCount
 
-		lowestInsertIndex := math.MaxInt
+		lowestInsertIndex := array.Count()
 
 		for range insertCount {
 			newValue := newElementFuncs[r.Intn(len(newElementFuncs))]
 			v, expected := newValue(storage)
 
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
 			if index < lowestInsertIndex {
 				lowestInsertIndex = index
 			}
 
-			err = array.Insert(uint64(index), v)
+			err = array.Insert(index, v)
 			require.NoError(t, err)
 
 			newExpectedValue := make([]atree.Value, len(expectedValues)+1)
@@ -1942,7 +1932,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 			expectedValues = newExpectedValue
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1950,12 +1940,9 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		// Remove some elements (including one previously inserted element)
 
-		var removeCount int
-		minRemoveCount := int(array.Count()) / 2
-		maxRemoveCount := int(array.Count()) / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count() / 4 * 3
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
@@ -1964,22 +1951,22 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 		{
 			index := lowestInsertIndex
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
 		// Remove more elements
 
-		for i := 1; i < removeCount; i++ {
-			index := r.Intn(int(array.Count()))
+		for i := uint64(1); i < removeCount; i++ {
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -1989,31 +1976,27 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 	t.Run("set and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount int
-		if array.Count() <= 10 {
-			setCount = int(array.Count())
-		} else {
-			for setCount < int(array.Count())/2 {
-				setCount = r.Intn(int(array.Count()) + 1)
-			}
+		setCount := array.Count()
+		if array.Count() > 10 {
+			setCount = getRandomUint64InRange(r, array.Count()/2, array.Count()+1)
 		}
 
-		setIndex := make([]int, 0, setCount)
+		setIndex := make([]uint64, 0, setCount)
 
 		for range setCount {
 			newValue := newElementFuncs[r.Intn(len(newElementFuncs))]
 			v, expected := newValue(storage)
 
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testSetElementInArray(t, storage, array, uint64(index), v, expectedValues[index])
+			testSetElementInArray(t, storage, array, int(index), v, expectedValues[index]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			expectedValues[index] = expected
 
 			setIndex = append(setIndex, index)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2021,19 +2004,16 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		// Remove some elements (including some previously set elements)
 
-		var removeCount int
-		minRemoveCount := int(array.Count()) / 2
-		maxRemoveCount := int(array.Count()) / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count() / 4 * 3
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
 		// Remove some previously set elements first
 
 		// Reverse sort and deduplicate set index
-		sort.Sort(sort.Reverse(sort.IntSlice(setIndex)))
+		sort.Sort(sort.Reverse(uint64Slice(setIndex)))
 
 		prev := setIndex[0]
 		for i := 1; i < len(setIndex); {
@@ -2048,25 +2028,25 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 		}
 
 		removeSetCount := removeCount / 2
-		if len(setIndex) < removeSetCount {
-			removeSetCount = len(setIndex)
+		if uint64(len(setIndex)) < removeSetCount {
+			removeSetCount = uint64(len(setIndex))
 		}
 
 		for _, index := range setIndex[:removeSetCount] {
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
 		for range removeCount - removeSetCount {
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2078,9 +2058,9 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		for array.Count() > 0 {
 			// Remove element at random index
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
@@ -2141,16 +2121,13 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 	array, err := atree.NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	actualArrayCount := 0
+	actualArrayCount := uint64(0)
 
 	t.Run("append and remove", func(t *testing.T) {
 
 		// Append elements
 
-		var appendCount int
-		for appendCount < minWriteOperationCount {
-			appendCount = r.Intn(maxWriteOperationCount + 1)
-		}
+		appendCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualArrayCount += appendCount
 
@@ -2163,7 +2140,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = append(expectedValues, expected)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2171,26 +2148,23 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		// Remove some elements
 
-		var removeCount int
-		minRemoveCount := int(array.Count()) / 2
-		maxRemoveCount := int(array.Count()) / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count() / 4 * 3
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
-		removeIndex := getRandomUniquePositiveNumbers(r, int(array.Count()), removeCount)
+		removeIndex := getRandomArrayIndexes(r, array, int(removeCount)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
-		sort.Sort(sort.Reverse(sort.IntSlice(removeIndex)))
+		sort.Sort(sort.Reverse(uint64Slice(removeIndex)))
 
 		for _, index := range removeIndex {
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2200,25 +2174,22 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 	t.Run("insert and remove", func(t *testing.T) {
 		// Insert elements
 
-		var insertCount int
-		for insertCount < minWriteOperationCount {
-			insertCount = r.Intn(maxWriteOperationCount + 1)
-		}
+		insertCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualArrayCount += insertCount
 
-		lowestInsertIndex := math.MaxInt
+		lowestInsertIndex := array.Count()
 
 		for range insertCount {
 			v, expected := newValue(storage)
 
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
 			if index < lowestInsertIndex {
 				lowestInsertIndex = index
 			}
 
-			err = array.Insert(uint64(index), v)
+			err = array.Insert(index, v)
 			require.NoError(t, err)
 
 			newExpectedValue := make([]atree.Value, len(expectedValues)+1)
@@ -2230,7 +2201,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			expectedValues = newExpectedValue
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2238,12 +2209,9 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		// Remove some elements (including one previously inserted element)
 
-		var removeCount int
-		minRemoveCount := int(array.Count()) / 2
-		maxRemoveCount := int(array.Count()) / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count() / 4 * 3
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
@@ -2252,22 +2220,22 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 		{
 			index := lowestInsertIndex
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
 		// Remove more elements
 
-		for i := 1; i < removeCount; i++ {
-			index := r.Intn(int(array.Count()))
+		for i := 1; i < int(removeCount); i++ { //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2277,23 +2245,19 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 	t.Run("modify retrieved nested container and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount int
-		if array.Count() <= 10 {
-			setCount = int(array.Count())
-		} else {
-			for setCount < int(array.Count())/2 {
-				setCount = r.Intn(int(array.Count()) + 1)
-			}
+		setCount := array.Count()
+		if array.Count() > 10 {
+			setCount = getRandomUint64InRange(r, array.Count()/2, array.Count()+1)
 		}
 
-		setIndex := make([]int, 0, setCount)
+		setIndex := make([]uint64, 0, setCount)
 
 		for range setCount {
 
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
 			// Get element
-			originalValue, err := array.Get(uint64(index))
+			originalValue, err := array.Get(index)
 			require.NoError(t, err)
 			require.NotNil(t, originalValue)
 
@@ -2309,7 +2273,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 			setIndex = append(setIndex, index)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2317,19 +2281,16 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		// Remove some elements (including some previously set elements)
 
-		var removeCount int
-		minRemoveCount := int(array.Count()) / 2
-		maxRemoveCount := int(array.Count()) / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count() / 4 * 3
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
 		// Remove some previously set elements first
 
 		// Reverse sort and deduplicate set index
-		sort.Sort(sort.Reverse(sort.IntSlice(setIndex)))
+		sort.Sort(sort.Reverse(uint64Slice(setIndex)))
 
 		prev := setIndex[0]
 		for i := 1; i < len(setIndex); {
@@ -2344,25 +2305,25 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 		}
 
 		removeSetCount := removeCount / 2
-		if len(setIndex) < removeSetCount {
-			removeSetCount = len(setIndex)
+		if uint64(len(setIndex)) < removeSetCount {
+			removeSetCount = uint64(len(setIndex))
 		}
 
 		for _, index := range setIndex[:removeSetCount] {
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
 		for range removeCount - removeSetCount {
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2374,9 +2335,9 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		for array.Count() > 0 {
 			// Remove element at random index
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
@@ -2450,16 +2411,13 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 	array, err := atree.NewArray(storage, address, typeInfo)
 	require.NoError(t, err)
 
-	actualArrayCount := 0
+	actualArrayCount := uint64(0)
 
 	t.Run("append and remove", func(t *testing.T) {
 
 		// Append elements
 
-		var appendCount int
-		for appendCount < minWriteOperationCount {
-			appendCount = r.Intn(maxWriteOperationCount + 1)
-		}
+		appendCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualArrayCount += appendCount
 
@@ -2472,7 +2430,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = append(expectedValues, expected)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2480,24 +2438,23 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		// Remove some elements
 
-		var removeCount int
-		for removeCount < int(array.Count())/2 {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		arrayCount := array.Count()
+
+		removeCount := getRandomUint64InRange(r, arrayCount/2, arrayCount)
 
 		actualArrayCount -= removeCount
 
-		removeIndex := getRandomUniquePositiveNumbers(r, int(array.Count()), removeCount)
+		removeIndex := getRandomArrayIndexes(r, array, int(removeCount)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
-		sort.Sort(sort.Reverse(sort.IntSlice(removeIndex)))
+		sort.Sort(sort.Reverse(uint64Slice(removeIndex)))
 
 		for _, index := range removeIndex {
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2507,25 +2464,22 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 	t.Run("insert and remove", func(t *testing.T) {
 		// Insert elements
 
-		var insertCount int
-		for insertCount < minWriteOperationCount {
-			insertCount = r.Intn(maxWriteOperationCount + 1)
-		}
+		insertCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualArrayCount += insertCount
 
-		lowestInsertIndex := math.MaxInt
+		lowestInsertIndex := array.Count()
 
 		for range insertCount {
 			v, expected := newValue(storage)
 
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
 			if index < lowestInsertIndex {
 				lowestInsertIndex = index
 			}
 
-			err = array.Insert(uint64(index), v)
+			err = array.Insert(index, v)
 			require.NoError(t, err)
 
 			newExpectedValue := make([]atree.Value, len(expectedValues)+1)
@@ -2537,7 +2491,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			expectedValues = newExpectedValue
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2545,10 +2499,9 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		// Remove some elements (including one previously inserted element)
 
-		var removeCount int
-		for removeCount < int(array.Count())/2 {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count()
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
@@ -2557,22 +2510,22 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 		{
 			index := lowestInsertIndex
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
 		// Remove more elements
 
-		for i := 1; i < removeCount; i++ {
-			index := r.Intn(int(array.Count()))
+		for range removeCount - 1 {
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2582,25 +2535,19 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 	t.Run("modify retrieved nested container and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount int
-		for setCount == 0 {
-			if array.Count() <= 10 {
-				setCount = int(array.Count())
-			} else {
-				for setCount < int(array.Count())/2 {
-					setCount = r.Intn(int(array.Count()) + 1)
-				}
-			}
+		setCount := array.Count()
+		if array.Count() > 10 {
+			setCount = getRandomUint64InRange(r, array.Count()/2, array.Count()+1)
 		}
 
-		setIndex := make([]int, 0, setCount)
+		setIndex := make([]uint64, 0, setCount)
 
 		for range setCount {
 
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
 			// Get element
-			originalValue, err := array.Get(uint64(index))
+			originalValue, err := array.Get(index)
 			require.NoError(t, err)
 			require.NotNil(t, originalValue)
 
@@ -2616,7 +2563,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 			setIndex = append(setIndex, index)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2624,17 +2571,16 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		// Remove some elements (including some previously set elements)
 
-		var removeCount int
-		for removeCount < int(array.Count())/2 {
-			removeCount = r.Intn(int(array.Count()))
-		}
+		minRemoveCount := array.Count() / 2
+		maxRemoveCount := array.Count()
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualArrayCount -= removeCount
 
 		// Remove some previously set elements first
 
 		// Reverse sort and deduplicate set index
-		sort.Sort(sort.Reverse(sort.IntSlice(setIndex)))
+		sort.Sort(sort.Reverse(uint64Slice(setIndex)))
 
 		prev := setIndex[0]
 		for i := 1; i < len(setIndex); {
@@ -2649,25 +2595,25 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 		}
 
 		removeSetCount := removeCount / 2
-		if len(setIndex) < removeSetCount {
-			removeSetCount = len(setIndex)
+		if uint64(len(setIndex)) < removeSetCount {
+			removeSetCount = uint64(len(setIndex))
 		}
 
 		for _, index := range setIndex[:removeSetCount] {
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
 		for range removeCount - removeSetCount {
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualArrayCount), array.Count())
+		require.Equal(t, actualArrayCount, array.Count())
 
 		testArrayMutableElementIndex(t, array)
 
@@ -2679,9 +2625,9 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		for array.Count() > 0 {
 			// Remove element at random index
-			index := r.Intn(int(array.Count()))
+			index := getRandomArrayIndex(r, array)
 
-			testRemoveElementFromArray(t, storage, array, uint64(index), expectedValues[index])
+			testRemoveElementFromArray(t, storage, array, index, expectedValues[index])
 
 			expectedValues = append(expectedValues[:index], expectedValues[index+1:]...)
 		}
@@ -2998,8 +2944,8 @@ func testArrayMutableElementIndex(t *testing.T, v atree.Value) {
 	require.Equal(t, 0, len(originalMutableIndex))
 }
 
-func testSetElementInArray(t *testing.T, storage atree.SlabStorage, array *atree.Array, index uint64, newValue atree.Value, expected atree.Value) {
-	existingStorable, err := array.Set(index, newValue)
+func testSetElementInArray(t *testing.T, storage atree.SlabStorage, array *atree.Array, index int, newValue atree.Value, expected atree.Value) {
+	existingStorable, err := array.Set(uint64(index), newValue) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 	require.NoError(t, err)
 	require.NotNil(t, existingStorable)
 
@@ -3054,21 +3000,6 @@ func testRemoveElementFromArray(t *testing.T, storage atree.SlabStorage, array *
 	testValueEqual(t, expected, existingValue)
 
 	removeFromStorage(t, storage, existingValue)
-}
-
-func getRandomUniquePositiveNumbers(r *rand.Rand, nonInclusiveMax int, count int) []int {
-	set := make(map[int]struct{})
-	for len(set) < count {
-		n := r.Intn(nonInclusiveMax)
-		set[n] = struct{}{}
-	}
-
-	slice := make([]int, 0, count)
-	for n := range set {
-		slice = append(slice, n)
-	}
-
-	return slice
 }
 
 func removeFromStorage(t *testing.T, storage atree.SlabStorage, v atree.Value) {

--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -467,7 +467,7 @@ func newArrayWrapperValueTestCases(
 
 // TestArrayWrapperValueAppendAndModify tests
 //   - appending WrapperValue to array
-//   - retrieveing WrapperValue from array
+//   - retrieving WrapperValue from array
 //   - modifing retrieved WrapperValue
 func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 

--- a/blake3_regression_test.go
+++ b/blake3_regression_test.go
@@ -188,7 +188,7 @@ func checksumVaryingEndPosNoSeed(t *testing.T, cryptoHash512 hash.Hash, data []b
 // produced from SHA-512 in a feedback loop. SHA-512 is used instead
 // of SHAKE-256 XOF or a stream cipher because SHA-512 is bundled with
 // Go and is available in most languages. One reason a simple PRNG
-// isn't used here is because different implementions in different
+// isn't used here is because different implementations in different
 // programming languages are sometimes incompatible due to errors
 // (like SplitMix64). SHA-512 will be compatible everywhere.
 // For BLAKE3, we should use at least 64KiB because implementations

--- a/circlehash64_regression_test.go
+++ b/circlehash64_regression_test.go
@@ -192,7 +192,7 @@ func checksumVaryingEndPos(t *testing.T, cryptoHash512 hash.Hash, seed uint64, d
 // produced from SHA-512 in a feedback loop. SHA-512 is used instead
 // of SHAKE-256 XOF or a stream cipher because SHA-512 is bundled with
 // Go and is available in most languages. One reason a simple PRNG
-// isn't used here is because different implementions in different
+// isn't used here is because different implementations in different
 // programming languages are sometimes incompatible due to errors
 // (like SplitMix64). SHA-512 will be compatible everywhere.
 // SHA-512 of the returned 16384-byte slice is:

--- a/cmd/smoke/map.go
+++ b/cmd/smoke/map.go
@@ -462,7 +462,7 @@ func modifyMap(
 			return nil, 0, fmt.Errorf("Remove() returned wrong existing value %s, want %s", existingValueStorable, oldExpectedValue)
 		}
 		if !equal {
-			return nil, 0, fmt.Errorf("removed map elemnet isn't as expected: %s, %s", oldExpectedValue, existingValue)
+			return nil, 0, fmt.Errorf("removed map element isn't as expected: %s, %s", oldExpectedValue, existingValue)
 		}
 
 		// Delete removed element from storage
@@ -542,7 +542,7 @@ func checkMapDataLoss(expectedValues test_utils.ExpectedMapValue, m *atree.Order
 			return fmt.Errorf("failed to compare %s and %s: %w", v, convertedValue, err)
 		}
 		if !equal {
-			return fmt.Errorf("map elemnet isn't as expected: %s, %s", convertedValue, v)
+			return fmt.Errorf("map element isn't as expected: %s, %s", convertedValue, v)
 		}
 	}
 

--- a/cmd/smoke/typeinfo.go
+++ b/cmd/smoke/typeinfo.go
@@ -197,7 +197,7 @@ func decodeTypeInfo(dec *cbor.StreamDecoder) (atree.TypeInfo, error) {
 		}
 		if count != 2 {
 			return nil, fmt.Errorf(
-				"failed to decode composite type info: expect 2 elemets, got %d elements",
+				"failed to decode composite type info: expect 2 elements, got %d elements",
 				count,
 			)
 		}

--- a/cmd/smoke/utils.go
+++ b/cmd/smoke/utils.go
@@ -105,7 +105,7 @@ func generateSimpleValue(
 		return v, v, nil
 
 	default:
-		return nil, nil, fmt.Errorf("unexpected randome simple value type %d", valueType)
+		return nil, nil, fmt.Errorf("unexpected random simple value type %d", valueType)
 	}
 }
 
@@ -128,7 +128,7 @@ func generateContainerValue(
 		return newComposite(storage, address, nestedLevels)
 
 	default:
-		return nil, nil, fmt.Errorf("unexpected randome container value type %d", valueType)
+		return nil, nil, fmt.Errorf("unexpected random container value type %d", valueType)
 	}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -126,7 +126,7 @@ func GetMutableValueNotifierValueID(v Value) (ValueID, error) {
 	return m.ValueID(), nil
 }
 
-func ComputeArrayRootDataSlabByteSizeWithFixSizedElement(storableByteSize uint32, count int) uint32 {
+func ComputeArrayRootDataSlabByteSizeWithFixSizedElement(storableByteSize uint32, count uint64) uint32 {
 	storableByteSizes := make([]uint32, count)
 	for i := range storableByteSizes {
 		storableByteSizes[i] = storableByteSize
@@ -142,7 +142,7 @@ func ComputeArrayRootDataSlabByteSize(storableByteSizes []uint32) uint32 {
 	return slabSize
 }
 
-func ComputeInlinedArraySlabByteSizeWithFixSizedElement(storableByteSize uint32, count int) uint32 {
+func ComputeInlinedArraySlabByteSizeWithFixSizedElement(storableByteSize uint32, count uint64) uint32 {
 	storableByteSizes := make([]uint32, count)
 	for i := range storableByteSizes {
 		storableByteSizes[i] = storableByteSize

--- a/map.go
+++ b/map.go
@@ -269,7 +269,7 @@ func NewMapFromBatchData(
 		if currentSlabSize >= uint32(targetThreshold) ||
 			currentSlabSize+newElementSize > uint32(maxThreshold) {
 
-			// Generate storge id for next data slab
+			// Generate storage id for next data slab
 			nextID, err := storage.GenerateSlabID(address)
 			if err != nil {
 				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
@@ -417,7 +417,7 @@ func nextLevelMapSlabs(storage SlabStorage, address Address, slabs []MapSlab) ([
 
 	nextLevelSlabsIndex := 0
 
-	// Generate storge id
+	// Generate storage id
 	id, err := storage.GenerateSlabID(address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
@@ -451,7 +451,7 @@ func nextLevelMapSlabs(storage SlabStorage, address Address, slabs []MapSlab) ([
 				childrenCount = uint64(len(slabs) - i)
 			}
 
-			// Generate storge id for next meta data slab
+			// Generate storage id for next meta data slab
 			id, err = storage.GenerateSlabID(address)
 			if err != nil {
 				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.

--- a/map_test.go
+++ b/map_test.go
@@ -252,7 +252,7 @@ func _testMap(
 
 		stats, err := atree.GetMapStats(m)
 		require.NoError(t, err)
-		require.Equal(t, stats.SlabCount(), uint64(storage.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, stats.SlabCount(), uint64(storage.Count()))
 
 		if len(expectedValues) == 0 {
 			// Verify slab count for empty map
@@ -702,7 +702,7 @@ func TestMapHas(t *testing.T) {
 		require.NoError(t, err)
 
 		for i, k := range keysToInsert {
-			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.Uint64Value(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.Uint64Value(i))
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 		}
@@ -893,8 +893,8 @@ func TestMapRemove(t *testing.T) {
 
 		collisionKeyValues := make(map[atree.Value]atree.Value)
 		for uint64(len(collisionKeyValues)) < numOfElementsWithCollision {
-			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
+			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
 			collisionKeyValues[k] = v
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{nextDigest}})
@@ -917,7 +917,7 @@ func TestMapRemove(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		count := uint64(len(nonCollisionKeyValues) + len(collisionKeyValues)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		count := uint64(len(nonCollisionKeyValues) + len(collisionKeyValues))
 
 		// Remove all collision elements
 		for k, v := range collisionKeyValues {
@@ -974,8 +974,8 @@ func TestMapRemove(t *testing.T) {
 
 		collisionKeyValues := make(map[atree.Value]atree.Value)
 		for uint64(len(collisionKeyValues)) < numOfElementsWithCollision {
-			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
+			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
 			collisionKeyValues[k] = v
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{0}})
@@ -1000,7 +1000,7 @@ func TestMapRemove(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		count := uint64(len(nonCollisionKeyValues) + len(collisionKeyValues)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		count := uint64(len(nonCollisionKeyValues) + len(collisionKeyValues))
 
 		// Remove all collision elements
 		for k, v := range collisionKeyValues {
@@ -2289,7 +2289,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2349,7 +2349,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2411,7 +2411,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2473,7 +2473,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2536,7 +2536,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2598,7 +2598,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -2659,7 +2659,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -2742,7 +2742,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2826,7 +2826,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2921,7 +2921,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3016,7 +3016,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3111,7 +3111,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3194,7 +3194,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -3276,7 +3276,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -3360,7 +3360,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -3396,7 +3396,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -3489,7 +3489,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3583,7 +3583,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3677,7 +3677,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3771,7 +3771,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3855,7 +3855,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3915,7 +3915,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3977,7 +3977,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4039,7 +4039,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4102,7 +4102,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4163,7 +4163,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -4223,7 +4223,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -4308,7 +4308,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4394,7 +4394,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4491,7 +4491,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4588,7 +4588,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4685,7 +4685,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4770,7 +4770,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -4853,7 +4853,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -4939,7 +4939,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -4977,7 +4977,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -5072,7 +5072,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5168,7 +5168,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5264,7 +5264,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5360,7 +5360,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5445,7 +5445,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5506,7 +5506,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5570,7 +5570,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5633,7 +5633,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5697,7 +5697,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5760,7 +5760,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -5822,7 +5822,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -5906,7 +5906,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5991,7 +5991,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6087,7 +6087,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6183,7 +6183,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6279,7 +6279,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6363,7 +6363,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -6446,7 +6446,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
@@ -6531,7 +6531,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
@@ -6568,7 +6568,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
@@ -6662,7 +6662,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6757,7 +6757,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6852,7 +6852,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6947,7 +6947,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, mapCount, uint64(i))
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -7185,7 +7185,7 @@ func testMapSetRemoveRandomValues(
 
 			digests := make([]atree.Digest, digestMaxLevels)
 			for i := range digests {
-				digests[i] = atree.Digest(r.Intn(digestMaxValue)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				digests[i] = atree.Digest(r.Intn(digestMaxValue))
 			}
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -8589,10 +8589,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		childSlabIDs, childSizes, _ := atree.GetMapMetaDataSlabChildInfo(meta)
 
 		require.Equal(t, 2, len(childSlabIDs))
-		require.Equal(t, uint32(len(stored[id2])), childSizes[0]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, uint32(len(stored[id2])), childSizes[0])
 
 		const inlinedExtraDataSize = 8
-		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+atree.SlabIDLength), childSizes[1]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+atree.SlabIDLength), childSizes[1])
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -11782,8 +11782,8 @@ func TestMapEncodeDecode(t *testing.T) {
 		childSlabIDs, childSizes, _ := atree.GetMapMetaDataSlabChildInfo(meta)
 
 		require.Equal(t, 2, len(childSlabIDs))
-		require.Equal(t, uint32(len(stored[id2])), childSizes[0])                    //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		require.Equal(t, uint32(len(stored[id3])+atree.SlabIDLength), childSizes[1]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, uint32(len(stored[id2])), childSizes[0])
+		require.Equal(t, uint32(len(stored[id3])+atree.SlabIDLength), childSizes[1])
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -13594,8 +13594,8 @@ func TestMapPopIterate(t *testing.T) {
 				keyValues[k] = test_utils.NewStringValue(randStr(r, 16))
 
 				digests := []atree.Digest{
-					atree.Digest(i % 100), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-					atree.Digest(i % 5),   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					atree.Digest(i % 100),
+					atree.Digest(i % 5),
 				}
 
 				digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -13884,8 +13884,8 @@ func TestMapFromBatchData(t *testing.T) {
 			require.Nil(t, storable)
 		}
 
-		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapElementSize()-2)))
+		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2)))
 		storable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 		require.NoError(t, err)
 		require.Nil(t, storable)
@@ -13952,8 +13952,8 @@ func TestMapFromBatchData(t *testing.T) {
 		storable, err := m.Set(
 			test_utils.CompareValue,
 			test_utils.GetHashInput,
-			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))),
+			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))),
 		)
 		require.NoError(t, err)
 		require.Nil(t, storable)
@@ -14154,7 +14154,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		r := newRand(t)
 
-		maxStringSize := int(atree.MaxInlineMapKeySize() - 2) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		maxStringSize := int(atree.MaxInlineMapKeySize() - 2)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -14302,7 +14302,7 @@ func TestMapMaxInlineElement(t *testing.T) {
 	t.Parallel()
 
 	r := newRand(t)
-	maxStringSize := int(atree.MaxInlineMapKeySize() - 2) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+	maxStringSize := int(atree.MaxInlineMapKeySize() - 2)
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 	storage := newTestPersistentStorage(t)
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -14524,8 +14524,8 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapKeySize()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize())))
+		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapKeySize())))
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{atree.Digest(0)}})
 
 		existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -14551,8 +14551,8 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize()-2)))   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize()-2)))
+		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize())))
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{atree.Digest(0)}})
 
 		existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -14768,7 +14768,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -14791,7 +14791,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -14816,7 +14816,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -14841,7 +14841,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -14865,7 +14865,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -14943,7 +14943,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -14976,7 +14976,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15009,7 +15009,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15063,7 +15063,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15143,7 +15143,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15177,7 +15177,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15211,7 +15211,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15264,7 +15264,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15348,7 +15348,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15388,7 +15388,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15431,7 +15431,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15485,7 +15485,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15533,7 +15533,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					typeInfo,
 					mapCount,
 					childArrayIndex,
-					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 					useWrapperValue,
 				)
 
@@ -15567,7 +15567,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15590,7 +15590,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15614,7 +15614,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15646,7 +15646,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15679,7 +15679,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15721,7 +15721,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					typeInfo,
 					mapCount,
 					childArrayIndex,
-					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 					useWrapperValue,
 				)
 
@@ -15755,7 +15755,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15802,7 +15802,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15851,7 +15851,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15908,7 +15908,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15929,7 +15929,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				var loadedExpectedValues [][2]atree.Value
 				if i < len(childSlabIDs)-1 {
 					nextFirstKey := childFirstKeys[i+1]
-					loadedExpectedValues = expectedValues[int(nextFirstKey):] //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					loadedExpectedValues = expectedValues[int(nextFirstKey):]
 				}
 
 				testMapLoadedElements(t, m, loadedExpectedValues)
@@ -15949,7 +15949,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -15989,7 +15989,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -16033,7 +16033,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -16070,10 +16070,10 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					if len(dataSlabInfos) > 0 {
 						// Update previous slabInfo.count
-						dataSlabInfos[len(dataSlabInfos)-1].count = int(firstKey) - dataSlabInfos[len(dataSlabInfos)-1].startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+						dataSlabInfos[len(dataSlabInfos)-1].count = int(firstKey) - dataSlabInfos[len(dataSlabInfos)-1].startIndex
 					}
 
-					dataSlabInfos = append(dataSlabInfos, &slabInfo{id: slabID, startIndex: int(firstKey)}) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					dataSlabInfos = append(dataSlabInfos, &slabInfo{id: slabID, startIndex: int(firstKey)})
 				}
 			}
 
@@ -16121,7 +16121,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
 				useWrapperValue,
 			)
 
@@ -16154,15 +16154,15 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					prevDataSlabInfo := prevMetaDataSlabInfo.children[len(prevMetaDataSlabInfo.children)-1]
 
 					// Update previous metadata slab count
-					prevMetaDataSlabInfo.count = int(firstKey) - prevMetaDataSlabInfo.startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					prevMetaDataSlabInfo.count = int(firstKey) - prevMetaDataSlabInfo.startIndex
 
 					// Update previous data slab count
-					prevDataSlabInfo.count = int(firstKey) - prevDataSlabInfo.startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					prevDataSlabInfo.count = int(firstKey) - prevDataSlabInfo.startIndex
 				}
 
 				metadataSlabInfo := &slabInfo{
 					id:         slabID,
-					startIndex: int(firstKey), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					startIndex: int(firstKey),
 				}
 
 				nonRootMetadataSlab, ok := atree.GetDeltas(storage)[slabID].(*atree.MapMetaDataSlab)
@@ -16176,10 +16176,10 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					children[i] = &slabInfo{
 						id:         slabID,
-						startIndex: int(firstKey), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+						startIndex: int(firstKey),
 					}
 					if i > 0 {
-						children[i-1].count = int(firstKey) - children[i-1].startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+						children[i-1].count = int(firstKey) - children[i-1].startIndex
 					}
 				}
 
@@ -16300,12 +16300,12 @@ func createMapWithLongStringKey(
 	expectedValues := make([][2]atree.Value, count)
 	r := 'a'
 	for i := range expectedValues {
-		s := strings.Repeat(string(r), int(atree.MaxInlineMapElementSize())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		s := strings.Repeat(string(r), int(atree.MaxInlineMapElementSize()))
 
 		k := test_utils.NewStringValue(s)
 		v := test_utils.NewUint64ValueFromInteger(i)
 
-		digests := []atree.Digest{atree.Digest(i)} //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		digests := []atree.Digest{atree.Digest(i)}
 		digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 		if useWrapperValue {
@@ -16544,7 +16544,7 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for len(keyValues) < mapCount {
 			k := test_utils.NewStringValue(randStr(r, keyStringSize))
-			v := test_utils.NewStringValue(randStr(r, int(valueStringSize))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewStringValue(randStr(r, int(valueStringSize)))
 			keyValues[k] = v
 		}
 
@@ -16581,8 +16581,8 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for len(keyValues) < mapCount {
-			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			v := test_utils.NewStringValue(randStr(r, int(valueStringSize))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))
+			v := test_utils.NewStringValue(randStr(r, int(valueStringSize)))
 			keyValues[k] = v
 		}
 
@@ -16621,8 +16621,8 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for len(keyValues) < mapCount {
-			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			v := test_utils.NewStringValue(randStr(r, int(valueStringSize))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))
+			v := test_utils.NewStringValue(randStr(r, int(valueStringSize)))
 			keyValues[k] = v
 		}
 
@@ -16783,7 +16783,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()))
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent slab size
@@ -16830,7 +16830,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedStandaloneSlabSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
@@ -16878,7 +16878,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()))
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				elementByteSizesByKey[childKey] = [2]uint32{elementByteSizesByKey[childKey][0], expectedInlinedMapSize}
@@ -16956,7 +16956,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17006,7 +17006,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedStandaloneSlabSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
@@ -17060,7 +17060,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17109,7 +17109,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17190,7 +17190,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17229,7 +17229,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedStandaloneSlabSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
@@ -17269,7 +17269,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17308,7 +17308,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17423,7 +17423,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17431,7 +17431,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17508,7 +17508,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17516,7 +17516,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17524,7 +17524,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedParentSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				slabIDStorableByteSize,
-				int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(parentMap.Count()),
 			)
 			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
@@ -17585,7 +17585,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(gchildMap.Count()),
 				)
 				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17593,7 +17593,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					expectedGrandChildMapSize,
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17601,7 +17601,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedParentMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					expectedChildMapSize,
-					int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(parentMap.Count()),
 				)
 				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
@@ -17705,7 +17705,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17713,7 +17713,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17870,7 +17870,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(gchildMap.Count()),
 				)
 				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17878,14 +17878,14 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					expectedGrandChildMapSize,
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent child slab size
 				expectedParentMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 					encodedKeySize, expectedChildMapSize,
-					int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(parentMap.Count()),
 				)
 				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
@@ -17986,7 +17986,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17994,7 +17994,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18062,7 +18062,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18142,7 +18142,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18231,12 +18231,12 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
-			elementByteSizes := make([][2]uint32, int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			elementByteSizes := make([][2]uint32, int(childMap.Count()))
 			elementByteSizes[0] = [2]uint32{encodedKeySize, expectedGrandChildMapSize}
 			for i := 1; i < len(elementByteSizes); i++ {
 				elementByteSizes[i] = [2]uint32{encodedKeySize, encodedValueSize}
@@ -18312,12 +18312,12 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(gchildMap.Count()),
 				)
 				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 				// Test inlined child slab size
-				elementByteSizes := make([][2]uint32, int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				elementByteSizes := make([][2]uint32, int(childMap.Count()))
 				elementByteSizes[0] = [2]uint32{encodedKeySize, expectedGrandChildMapSize}
 				for i := 1; i < len(elementByteSizes); i++ {
 					elementByteSizes[i] = [2]uint32{encodedKeySize, encodedValueSize}
@@ -18429,7 +18429,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18437,7 +18437,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18498,7 +18498,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18506,7 +18506,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(childMap.Count()),
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18521,7 +18521,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		expectedParentMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 			encodedKeySize,
 			slabIDStorableSize,
-			int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			int(parentMap.Count()),
 		)
 		require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
@@ -18579,12 +18579,12 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				int(gchildMap.Count()),
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
-			elementByteSizes := make([][2]uint32, int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			elementByteSizes := make([][2]uint32, int(childMap.Count()))
 			elementByteSizes[0] = [2]uint32{encodedKeySize, expectedGrandChildMapSize}
 			for i := 1; i < len(elementByteSizes); i++ {
 				elementByteSizes[i] = [2]uint32{encodedKeySize, encodedValueSize}
@@ -18795,7 +18795,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					k.ByteSize(),
 					v.ByteSize(),
-					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					int(childMap.Count()),
 				)
 				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18844,7 +18844,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 					expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 						k.ByteSize(),
 						v.ByteSize(),
-						int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+						int(childMap.Count()),
 					)
 					require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18965,7 +18965,7 @@ func createMapWithEmpty2LevelChildMap(
 		expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 			ks.ByteSize(),
 			emptyInlinedMapByteSize,
-			int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			int(childMap.Count()),
 		)
 		require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -19961,5 +19961,5 @@ func newRandomDigests(r *rand.Rand, level int) []atree.Digest {
 }
 
 func newRandomDigest(r *rand.Rand) atree.Digest {
-	return atree.Digest(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+	return atree.Digest(r.Intn(256))
 }

--- a/map_test.go
+++ b/map_test.go
@@ -1713,7 +1713,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {{}:0, {}:1} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1770,7 +1770,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1826,7 +1826,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {{}: 0, {}: 1} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1879,7 +1879,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1950,7 +1950,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2008,7 +2008,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2102,7 +2102,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2156,7 +2156,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			k := test_utils.NewUint64ValueFromInteger(i)
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2519,7 +2519,7 @@ func TestMutableMapIterate(t *testing.T) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
-			newValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			newValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, newValue)
 			require.NoError(t, err)
@@ -2723,7 +2723,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -2807,7 +2807,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -3180,7 +3180,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -3262,7 +3262,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4085,7 +4085,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			testValueEqual(t, sortedKeys[i], k)
 
 			v := keyValues[k]
-			newValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			newValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, newValue)
 			require.NoError(t, err)
@@ -4289,7 +4289,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4375,7 +4375,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4756,7 +4756,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4839,7 +4839,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -5680,7 +5680,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			testValueEqual(t, keyValues[k], v)
 
-			newValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			newValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, newValue)
 			require.NoError(t, err)
@@ -5887,7 +5887,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -5972,7 +5972,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -6349,7 +6349,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -6432,7 +6432,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			childNewValue := test_utils.NewUint64ValueFromInteger(i)
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -16303,7 +16303,7 @@ func createMapWithLongStringKey(
 		s := strings.Repeat(string(r), int(atree.MaxInlineMapElementSize())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		k := test_utils.NewStringValue(s)
-		v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.NewUint64ValueFromInteger(i)
 
 		digests := []atree.Digest{atree.Digest(i)} //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -16346,7 +16346,7 @@ func createMapWithSimpleValues(
 	expectedValues := make([][2]atree.Value, count)
 	r := rune('a')
 	for i := range expectedValues {
-		k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		k := test_utils.NewUint64ValueFromInteger(i)
 		v := test_utils.NewStringValue(strings.Repeat(string(r), 20))
 
 		digests := newDigests(i)
@@ -16397,7 +16397,7 @@ func createMapWithChildArrayValues(
 
 		expectedChildValues := make([]atree.Value, childArrayCount)
 		for j := range expectedChildValues {
-			v := test_utils.Uint64Value(j) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewUint64ValueFromInteger(j)
 
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -16405,7 +16405,7 @@ func createMapWithChildArrayValues(
 			expectedChildValues[j] = v
 		}
 
-		k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		k := test_utils.NewUint64ValueFromInteger(i)
 		v := childArray
 
 		slabIDs[i] = childArray.SlabID()
@@ -16455,7 +16455,7 @@ func createMapWithSimpleAndChildArrayValues(
 	r := 'a'
 	for i := range expectedValues {
 
-		k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		k := test_utils.NewUint64ValueFromInteger(i)
 
 		digests := newDigests(i)
 		digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -16467,7 +16467,7 @@ func createMapWithSimpleAndChildArrayValues(
 
 			expectedChildValues := make([]atree.Value, childArrayCount)
 			for j := range expectedChildValues {
-				v := test_utils.Uint64Value(j) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				v := test_utils.NewUint64ValueFromInteger(j)
 				err = childArray.Append(v)
 				require.NoError(t, err)
 

--- a/map_test.go
+++ b/map_test.go
@@ -854,7 +854,7 @@ func TestMapRemove(t *testing.T) {
 		// Test:
 		// - data slab refers to an external slab containing elements with hash collision
 		// - last collision element is inlined after all other collision elements are removed
-		// - data slab overflows with inlined colllision element
+		// - data slab overflows with inlined collision element
 		// - data slab splits
 
 		atree.SetThreshold(512)
@@ -952,7 +952,7 @@ func TestMapRemove(t *testing.T) {
 		// Test:
 		// - data slab refers to an external slab containing elements with hash collision
 		// - last collision element is inlined after all other collision elements are removed
-		// - data slab overflows with inlined colllision element
+		// - data slab overflows with inlined collision element
 		// - data slab splits
 
 		atree.SetThreshold(512)
@@ -16084,7 +16084,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 				slabToBeRemoved := dataSlabInfos[index]
 
-				// Update startIndex for all subsequence data slabs
+				// Update startIndex for all subsequent data slabs
 				for i := index + 1; i < len(dataSlabInfos); i++ {
 					dataSlabInfos[i].startIndex -= slabToBeRemoved.count
 				}
@@ -16212,7 +16212,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					count := slabInfoToBeRemoved.count
 
-					// Update startIndex for subsequence metadata slabs
+					// Update startIndex for subsequent metadata slabs
 					for _, slabInfo := range metadataSlabInfos[metadataSlabIndex+1:] {
 						slabInfo.startIndex -= count
 
@@ -16239,7 +16239,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					count := slabInfoToBeRemoved.count
 
-					// Update startIndex for all subsequence data slabs in this metadata slab info
+					// Update startIndex for all subsequent data slabs in this metadata slab info
 					for _, childSlabInfo := range metadataSlabInfo.children[dataSlabIndex+1:] {
 						childSlabInfo.startIndex -= count
 					}
@@ -16249,7 +16249,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					metadataSlabInfo.count -= count
 
-					// Update startIndex for all subsequence metadata slabs.
+					// Update startIndex for all subsequent metadata slabs.
 					for _, slabInfo := range metadataSlabInfos[metadataSlabIndex+1:] {
 						slabInfo.startIndex -= count
 

--- a/map_test.go
+++ b/map_test.go
@@ -252,7 +252,7 @@ func _testMap(
 
 		stats, err := atree.GetMapStats(m)
 		require.NoError(t, err)
-		require.Equal(t, stats.SlabCount(), uint64(storage.Count()))
+		require.Equal(t, stats.SlabCount(), uint64(storage.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		if len(expectedValues) == 0 {
 			// Verify slab count for empty map
@@ -411,7 +411,7 @@ func TestMapSetAndGet(t *testing.T) {
 		for len(keyValues) < mapCount {
 			slen := r.Intn(keyStringMaxSize)
 			k := test_utils.NewStringValue(randStr(r, slen))
-			v := randomValue(r, int(atree.MaxInlineMapElementSize()))
+			v := randomValue(r, atree.MaxInlineMapElementSize())
 			keyValues[k] = v
 		}
 
@@ -547,7 +547,7 @@ func TestMapSetAndGet(t *testing.T) {
 
 func TestMapGetKeyNotFound(t *testing.T) {
 	t.Run("no collision", func(t *testing.T) {
-		const mapCount = 1024
+		const mapCount = uint64(1024)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -582,7 +582,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 	})
 
 	t.Run("collision", func(t *testing.T) {
-		const mapCount = 256
+		const mapCount = uint64(256)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -625,7 +625,7 @@ func TestMapGetKeyNotFound(t *testing.T) {
 	})
 
 	t.Run("collision group", func(t *testing.T) {
-		const mapCount = 256
+		const mapCount = uint64(256)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -702,7 +702,7 @@ func TestMapHas(t *testing.T) {
 		require.NoError(t, err)
 
 		for i, k := range keysToInsert {
-			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.Uint64Value(i))
+			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.Uint64Value(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 		}
@@ -832,7 +832,7 @@ func TestMapRemove(t *testing.T) {
 
 			testMap(t, storage, typeInfo, address, m, tc.keyValues, nil, false)
 
-			count := len(tc.keyValues)
+			count := uint64(len(tc.keyValues))
 
 			// Remove all elements
 			for k, v := range tc.keyValues {
@@ -843,7 +843,7 @@ func TestMapRemove(t *testing.T) {
 
 				require.True(t, test_utils.CompareTypeInfo(typeInfo, m.Type()))
 				require.Equal(t, address, m.Address())
-				require.Equal(t, uint64(count), m.Count())
+				require.Equal(t, count, m.Count())
 			}
 
 			testEmptyMap(t, storage, typeInfo, address, m)
@@ -861,9 +861,9 @@ func TestMapRemove(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			numOfElementsBeforeCollision = 54
-			numOfElementsWithCollision   = 10
-			numOfElementsAfterCollision  = 1
+			numOfElementsBeforeCollision = uint64(54)
+			numOfElementsWithCollision   = uint64(10)
+			numOfElementsAfterCollision  = uint64(1)
 		)
 
 		digesterBuilder := &mockDigesterBuilder{}
@@ -892,9 +892,9 @@ func TestMapRemove(t *testing.T) {
 		}
 
 		collisionKeyValues := make(map[atree.Value]atree.Value)
-		for len(collisionKeyValues) < numOfElementsWithCollision {
-			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
-			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
+		for uint64(len(collisionKeyValues)) < numOfElementsWithCollision {
+			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			collisionKeyValues[k] = v
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{nextDigest}})
@@ -917,7 +917,7 @@ func TestMapRemove(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		count := len(nonCollisionKeyValues) + len(collisionKeyValues)
+		count := uint64(len(nonCollisionKeyValues) + len(collisionKeyValues)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		// Remove all collision elements
 		for k, v := range collisionKeyValues {
@@ -928,7 +928,7 @@ func TestMapRemove(t *testing.T) {
 
 			require.True(t, test_utils.CompareTypeInfo(typeInfo, m.Type()))
 			require.Equal(t, address, m.Address())
-			require.Equal(t, uint64(count), m.Count())
+			require.Equal(t, count, m.Count())
 		}
 
 		testMap(t, storage, typeInfo, address, m, nonCollisionKeyValues, nil, false)
@@ -942,7 +942,7 @@ func TestMapRemove(t *testing.T) {
 
 			require.True(t, test_utils.CompareTypeInfo(typeInfo, m.Type()))
 			require.Equal(t, address, m.Address())
-			require.Equal(t, uint64(count), m.Count())
+			require.Equal(t, count, m.Count())
 		}
 
 		testEmptyMap(t, storage, typeInfo, address, m)
@@ -959,8 +959,8 @@ func TestMapRemove(t *testing.T) {
 		defer atree.SetThreshold(1024)
 
 		const (
-			numOfElementsWithCollision    = 10
-			numOfElementsWithoutCollision = 35
+			numOfElementsWithCollision    = uint64(10)
+			numOfElementsWithoutCollision = uint64(35)
 		)
 
 		digesterBuilder := &mockDigesterBuilder{}
@@ -973,9 +973,9 @@ func TestMapRemove(t *testing.T) {
 		require.NoError(t, err)
 
 		collisionKeyValues := make(map[atree.Value]atree.Value)
-		for len(collisionKeyValues) < numOfElementsWithCollision {
-			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
-			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2))
+		for uint64(len(collisionKeyValues)) < numOfElementsWithCollision {
+			k := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewStringValue(randStr(r, int(atree.MaxInlineMapKeySize())-2)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			collisionKeyValues[k] = v
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{0}})
@@ -1000,7 +1000,7 @@ func TestMapRemove(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		count := len(nonCollisionKeyValues) + len(collisionKeyValues)
+		count := uint64(len(nonCollisionKeyValues) + len(collisionKeyValues)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		// Remove all collision elements
 		for k, v := range collisionKeyValues {
@@ -1011,7 +1011,7 @@ func TestMapRemove(t *testing.T) {
 
 			require.True(t, test_utils.CompareTypeInfo(typeInfo, m.Type()))
 			require.Equal(t, address, m.Address())
-			require.Equal(t, uint64(count), m.Count())
+			require.Equal(t, count, m.Count())
 		}
 
 		testMap(t, storage, typeInfo, address, m, nonCollisionKeyValues, nil, false)
@@ -1025,14 +1025,14 @@ func TestMapRemove(t *testing.T) {
 
 			require.True(t, test_utils.CompareTypeInfo(typeInfo, m.Type()))
 			require.Equal(t, address, m.Address())
-			require.Equal(t, uint64(count), m.Count())
+			require.Equal(t, count, m.Count())
 		}
 
 		testEmptyMap(t, storage, typeInfo, address, m)
 	})
 
 	t.Run("no collision key not found", func(t *testing.T) {
-		const mapCount = 1024
+		const mapCount = uint64(1024)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -1068,7 +1068,7 @@ func TestMapRemove(t *testing.T) {
 	})
 
 	t.Run("collision key not found", func(t *testing.T) {
-		const mapCount = 256
+		const mapCount = uint64(256)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -1259,10 +1259,10 @@ func TestReadOnlyMapIterate(t *testing.T) {
 				keyValues[k] = v
 
 				digests := []atree.Digest{
-					atree.Digest(r.Intn(256)),
-					atree.Digest(r.Intn(256)),
-					atree.Digest(r.Intn(256)),
-					atree.Digest(r.Intn(256)),
+					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				}
 				digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -1500,8 +1500,8 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		require.False(t, childMapKey.Inlined())
 
 		// Inserting elements into childMapKey so it can't be inlined
-		const count = 20
-		for i := range count {
+		const mapCount = uint64(20)
+		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := childMapKey.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -1561,7 +1561,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		require.True(t, childMap.Inlined())
 
 		// Inserting elements into childMap until it is no longer inlined
-		for i := 0; childMap.Inlined(); i++ {
+		for i := uint64(0); childMap.Inlined(); i++ {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -1609,8 +1609,8 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		require.False(t, childMapKey.Inlined())
 
 		// Inserting elements into childMap so it can't be inlined.
-		const count = 20
-		for i := range count {
+		const mapCount = uint64(20)
+		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := childMapKey.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -1666,7 +1666,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		require.True(t, childMap.Inlined())
 
 		// Inserting elements into childMap until it is no longer inlined
-		for i := 0; childMap.Inlined(); i++ {
+		for i := uint64(0); childMap.Inlined(); i++ {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -1717,7 +1717,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {{}:0, {}:1} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i)
+			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1774,7 +1774,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i)
+			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1830,7 +1830,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {{}: 0, {}: 1} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i)
+			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1883,7 +1883,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i)
+			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -1925,8 +1925,8 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		childMapKey1, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		const count = 20
-		for i := range count {
+		const mapCount = uint64(20)
+		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -1939,7 +1939,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		childMapKey2, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		for i := range count {
+		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -1954,7 +1954,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i)
+			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2012,7 +2012,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i)
+			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2022,7 +2022,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		for i := 0; childMap1.Inlined(); i++ {
+		for i := uint64(0); childMap1.Inlined(); i++ {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -2031,7 +2031,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		for i := 0; childMap2.Inlined(); i++ {
+		for i := uint64(0); childMap2.Inlined(); i++ {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -2077,8 +2077,8 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		childMapKey1, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		count := 20
-		for i := range count {
+		const mapCount = uint64(20)
+		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -2091,7 +2091,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		childMapKey2, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		for i := range count {
+		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -2106,7 +2106,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMapKey1, childMapKey2} {
 			k := test_utils.NewHashableMap(m)
-			v := test_utils.Uint64Value(i)
+			v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2160,7 +2160,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 
 		// parentMap {0: {}, 1:{}} with all elements in the same collision group
 		for i, m := range []*atree.OrderedMap{childMap1, childMap2} {
-			k := test_utils.Uint64Value(i)
+			k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			digests := []atree.Digest{atree.Digest(0)}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -2170,7 +2170,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		for i := 0; childMap1.Inlined(); i++ {
+		for i := uint64(0); childMap1.Inlined(); i++ {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -2179,7 +2179,7 @@ func TestMutateElementFromReadOnlyMapIterator(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		for i := 0; childMap2.Inlined(); i++ {
+		for i := uint64(0); childMap2.Inlined(); i++ {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i)
 
@@ -2243,7 +2243,7 @@ func TestMutableMapIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 15
+		const mapCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -2266,7 +2266,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2293,7 +2293,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2303,7 +2303,7 @@ func TestMutableMapIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 25
+		const mapCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -2326,7 +2326,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 			keyValues[k] = v
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2353,7 +2353,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2363,7 +2363,7 @@ func TestMutableMapIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 15
+		const mapCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -2386,7 +2386,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2415,7 +2415,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2425,7 +2425,7 @@ func TestMutableMapIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 25
+		const mapCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -2448,7 +2448,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2477,7 +2477,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2487,7 +2487,7 @@ func TestMutableMapIterate(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 10
+		const mapCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -2512,7 +2512,7 @@ func TestMutableMapIterate(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -2523,7 +2523,7 @@ func TestMutableMapIterate(t *testing.T) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
-			newValue := test_utils.Uint64Value(i)
+			newValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, newValue)
 			require.NoError(t, err)
@@ -2540,7 +2540,7 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2548,7 +2548,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate collision primitive values, 1 level", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -2568,7 +2568,7 @@ func TestMutableMapIterate(t *testing.T) {
 			v := test_utils.Uint64Value(i * 2)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -2584,7 +2584,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -2603,14 +2603,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision primitive values, 4 levels", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -2630,10 +2630,10 @@ func TestMutableMapIterate(t *testing.T) {
 			v := test_utils.Uint64Value(i * 2)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -2649,7 +2649,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -2668,14 +2668,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount = 15
+			mapCount = uint64(15)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -2712,7 +2712,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2721,7 +2721,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (updating elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -2732,7 +2732,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -2751,7 +2751,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2759,7 +2759,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount = 35
+			mapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -2796,7 +2796,7 @@ func TestMutableMapIterate(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2805,7 +2805,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (updating elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -2816,7 +2816,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -2835,7 +2835,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2843,9 +2843,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 1
-			mutatedChildMapCount = 5
+			mapCount             = uint64(15)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(5)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -2881,14 +2881,14 @@ func TestMutableMapIterate(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2897,14 +2897,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -2921,7 +2921,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -2930,7 +2930,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2938,9 +2938,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 35
-			childMapCount        = 1
-			mutatedChildMapCount = 5
+			mapCount             = uint64(35)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(5)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -2976,14 +2976,14 @@ func TestMutableMapIterate(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -2992,14 +2992,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -3016,7 +3016,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3025,7 +3025,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3033,9 +3033,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 10
-			mutatedChildMapCount = 1
+			mapCount             = uint64(15)
+			childMapCount        = uint64(10)
+			mutatedChildMapCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -3071,14 +3071,14 @@ func TestMutableMapIterate(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3087,14 +3087,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -3111,7 +3111,7 @@ func TestMutableMapIterate(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3120,7 +3120,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3128,7 +3128,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("mutate collision inlined container, 1 level", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -3157,7 +3157,7 @@ func TestMutableMapIterate(t *testing.T) {
 			k := test_utils.Uint64Value(i)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -3176,7 +3176,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -3190,7 +3190,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -3204,14 +3204,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision inlined container, 4 levels", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -3240,10 +3240,10 @@ func TestMutableMapIterate(t *testing.T) {
 			k := test_utils.Uint64Value(i)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -3262,7 +3262,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -3276,7 +3276,7 @@ func TestMutableMapIterate(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -3290,14 +3290,14 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container", func(t *testing.T) {
 		const (
-			mapCount        = 15
+			mapCount        = uint64(15)
 			valueStringSize = 16
 		)
 
@@ -3313,7 +3313,6 @@ func TestMutableMapIterate(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
-		i := uint64(0)
 		for i := range mapCount {
 			ck := test_utils.Uint64Value(0)
 			cv := test_utils.NewStringValue(randStr(r, valueStringSize))
@@ -3337,7 +3336,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3346,7 +3345,7 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i = uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -3375,12 +3374,12 @@ func TestMutableMapIterate(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
 		// Iterate and mutate child map (removing elements)
-		i = uint64(0)
+		i = 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
@@ -3411,16 +3410,16 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 1
-			mutatedChildMapCount = 35
+			mapCount             = uint64(15)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -3455,14 +3454,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3471,14 +3470,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -3495,7 +3494,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -3504,7 +3503,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3512,9 +3511,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 5
-			mutatedChildMapCount = 35
+			mapCount             = uint64(15)
+			childMapCount        = uint64(5)
+			mutatedChildMapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -3549,14 +3548,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3565,14 +3564,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -3589,7 +3588,7 @@ func TestMutableMapIterate(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -3598,7 +3597,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3606,9 +3605,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 35
-			mutatedChildMapCount = 1
+			mapCount             = uint64(15)
+			childMapCount        = uint64(35)
+			mutatedChildMapCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -3643,14 +3642,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3659,14 +3658,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -3683,7 +3682,7 @@ func TestMutableMapIterate(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3692,7 +3691,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3700,9 +3699,9 @@ func TestMutableMapIterate(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 35
-			mutatedChildMapCount = 10
+			mapCount             = uint64(15)
+			childMapCount        = uint64(35)
+			mutatedChildMapCount = uint64(10)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -3737,14 +3736,14 @@ func TestMutableMapIterate(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3753,14 +3752,14 @@ func TestMutableMapIterate(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.Iterate(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value, v atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 			testValueEqual(t, keyValues[k], v)
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -3777,7 +3776,7 @@ func TestMutableMapIterate(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -3786,7 +3785,7 @@ func TestMutableMapIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3820,7 +3819,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 15
+		const mapCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -3843,7 +3842,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -3870,7 +3869,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3880,7 +3879,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 25
+		const mapCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -3903,7 +3902,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 			keyValues[k] = v
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -3930,7 +3929,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -3940,7 +3939,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 15
+		const mapCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -3963,7 +3962,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -3992,7 +3991,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4002,7 +4001,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 25
+		const mapCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -4025,7 +4024,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -4054,7 +4053,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4064,7 +4063,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 10
+		const mapCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -4089,7 +4088,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -4100,7 +4099,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			testValueEqual(t, sortedKeys[i], k)
 
 			v := keyValues[k]
-			newValue := test_utils.Uint64Value(i)
+			newValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, newValue)
 			require.NoError(t, err)
@@ -4117,7 +4116,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4125,7 +4124,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate collision primitive values, 1 level", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -4145,7 +4144,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			v := test_utils.Uint64Value(i * 2)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -4160,7 +4159,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4179,14 +4178,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision primitive values, 4 levels", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -4206,10 +4205,10 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			v := test_utils.Uint64Value(i * 2)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -4224,7 +4223,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4243,14 +4242,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount = 15
+			mapCount = uint64(15)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -4287,7 +4286,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4296,7 +4295,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (updating elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4309,7 +4308,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4328,7 +4327,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4336,7 +4335,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount = 35
+			mapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -4373,7 +4372,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4382,7 +4381,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (updating elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4395,7 +4394,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4414,7 +4413,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4422,9 +4421,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 1
-			mutatedChildMapCount = 5
+			mapCount             = uint64(15)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(5)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -4460,14 +4459,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4476,7 +4475,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4485,7 +4484,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -4502,7 +4501,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -4511,7 +4510,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4519,9 +4518,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 35
-			childMapCount        = 1
-			mutatedChildMapCount = 5
+			mapCount             = uint64(35)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(5)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -4557,14 +4556,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4573,7 +4572,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4582,7 +4581,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -4599,7 +4598,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -4608,7 +4607,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4616,9 +4615,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 10
-			mutatedChildMapCount = 1
+			mapCount             = uint64(15)
+			childMapCount        = uint64(10)
+			mutatedChildMapCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -4654,14 +4653,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4670,7 +4669,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4679,7 +4678,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -4696,7 +4695,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -4705,7 +4704,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4713,7 +4712,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("mutate collision inlined container, 1 level", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -4742,7 +4741,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			k := test_utils.Uint64Value(i)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -4761,7 +4760,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4777,7 +4776,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4791,14 +4790,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision inlined container, 4 levels", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -4827,10 +4826,10 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			k := test_utils.Uint64Value(i)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -4848,7 +4847,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		// Sort keys by digest
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4864,7 +4863,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -4878,14 +4877,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container", func(t *testing.T) {
 		const (
-			mapCount        = 15
+			mapCount        = uint64(15)
 			valueStringSize = 16
 		)
 
@@ -4901,7 +4900,6 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
-		i := uint64(0)
 		for i := range mapCount {
 			ck := test_utils.Uint64Value(0)
 			cv := test_utils.NewStringValue(randStr(r, valueStringSize))
@@ -4925,7 +4923,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -4934,7 +4932,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i = uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -4965,12 +4963,12 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
 		// Iterate and mutate child map (removing elements)
-		i = uint64(0)
+		i = 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -5003,16 +5001,16 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 1
-			mutatedChildMapCount = 35
+			mapCount             = uint64(15)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -5047,14 +5045,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5063,7 +5061,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -5072,7 +5070,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -5089,7 +5087,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -5098,7 +5096,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5106,9 +5104,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 5
-			mutatedChildMapCount = 35
+			mapCount             = uint64(15)
+			childMapCount        = uint64(5)
+			mutatedChildMapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -5143,14 +5141,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5159,7 +5157,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -5168,7 +5166,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -5185,7 +5183,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -5194,7 +5192,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5202,9 +5200,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 35
-			mutatedChildMapCount = 1
+			mapCount             = uint64(15)
+			childMapCount        = uint64(35)
+			mutatedChildMapCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -5239,14 +5237,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5255,7 +5253,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -5264,7 +5262,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -5281,7 +5279,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -5290,7 +5288,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5298,9 +5296,9 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 35
-			mutatedChildMapCount = 10
+			mapCount             = uint64(15)
+			childMapCount        = uint64(35)
+			mutatedChildMapCount = uint64(10)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -5335,14 +5333,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5351,7 +5349,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateKeys(test_utils.CompareValue, test_utils.GetHashInput, func(k atree.Value) (resume bool, err error) {
 			testValueEqual(t, sortedKeys[i], k)
 
@@ -5360,7 +5358,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -5377,7 +5375,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -5386,7 +5384,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5420,7 +5418,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 15
+		const mapCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5443,7 +5441,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5471,7 +5469,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5481,7 +5479,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 25
+		const mapCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5504,7 +5502,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 			keyValues[k] = v
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5532,7 +5530,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5542,7 +5540,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 15
+		const mapCount = uint64(15)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5565,7 +5563,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5596,7 +5594,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5606,7 +5604,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 25
+		const mapCount = uint64(25)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5629,7 +5627,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5659,7 +5657,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5669,7 +5667,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 10
+		const mapCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -5694,7 +5692,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			keyValues[k] = v
 			sortedKeys[i] = k
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		// Sort keys by digest
@@ -5706,7 +5704,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			testValueEqual(t, keyValues[k], v)
 
-			newValue := test_utils.Uint64Value(i)
+			newValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, newValue)
 			require.NoError(t, err)
@@ -5723,7 +5721,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, mapCount, i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5731,7 +5729,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate collision primitive values, 1 level", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -5751,7 +5749,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			v := test_utils.Uint64Value(i * 2)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -5767,7 +5765,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -5787,14 +5785,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision primitive values, 4 levels", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -5814,10 +5812,10 @@ func TestMutableMapIterateValues(t *testing.T) {
 			v := test_utils.Uint64Value(i * 2)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -5833,7 +5831,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -5853,14 +5851,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount = 15
+			mapCount = uint64(15)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -5897,7 +5895,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5906,7 +5904,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (updating elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -5918,7 +5916,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -5937,7 +5935,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5945,7 +5943,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount = 35
+			mapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -5982,7 +5980,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -5991,7 +5989,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (updating elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6003,7 +6001,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, childMap.Inlined())
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -6022,7 +6020,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6030,9 +6028,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 1
-			mutatedChildMapCount = 5
+			mapCount             = uint64(15)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(5)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6068,14 +6066,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6084,7 +6082,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6092,7 +6090,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6109,7 +6107,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6118,7 +6116,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6126,9 +6124,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 35
-			childMapCount        = 1
-			mutatedChildMapCount = 5
+			mapCount             = uint64(35)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(5)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6164,14 +6162,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6180,7 +6178,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6188,7 +6186,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6205,7 +6203,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6214,7 +6212,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6222,9 +6220,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 10
-			mutatedChildMapCount = 1
+			mapCount             = uint64(15)
+			childMapCount        = uint64(10)
+			mutatedChildMapCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6260,14 +6258,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
 
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6276,7 +6274,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6284,7 +6282,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6301,7 +6299,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6310,7 +6308,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6318,7 +6316,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("mutate collision inlined container, 1 level", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -6347,7 +6345,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			k := test_utils.Uint64Value(i)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -6366,7 +6364,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6381,7 +6379,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -6395,14 +6393,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate collision inlined container, 4 levels", func(t *testing.T) {
 		const (
-			mapCount = 1024
+			mapCount = uint64(1024)
 		)
 
 		r := newRand(t)
@@ -6431,10 +6429,10 @@ func TestMutableMapIterateValues(t *testing.T) {
 			k := test_utils.Uint64Value(i)
 
 			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
-				atree.Digest(r.Intn(256)),
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
@@ -6453,7 +6451,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate key value pairs
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6468,7 +6466,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 			require.True(t, ok)
 
 			childKey := test_utils.Uint64Value(0)
-			childNewValue := test_utils.Uint64Value(i)
+			childNewValue := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, childKey, childNewValue)
 			require.NoError(t, err)
@@ -6482,14 +6480,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, i, uint64(mapCount))
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, sortedKeys, false)
 	})
 
 	t.Run("mutate inlined container", func(t *testing.T) {
 		const (
-			mapCount        = 15
+			mapCount        = uint64(15)
 			valueStringSize = 16
 		)
 
@@ -6505,7 +6503,6 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
-		i := uint64(0)
 		for i := range mapCount {
 			ck := test_utils.Uint64Value(0)
 			cv := test_utils.NewStringValue(randStr(r, valueStringSize))
@@ -6529,7 +6526,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6538,7 +6535,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i = uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6568,12 +6565,12 @@ func TestMutableMapIterateValues(t *testing.T) {
 			return true, nil
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 
 		// Iterate and mutate child map (removing elements)
-		i = uint64(0)
+		i = 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6605,16 +6602,16 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 1
-			mutatedChildMapCount = 35
+			mapCount             = uint64(15)
+			childMapCount        = uint64(1)
+			mutatedChildMapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6649,14 +6646,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6665,7 +6662,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6673,7 +6670,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6690,7 +6687,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -6699,7 +6696,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6707,9 +6704,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 5
-			mutatedChildMapCount = 35
+			mapCount             = uint64(15)
+			childMapCount        = uint64(5)
+			mutatedChildMapCount = uint64(35)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6744,14 +6741,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6760,7 +6757,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6768,7 +6765,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6785,7 +6782,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				expectedChildMapValues[childKey] = childValue
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			i++
@@ -6794,7 +6791,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6802,9 +6799,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 35
-			mutatedChildMapCount = 1
+			mapCount             = uint64(15)
+			childMapCount        = uint64(35)
+			mutatedChildMapCount = uint64(1)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6839,14 +6836,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6855,7 +6852,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6863,7 +6860,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6880,7 +6877,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6889,7 +6886,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6897,9 +6894,9 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
 		const (
-			mapCount             = 15
-			childMapCount        = 35
-			mutatedChildMapCount = 10
+			mapCount             = uint64(15)
+			childMapCount        = uint64(35)
+			mutatedChildMapCount = uint64(10)
 		)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -6934,14 +6931,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
 			require.NoError(t, err)
 			require.Nil(t, existingStorable)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			keyValues[k] = childMapValues
 			sortedKeys[i] = k
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.True(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -6950,7 +6947,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		sort.Stable(keysByDigest{sortedKeys, digesterBuilder})
 
 		// Iterate and mutate child map (inserting elements)
-		i := uint64(0)
+		i := 0
 		err = m.IterateValues(test_utils.CompareValue, test_utils.GetHashInput, func(v atree.Value) (resume bool, err error) {
 			k := sortedKeys[i]
 
@@ -6958,7 +6955,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			childMap, ok := v.(*atree.OrderedMap)
 			require.True(t, ok)
-			require.Equal(t, uint64(childMapCount), childMap.Count())
+			require.Equal(t, childMapCount, childMap.Count())
 			require.False(t, childMap.Inlined())
 
 			expectedChildMapValues, ok := keyValues[k].(test_utils.ExpectedMapValue)
@@ -6975,7 +6972,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 				delete(expectedChildMapValues, childKey)
 			}
 
-			require.Equal(t, uint64(mutatedChildMapCount), childMap.Count())
+			require.Equal(t, mutatedChildMapCount, childMap.Count())
 			require.True(t, childMap.Inlined())
 
 			i++
@@ -6984,7 +6981,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, uint64(mapCount), i)
+		require.Equal(t, mapCount, uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		require.False(t, IsMapRootDataSlab(m))
 
 		testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
@@ -7006,7 +7003,7 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 	uniqueFirstLevelDigests := make(map[atree.Digest]bool, mockDigestCount)
 	firstLevelDigests := make([]atree.Digest, 0, mockDigestCount)
 	for len(firstLevelDigests) < mockDigestCount {
-		d := atree.Digest(uint64(r.Intn(256)))
+		d := atree.Digest(uint64(r.Intn(256))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		if !uniqueFirstLevelDigests[d] {
 			uniqueFirstLevelDigests[d] = true
 			firstLevelDigests = append(firstLevelDigests, d)
@@ -7018,7 +7015,7 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 		digests := make([]atree.Digest, maxDigestLevel)
 		digests[0] = firstLevelDigests[i]
 		for j := 1; j < maxDigestLevel; j++ {
-			digests[j] = atree.Digest(uint64(r.Intn(256)))
+			digests[j] = atree.Digest(uint64(r.Intn(256))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 		digestsGroup[i] = digests
 	}
@@ -7105,7 +7102,7 @@ func testMapRandomHashCollision(t *testing.T, r *rand.Rand, maxDigestLevel int) 
 
 			digests := make([]atree.Digest, maxDigestLevel)
 			for i := range digests {
-				digests[i] = atree.Digest(r.Intn(256))
+				digests[i] = atree.Digest(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -7217,12 +7214,12 @@ func testMapSetRemoveRandomValues(
 
 		case MapSetOp:
 
-			k := randomValue(r, int(atree.MaxInlineMapElementSize()))
-			v := randomValue(r, int(atree.MaxInlineMapElementSize()))
+			k := randomValue(r, atree.MaxInlineMapElementSize())
+			v := randomValue(r, atree.MaxInlineMapElementSize())
 
 			digests := make([]atree.Digest, digestMaxLevels)
 			for i := range digests {
-				digests[i] = atree.Digest(r.Intn(digestMaxValue))
+				digests[i] = atree.Digest(r.Intn(digestMaxValue)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -7366,7 +7363,7 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapCount = 1
+		const mapCount = uint64(1)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -7440,7 +7437,7 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount - 1 {
@@ -7641,7 +7638,7 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -7815,7 +7812,7 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -8039,7 +8036,7 @@ func TestMapDecodeV0(t *testing.T) {
 
 		digesterBuilder := &mockDigesterBuilder{}
 
-		const mapCount = 20
+		const mapCount = uint64(20)
 		keyValues := make(map[atree.Value]atree.Value)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -8331,7 +8328,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 1
+		const mapCount = uint64(1)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -8346,7 +8343,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -8421,7 +8418,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount - 1 {
@@ -8461,7 +8458,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -8626,10 +8623,10 @@ func TestMapEncodeDecode(t *testing.T) {
 		childSlabIDs, childSizes, _ := atree.GetMapMetaDataSlabChildInfo(meta)
 
 		require.Equal(t, 2, len(childSlabIDs))
-		require.Equal(t, uint32(len(stored[id2])), childSizes[0])
+		require.Equal(t, uint32(len(stored[id2])), childSizes[0]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		const inlinedExtraDataSize = 8
-		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+atree.SlabIDLength), childSizes[1])
+		require.Equal(t, uint32(len(stored[id3])-inlinedExtraDataSize+atree.SlabIDLength), childSizes[1]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -8656,7 +8653,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount {
@@ -8686,7 +8683,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -8844,7 +8841,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount {
@@ -8881,7 +8878,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -9034,7 +9031,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount {
@@ -9074,7 +9071,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: test_utils.ExpectedMapValue{gck: gcv}}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -9299,7 +9296,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount {
@@ -9353,7 +9350,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: test_utils.ExpectedMapValue{gck: gcv}}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -9568,7 +9565,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount {
@@ -9598,7 +9595,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 10}) // inlined maps index 2-9
@@ -10055,7 +10052,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount {
@@ -10097,7 +10094,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 10}) // inlined maps index 2-9
@@ -10532,7 +10529,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -10548,7 +10545,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = v
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -10719,7 +10716,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -10735,7 +10732,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = v
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -10956,7 +10953,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 20
+		const mapCount = uint64(20)
 		keyValues := make(map[atree.Value]atree.Value)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
@@ -10972,7 +10969,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = v
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -11185,7 +11182,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount - 1 {
@@ -11210,7 +11207,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 
 		expectedChildMapValues := test_utils.ExpectedMapValue{}
-		for i := range 2 {
+		for i := range uint64(2) {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.NewStringValue(strings.Repeat("b", 22))
 
@@ -11233,7 +11230,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		// root slab (data slab) ID
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -11364,7 +11361,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount - 1 {
 			k := test_utils.Uint64Value(i)
@@ -11423,7 +11420,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		// root slab (data slab) ID
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -11594,7 +11591,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount - 1 {
@@ -11642,7 +11639,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 		id2 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 2})
@@ -11819,8 +11816,8 @@ func TestMapEncodeDecode(t *testing.T) {
 		childSlabIDs, childSizes, _ := atree.GetMapMetaDataSlabChildInfo(meta)
 
 		require.Equal(t, 2, len(childSlabIDs))
-		require.Equal(t, uint32(len(stored[id2])), childSizes[0])
-		require.Equal(t, uint32(len(stored[id3])+atree.SlabIDLength), childSizes[1])
+		require.Equal(t, uint32(len(stored[id2])), childSizes[0])                    //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		require.Equal(t, uint32(len(stored[id3])+atree.SlabIDLength), childSizes[1]) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		// Decode data to new storage
 		storage2 := newTestPersistentStorageWithData(t, stored)
@@ -11846,7 +11843,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		r := 'a'
 		for i := range mapCount - 1 {
@@ -11904,7 +11901,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		// parent map root slab ID
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
@@ -12179,7 +12176,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount {
 
@@ -12207,7 +12204,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = test_utils.ExpectedMapValue{ck: cv}
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12338,7 +12335,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for i := range mapCount {
 			expectedChildMapVaues := test_utils.ExpectedMapValue{}
@@ -12379,7 +12376,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapVaues
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12516,7 +12513,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		// fields are ordered differently because of different seed.
 		for i := range mapCount {
@@ -12558,7 +12555,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12697,7 +12694,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 3
+		const mapCount = uint64(3)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 
 		for i := range mapCount {
@@ -12752,7 +12749,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -12952,7 +12949,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 2
+		const mapCount = uint64(2)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		// fields are ordered differently because of different seed.
 		for i := range mapCount {
@@ -12996,7 +12993,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -13152,7 +13149,7 @@ func TestMapEncodeDecode(t *testing.T) {
 		parentMap, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		const mapCount = 4
+		const mapCount = uint64(4)
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		// fields are ordered differently because of different seed.
 		for i := range mapCount {
@@ -13201,7 +13198,7 @@ func TestMapEncodeDecode(t *testing.T) {
 			keyValues[k] = expectedChildMapValues
 		}
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 
 		id1 := atree.NewSlabID(address, atree.SlabIndex{0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -13420,7 +13417,7 @@ func TestMapStoredValue(t *testing.T) {
 	storage := newTestPersistentStorage(t)
 
 	keyValues := make(map[atree.Value]atree.Value, mapCount)
-	i := 0
+	i := uint64(0)
 	for len(keyValues) < mapCount {
 		k := test_utils.NewStringValue(randStr(r, 16))
 		keyValues[k] = test_utils.Uint64Value(i)
@@ -13484,18 +13481,18 @@ func TestMapPopIterate(t *testing.T) {
 
 		require.Equal(t, 1, storage.Count())
 
-		i := uint64(0)
+		i := 0
 		err = m.PopIterate(func(atree.Storable, atree.Storable) {
 			i++
 		})
 		require.NoError(t, err)
-		require.Equal(t, uint64(0), i)
+		require.Equal(t, 0, i)
 
 		testEmptyMap(t, storage, typeInfo, address, m)
 	})
 
 	t.Run("root-dataslab", func(t *testing.T) {
-		const mapCount = 10
+		const mapCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 		storage := newTestPersistentStorage(t)
@@ -13517,7 +13514,7 @@ func TestMapPopIterate(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		err = storage.Commit()
 		require.NoError(t, err)
@@ -13540,7 +13537,7 @@ func TestMapPopIterate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		require.Equal(t, 0, i)
+		require.Equal(t, uint64(0), i)
 
 		testEmptyMap(t, storage, typeInfo, address, m)
 	})
@@ -13631,8 +13628,8 @@ func TestMapPopIterate(t *testing.T) {
 				keyValues[k] = test_utils.NewStringValue(randStr(r, 16))
 
 				digests := []atree.Digest{
-					atree.Digest(i % 100),
-					atree.Digest(i % 5),
+					atree.Digest(i % 100), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+					atree.Digest(i % 5),   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				}
 
 				digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -13782,7 +13779,7 @@ func TestMapFromBatchData(t *testing.T) {
 	t.Run("root-dataslab", func(t *testing.T) {
 		atree.SetThreshold(1024)
 
-		const mapCount = 10
+		const mapCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -13800,7 +13797,7 @@ func TestMapFromBatchData(t *testing.T) {
 			require.Nil(t, storable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -13844,7 +13841,7 @@ func TestMapFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 4096
+		const mapCount = uint64(4096)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -13862,7 +13859,7 @@ func TestMapFromBatchData(t *testing.T) {
 			require.Nil(t, storable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -13903,7 +13900,7 @@ func TestMapFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 10
+		const mapCount = uint64(10)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -13921,13 +13918,13 @@ func TestMapFromBatchData(t *testing.T) {
 			require.Nil(t, storable)
 		}
 
-		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapElementSize()-2)))
-		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2)))
+		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		storable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 		require.NoError(t, err)
 		require.Nil(t, storable)
 
-		require.Equal(t, uint64(mapCount+1), m.Count())
+		require.Equal(t, mapCount+1, m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -13968,7 +13965,7 @@ func TestMapFromBatchData(t *testing.T) {
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
 
-		const mapCount = 8
+		const mapCount = uint64(8)
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -13989,13 +13986,13 @@ func TestMapFromBatchData(t *testing.T) {
 		storable, err := m.Set(
 			test_utils.CompareValue,
 			test_utils.GetHashInput,
-			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))),
-			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))),
+			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()-2))), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		)
 		require.NoError(t, err)
 		require.Nil(t, storable)
 
-		require.Equal(t, uint64(mapCount+1), m.Count())
+		require.Equal(t, mapCount+1, m.Count())
 		require.Equal(t, typeInfo, m.Type())
 
 		iter, err := m.ReadOnlyIterator()
@@ -14052,8 +14049,8 @@ func TestMapFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 
 		for m.Count() < mapCount {
-			k := randomValue(r, int(atree.MaxInlineMapElementSize()))
-			v := randomValue(r, int(atree.MaxInlineMapElementSize()))
+			k := randomValue(r, atree.MaxInlineMapElementSize())
+			v := randomValue(r, atree.MaxInlineMapElementSize())
 
 			_, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 			require.NoError(t, err)
@@ -14098,7 +14095,10 @@ func TestMapFromBatchData(t *testing.T) {
 
 	t.Run("collision", func(t *testing.T) {
 
-		const mapCount = 1024
+		const (
+			mapCount                   = uint64(1024)
+			maxCollisionLimitPerDigest = uint32(1024 / 2)
+		)
 
 		atree.SetThreshold(512)
 		defer atree.SetThreshold(1024)
@@ -14107,7 +14107,7 @@ func TestMapFromBatchData(t *testing.T) {
 		defer func() {
 			atree.MaxCollisionLimitPerDigest = savedMaxCollisionLimitPerDigest
 		}()
-		atree.MaxCollisionLimitPerDigest = mapCount / 2
+		atree.MaxCollisionLimitPerDigest = maxCollisionLimitPerDigest
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -14140,7 +14140,7 @@ func TestMapFromBatchData(t *testing.T) {
 			require.Nil(t, storable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 
 		iter, err := m.ReadOnlyIterator()
 		require.NoError(t, err)
@@ -14188,7 +14188,7 @@ func TestMapFromBatchData(t *testing.T) {
 
 		r := newRand(t)
 
-		maxStringSize := int(atree.MaxInlineMapKeySize() - 2)
+		maxStringSize := int(atree.MaxInlineMapKeySize() - 2) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
 
@@ -14336,7 +14336,7 @@ func TestMapMaxInlineElement(t *testing.T) {
 	t.Parallel()
 
 	r := newRand(t)
-	maxStringSize := int(atree.MaxInlineMapKeySize() - 2)
+	maxStringSize := int(atree.MaxInlineMapKeySize() - 2) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 	typeInfo := test_utils.NewSimpleTypeInfo(42)
 	storage := newTestPersistentStorage(t)
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
@@ -14371,7 +14371,7 @@ func TestMapString(t *testing.T) {
 	defer atree.SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const mapCount = 3
+		const mapCount = uint64(3)
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -14396,7 +14396,7 @@ func TestMapString(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const mapCount = 30
+		const mapCount = uint64(30)
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -14427,7 +14427,7 @@ func TestMapSlabDump(t *testing.T) {
 	defer atree.SetThreshold(1024)
 
 	t.Run("small", func(t *testing.T) {
-		const mapCount = 3
+		const mapCount = uint64(3)
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -14456,7 +14456,7 @@ func TestMapSlabDump(t *testing.T) {
 	})
 
 	t.Run("large", func(t *testing.T) {
-		const mapCount = 30
+		const mapCount = uint64(30)
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -14487,7 +14487,7 @@ func TestMapSlabDump(t *testing.T) {
 	})
 
 	t.Run("inline collision", func(t *testing.T) {
-		const mapCount = 30
+		const mapCount = uint64(30)
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -14518,7 +14518,7 @@ func TestMapSlabDump(t *testing.T) {
 	})
 
 	t.Run("external collision", func(t *testing.T) {
-		const mapCount = 30
+		const mapCount = uint64(30)
 
 		digesterBuilder := &mockDigesterBuilder{}
 		typeInfo := test_utils.NewSimpleTypeInfo(42)
@@ -14558,8 +14558,8 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize())))
-		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapKeySize())))
+		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapKeySize()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{atree.Digest(0)}})
 
 		existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -14585,8 +14585,8 @@ func TestMapSlabDump(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
-		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize()-2)))
-		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize())))
+		k := test_utils.NewStringValue(strings.Repeat("a", int(atree.MaxInlineMapKeySize()-2)))   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.NewStringValue(strings.Repeat("b", int(atree.MaxInlineMapElementSize()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		digesterBuilder.On("Digest", k).Return(mockDigester{d: []atree.Digest{atree.Digest(0)}})
 
 		existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -14610,7 +14610,7 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 	}()
 
 	t.Run("collision limit 0", func(t *testing.T) {
-		const mapCount = 1024
+		const mapCount = uint64(1024)
 
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
@@ -14684,7 +14684,7 @@ func TestMaxCollisionLimitPerDigest(t *testing.T) {
 	})
 
 	t.Run("collision limit > 0", func(t *testing.T) {
-		const mapCount = 1024
+		const mapCount = uint64(1024)
 
 		atree.SetThreshold(256)
 		defer atree.SetThreshold(1024)
@@ -14802,7 +14802,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -14825,7 +14825,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -14850,7 +14850,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -14875,7 +14875,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -14899,7 +14899,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -14977,7 +14977,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15010,7 +15010,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15043,7 +15043,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15097,7 +15097,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15177,7 +15177,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15211,7 +15211,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15245,7 +15245,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15298,7 +15298,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15382,7 +15382,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 2), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15422,7 +15422,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15465,7 +15465,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i / 4), atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15519,7 +15519,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15567,7 +15567,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					typeInfo,
 					mapCount,
 					childArrayIndex,
-					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					useWrapperValue,
 				)
 
@@ -15601,7 +15601,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15624,7 +15624,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15648,7 +15648,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15680,7 +15680,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15713,7 +15713,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15755,7 +15755,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					typeInfo,
 					mapCount,
 					childArrayIndex,
-					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+					func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					useWrapperValue,
 				)
 
@@ -15789,7 +15789,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15836,7 +15836,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15885,7 +15885,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15942,7 +15942,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -15963,7 +15963,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				var loadedExpectedValues [][2]atree.Value
 				if i < len(childSlabIDs)-1 {
 					nextFirstKey := childFirstKeys[i+1]
-					loadedExpectedValues = expectedValues[int(nextFirstKey):]
+					loadedExpectedValues = expectedValues[int(nextFirstKey):] //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				}
 
 				testMapLoadedElements(t, m, loadedExpectedValues)
@@ -15983,7 +15983,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -16023,7 +16023,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -16067,7 +16067,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -16104,10 +16104,10 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					if len(dataSlabInfos) > 0 {
 						// Update previous slabInfo.count
-						dataSlabInfos[len(dataSlabInfos)-1].count = int(firstKey) - dataSlabInfos[len(dataSlabInfos)-1].startIndex
+						dataSlabInfos[len(dataSlabInfos)-1].count = int(firstKey) - dataSlabInfos[len(dataSlabInfos)-1].startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					}
 
-					dataSlabInfos = append(dataSlabInfos, &slabInfo{id: slabID, startIndex: int(firstKey)})
+					dataSlabInfos = append(dataSlabInfos, &slabInfo{id: slabID, startIndex: int(firstKey)}) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				}
 			}
 
@@ -16155,7 +16155,7 @@ func TestMapLoadedValueIterator(t *testing.T) {
 				address,
 				typeInfo,
 				mapCount,
-				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} },
+				func(i int) []atree.Digest { return []atree.Digest{atree.Digest(i)} }, //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				useWrapperValue,
 			)
 
@@ -16188,15 +16188,15 @@ func TestMapLoadedValueIterator(t *testing.T) {
 					prevDataSlabInfo := prevMetaDataSlabInfo.children[len(prevMetaDataSlabInfo.children)-1]
 
 					// Update previous metadata slab count
-					prevMetaDataSlabInfo.count = int(firstKey) - prevMetaDataSlabInfo.startIndex
+					prevMetaDataSlabInfo.count = int(firstKey) - prevMetaDataSlabInfo.startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 					// Update previous data slab count
-					prevDataSlabInfo.count = int(firstKey) - prevDataSlabInfo.startIndex
+					prevDataSlabInfo.count = int(firstKey) - prevDataSlabInfo.startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				}
 
 				metadataSlabInfo := &slabInfo{
 					id:         slabID,
-					startIndex: int(firstKey),
+					startIndex: int(firstKey), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				}
 
 				nonRootMetadataSlab, ok := atree.GetDeltas(storage)[slabID].(*atree.MapMetaDataSlab)
@@ -16210,10 +16210,10 @@ func TestMapLoadedValueIterator(t *testing.T) {
 
 					children[i] = &slabInfo{
 						id:         slabID,
-						startIndex: int(firstKey),
+						startIndex: int(firstKey), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					}
 					if i > 0 {
-						children[i-1].count = int(firstKey) - children[i-1].startIndex
+						children[i-1].count = int(firstKey) - children[i-1].startIndex //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					}
 				}
 
@@ -16334,12 +16334,12 @@ func createMapWithLongStringKey(
 	expectedValues := make([][2]atree.Value, count)
 	r := 'a'
 	for i := range expectedValues {
-		s := strings.Repeat(string(r), int(atree.MaxInlineMapElementSize()))
+		s := strings.Repeat(string(r), int(atree.MaxInlineMapElementSize())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		k := test_utils.NewStringValue(s)
-		v := test_utils.Uint64Value(i)
+		v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
-		digests := []atree.Digest{atree.Digest(i)}
+		digests := []atree.Digest{atree.Digest(i)} //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 		if useWrapperValue {
@@ -16380,7 +16380,7 @@ func createMapWithSimpleValues(
 	expectedValues := make([][2]atree.Value, count)
 	r := rune('a')
 	for i := range expectedValues {
-		k := test_utils.Uint64Value(i)
+		k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		v := test_utils.NewStringValue(strings.Repeat(string(r), 20))
 
 		digests := newDigests(i)
@@ -16431,7 +16431,7 @@ func createMapWithChildArrayValues(
 
 		expectedChildValues := make([]atree.Value, childArrayCount)
 		for j := range expectedChildValues {
-			v := test_utils.Uint64Value(j)
+			v := test_utils.Uint64Value(j) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			err = childArray.Append(v)
 			require.NoError(t, err)
@@ -16439,7 +16439,7 @@ func createMapWithChildArrayValues(
 			expectedChildValues[j] = v
 		}
 
-		k := test_utils.Uint64Value(i)
+		k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		v := childArray
 
 		slabIDs[i] = childArray.SlabID()
@@ -16489,7 +16489,7 @@ func createMapWithSimpleAndChildArrayValues(
 	r := 'a'
 	for i := range expectedValues {
 
-		k := test_utils.Uint64Value(i)
+		k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		digests := newDigests(i)
 		digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -16501,7 +16501,7 @@ func createMapWithSimpleAndChildArrayValues(
 
 			expectedChildValues := make([]atree.Value, childArrayCount)
 			for j := range expectedChildValues {
-				v := test_utils.Uint64Value(j)
+				v := test_utils.Uint64Value(j) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				err = childArray.Append(v)
 				require.NoError(t, err)
 
@@ -16578,7 +16578,7 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for len(keyValues) < mapCount {
 			k := test_utils.NewStringValue(randStr(r, keyStringSize))
-			v := test_utils.NewStringValue(randStr(r, int(valueStringSize)))
+			v := test_utils.NewStringValue(randStr(r, int(valueStringSize))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			keyValues[k] = v
 		}
 
@@ -16615,8 +16615,8 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for len(keyValues) < mapCount {
-			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))
-			v := test_utils.NewStringValue(randStr(r, int(valueStringSize)))
+			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewStringValue(randStr(r, int(valueStringSize))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			keyValues[k] = v
 		}
 
@@ -16655,8 +16655,8 @@ func TestMaxInlineMapValueSize(t *testing.T) {
 
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		for len(keyValues) < mapCount {
-			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))
-			v := test_utils.NewStringValue(randStr(r, int(valueStringSize)))
+			k := test_utils.NewStringValue(randStr(r, int(keyStringSize)))   //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			v := test_utils.NewStringValue(randStr(r, int(valueStringSize))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			keyValues[k] = v
 		}
 
@@ -16696,7 +16696,7 @@ func TestMapID(t *testing.T) {
 
 func TestSlabSizeWhenResettingMutableStorableInMap(t *testing.T) {
 	const (
-		mapCount            = 3
+		mapCount            = uint64(3)
 		keyStringSize       = 16
 		initialStorableSize = 1
 		mutatedStorableSize = 5
@@ -16790,7 +16790,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 
 		// Appending 3 elements to child map so that inlined child map reaches max inlined size as map element.
-		for i := range 3 {
+		for i := range uint64(3) {
 			for childKey, child := range children {
 				childMap := child.m
 				valueID := child.valueID
@@ -16804,7 +16804,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
 				require.Nil(t, existingStorable)
-				require.Equal(t, uint64(i+1), childMap.Count())
+				require.Equal(t, i+1, childMap.Count())
 
 				expectedChildMapValues[k] = v
 
@@ -16817,7 +16817,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()))
+					int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent slab size
@@ -16864,7 +16864,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedStandaloneSlabSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
@@ -16912,7 +16912,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()))
+					int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
 				elementByteSizesByKey[childKey] = [2]uint32{elementByteSizesByKey[childKey][0], expectedInlinedMapSize}
@@ -16963,7 +16963,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 
 		// Appending 3 elements to child map so that inlined child map reaches max inlined size as map element.
-		for i := range 3 {
+		for i := range uint64(3) {
 			for childKey, child := range children {
 				childMap := child.m
 				valueID := child.valueID
@@ -16977,7 +16977,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
 				require.Nil(t, existingStorable)
-				require.Equal(t, uint64(i+1), childMap.Count())
+				require.Equal(t, i+1, childMap.Count())
 
 				expectedChildMapValues[k] = v
 
@@ -16990,7 +16990,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17040,7 +17040,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedStandaloneSlabSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
@@ -17094,7 +17094,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17143,7 +17143,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17198,7 +17198,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 		children := getInlinedChildMapsFromParentMap(t, address, parentMap)
 
 		// Appending 3 elements to child map so that inlined child map reaches max inlined size as map element.
-		for i := range 3 {
+		for i := range uint64(3) {
 			for childKey, child := range children {
 				childMap := child.m
 				valueID := child.valueID
@@ -17212,7 +17212,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
 				require.Nil(t, existingStorable)
-				require.Equal(t, uint64(i+1), childMap.Count())
+				require.Equal(t, i+1, childMap.Count())
 
 				expectedChildMapValues[k] = v
 
@@ -17224,7 +17224,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17263,7 +17263,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedStandaloneSlabSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedStandaloneSlabSize, GetMapRootSlabByteSize(childMap))
 
@@ -17303,7 +17303,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17342,7 +17342,7 @@ func TestChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedInlinedMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedInlinedMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17457,7 +17457,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17465,7 +17465,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17542,7 +17542,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17550,7 +17550,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17558,7 +17558,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedParentSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				slabIDStorableByteSize,
-				int(parentMap.Count()),
+				int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedParentSize, GetMapRootSlabByteSize(parentMap))
 
@@ -17619,7 +17619,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(gchildMap.Count()),
+					int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17627,7 +17627,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					expectedGrandChildMapSize,
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17635,7 +17635,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedParentMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					expectedChildMapSize,
-					int(parentMap.Count()),
+					int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
@@ -17739,7 +17739,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17747,7 +17747,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -17904,7 +17904,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(gchildMap.Count()),
+					int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -17912,14 +17912,14 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					expectedGrandChildMapSize,
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
 				// Test parent child slab size
 				expectedParentMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 					encodedKeySize, expectedChildMapSize,
-					int(parentMap.Count()),
+					int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
@@ -18020,7 +18020,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18028,7 +18028,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18096,7 +18096,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18176,7 +18176,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18265,14 +18265,14 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
-			elementByteSizes := make([][2]uint32, int(childMap.Count()))
+			elementByteSizes := make([][2]uint32, int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			elementByteSizes[0] = [2]uint32{encodedKeySize, expectedGrandChildMapSize}
-			for i := 1; i < int(childMap.Count()); i++ {
+			for i := 1; i < len(elementByteSizes); i++ {
 				elementByteSizes[i] = [2]uint32{encodedKeySize, encodedValueSize}
 			}
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSize(elementByteSizes)
@@ -18346,14 +18346,14 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 				expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					encodedKeySize,
 					encodedValueSize,
-					int(gchildMap.Count()),
+					int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 				// Test inlined child slab size
-				elementByteSizes := make([][2]uint32, int(childMap.Count()))
+				elementByteSizes := make([][2]uint32, int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				elementByteSizes[0] = [2]uint32{encodedKeySize, expectedGrandChildMapSize}
-				for i := 1; i < int(childMap.Count()); i++ {
+				for i := 1; i < len(elementByteSizes); i++ {
 					elementByteSizes[i] = [2]uint32{encodedKeySize, encodedValueSize}
 				}
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSize(elementByteSizes)
@@ -18463,7 +18463,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18471,7 +18471,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18532,7 +18532,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
@@ -18540,7 +18540,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedChildMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				expectedGrandChildMapSize,
-				int(childMap.Count()),
+				int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18555,7 +18555,7 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 		expectedParentMapSize := atree.ComputeMapRootDataSlabByteSizeWithFixSizedElement(
 			encodedKeySize,
 			slabIDStorableSize,
-			int(parentMap.Count()),
+			int(parentMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		)
 		require.Equal(t, expectedParentMapSize, GetMapRootSlabByteSize(parentMap))
 
@@ -18613,14 +18613,14 @@ func TestNestedThreeLevelChildMapInlinabilityInParentMap(t *testing.T) {
 			expectedGrandChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 				encodedKeySize,
 				encodedValueSize,
-				int(gchildMap.Count()),
+				int(gchildMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			)
 			require.Equal(t, expectedGrandChildMapSize, GetMapRootSlabByteSize(gchildMap))
 
 			// Test inlined child slab size
-			elementByteSizes := make([][2]uint32, int(childMap.Count()))
+			elementByteSizes := make([][2]uint32, int(childMap.Count())) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			elementByteSizes[0] = [2]uint32{encodedKeySize, expectedGrandChildMapSize}
-			for i := 1; i < int(childMap.Count()); i++ {
+			for i := 1; i < len(elementByteSizes); i++ {
 				elementByteSizes[i] = [2]uint32{encodedKeySize, encodedValueSize}
 			}
 			expectedChildMapSize := atree.ComputeInlinedMapSlabByteSize(elementByteSizes)
@@ -18724,7 +18724,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	parentMapDigesterBuilder := &mockDigesterBuilder{}
-	parentDigest := 1
+	parentDigest := uint64(1)
 
 	// Create parent map with mock digests
 	parentMap, err := atree.NewMap(storage, address, parentMapDigesterBuilder, typeInfo)
@@ -18802,7 +18802,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 			expectedKeyValues[k] = v
 			keysForNonChildMaps = append(keysForNonChildMaps, k)
 
-			i := 0
+			i := uint64(0)
 			for childKey, child := range children {
 				childMap := child.m
 				childValueID := child.valueID
@@ -18829,7 +18829,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 				expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 					k.ByteSize(),
 					v.ByteSize(),
-					int(childMap.Count()),
+					int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				)
 				require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18851,7 +18851,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 
 				delete(expectedKeyValues, k)
 
-				i := 0
+				i := uint64(0)
 				for childKey, child := range children {
 					childMap := child.m
 					childValueID := child.valueID
@@ -18878,7 +18878,7 @@ func TestChildMapWhenParentMapIsModified(t *testing.T) {
 					expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 						k.ByteSize(),
 						v.ByteSize(),
-						int(childMap.Count()),
+						int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 					)
 					require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -18999,7 +18999,7 @@ func createMapWithEmpty2LevelChildMap(
 		expectedChildMapSize := atree.ComputeInlinedMapSlabByteSizeWithFixSizedElement(
 			ks.ByteSize(),
 			emptyInlinedMapByteSize,
-			int(childMap.Count()),
+			int(childMap.Count()), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		)
 		require.Equal(t, expectedChildMapSize, GetMapRootSlabByteSize(childMap))
 
@@ -19066,7 +19066,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19130,7 +19130,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19187,7 +19187,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19212,11 +19212,10 @@ func TestMapSetReturnedValue(t *testing.T) {
 			expectedKeyValues[k] = expectedChildValues
 
 			// Insert into child map until child map is not inlined
-			j := 0
-			for {
+
+			for j := uint64(0); ; j++ {
 				k := test_utils.Uint64Value(j)
 				v := test_utils.NewStringValue(strings.Repeat("a", 10))
-				j++
 
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
@@ -19256,7 +19255,7 @@ func TestMapSetReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19321,7 +19320,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	t.Run("child array is not inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19385,7 +19384,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19442,7 +19441,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19467,11 +19466,10 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 			expectedKeyValues[k] = expectedChildValues
 
 			// Insert into child map until child map is not inlined
-			j := 0
-			for {
+
+			for j := uint64(0); ; j++ {
 				k := test_utils.Uint64Value(j)
 				v := test_utils.NewStringValue(strings.Repeat("a", 10))
-				j++
 
 				existingStorable, err := childMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
 				require.NoError(t, err)
@@ -19511,7 +19509,7 @@ func TestMapRemoveReturnedValue(t *testing.T) {
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
-		const mapCount = 2
+		const mapCount = uint64(2)
 
 		storage := newTestPersistentStorage(t)
 
@@ -19728,7 +19726,7 @@ func TestMapSetType(t *testing.T) {
 		m, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		mapCount := 10
+		const mapCount = uint64(10)
 		for i := range mapCount {
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, v, v)
@@ -19736,7 +19734,7 @@ func TestMapSetType(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.Equal(t, typeInfo, m.Type())
 		require.True(t, IsMapRootDataSlab(m))
 
@@ -19745,7 +19743,7 @@ func TestMapSetType(t *testing.T) {
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, m.Type())
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
@@ -19761,7 +19759,7 @@ func TestMapSetType(t *testing.T) {
 		m, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 		require.NoError(t, err)
 
-		mapCount := 10_000
+		const mapCount = uint64(10_000)
 		for i := range mapCount {
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, v, v)
@@ -19769,7 +19767,7 @@ func TestMapSetType(t *testing.T) {
 			require.Nil(t, existingStorable)
 		}
 
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.Equal(t, typeInfo, m.Type())
 		require.False(t, IsMapRootDataSlab(m))
 
@@ -19778,7 +19776,7 @@ func TestMapSetType(t *testing.T) {
 		err = m.SetType(newTypeInfo)
 		require.NoError(t, err)
 		require.Equal(t, newTypeInfo, m.Type())
-		require.Equal(t, uint64(mapCount), m.Count())
+		require.Equal(t, mapCount, m.Count())
 		require.Equal(t, seed, m.Seed())
 
 		// Commit modified slabs in storage
@@ -19845,7 +19843,7 @@ func TestMapSetType(t *testing.T) {
 
 		childMapSeed := childMap.Seed()
 
-		mapCount := 10_000
+		const mapCount = uint64(10_000)
 		for i := range mapCount - 1 {
 			v := test_utils.Uint64Value(i)
 			existingStorable, err := parentMap.Set(test_utils.CompareValue, test_utils.GetHashInput, v, v)
@@ -19857,7 +19855,7 @@ func TestMapSetType(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, existingStorable)
 
-		require.Equal(t, uint64(mapCount), parentMap.Count())
+		require.Equal(t, mapCount, parentMap.Count())
 		require.Equal(t, typeInfo, parentMap.Type())
 		require.False(t, IsMapRootDataSlab(parentMap))
 		require.False(t, parentMap.Inlined())

--- a/map_test.go
+++ b/map_test.go
@@ -1248,6 +1248,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, 0, mapCount)
 		for len(keyValues) < mapCount {
@@ -1258,12 +1259,7 @@ func TestReadOnlyMapIterate(t *testing.T) {
 				sortedKeys = append(sortedKeys, k)
 				keyValues[k] = v
 
-				digests := []atree.Digest{
-					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-					atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				}
+				digests := newRandomDigests(r, digestLevels)
 				digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 				existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -2561,15 +2557,14 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 1
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i * 2)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -2623,18 +2618,14 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i * 2)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -3141,6 +3132,7 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 1
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
@@ -3156,9 +3148,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 			k := test_utils.Uint64Value(i)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
@@ -3224,6 +3214,7 @@ func TestMutableMapIterate(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
@@ -3239,12 +3230,7 @@ func TestMutableMapIterate(t *testing.T) {
 
 			k := test_utils.Uint64Value(i)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
@@ -4137,15 +4123,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 1
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i * 2)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -4198,18 +4183,14 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i * 2)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -4725,6 +4706,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 1
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
@@ -4740,9 +4722,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			k := test_utils.Uint64Value(i)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
@@ -4810,6 +4790,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
@@ -4825,12 +4806,7 @@ func TestMutableMapIterateKeys(t *testing.T) {
 
 			k := test_utils.Uint64Value(i)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
@@ -5742,15 +5718,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 1
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i * 2)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -5805,18 +5780,14 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
 			k := test_utils.Uint64Value(i)
 			v := test_utils.Uint64Value(i * 2)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err := m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, v)
@@ -6329,6 +6300,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 1
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
@@ -6344,9 +6316,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			k := test_utils.Uint64Value(i)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
@@ -6413,6 +6383,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 		m, err := atree.NewMap(storage, address, digesterBuilder, typeInfo)
 		require.NoError(t, err)
 
+		const digestLevels = 4
 		keyValues := make(map[atree.Value]atree.Value, mapCount)
 		sortedKeys := make([]atree.Value, mapCount)
 		for i := range mapCount {
@@ -6428,12 +6399,7 @@ func TestMutableMapIterateValues(t *testing.T) {
 
 			k := test_utils.Uint64Value(i)
 
-			digests := []atree.Digest{
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				atree.Digest(r.Intn(256)), //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+			digests := newRandomDigests(r, digestLevels)
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
 
 			existingStorable, err = m.Set(test_utils.CompareValue, test_utils.GetHashInput, k, childMap)
@@ -7003,7 +6969,7 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 	uniqueFirstLevelDigests := make(map[atree.Digest]bool, mockDigestCount)
 	firstLevelDigests := make([]atree.Digest, 0, mockDigestCount)
 	for len(firstLevelDigests) < mockDigestCount {
-		d := atree.Digest(uint64(r.Intn(256))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		d := newRandomDigest(r)
 		if !uniqueFirstLevelDigests[d] {
 			uniqueFirstLevelDigests[d] = true
 			firstLevelDigests = append(firstLevelDigests, d)
@@ -7015,7 +6981,7 @@ func testMapDeterministicHashCollision(t *testing.T, r *rand.Rand, maxDigestLeve
 		digests := make([]atree.Digest, maxDigestLevel)
 		digests[0] = firstLevelDigests[i]
 		for j := 1; j < maxDigestLevel; j++ {
-			digests[j] = atree.Digest(uint64(r.Intn(256))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			digests[j] = newRandomDigest(r)
 		}
 		digestsGroup[i] = digests
 	}
@@ -7102,7 +7068,7 @@ func testMapRandomHashCollision(t *testing.T, r *rand.Rand, maxDigestLevel int) 
 
 			digests := make([]atree.Digest, maxDigestLevel)
 			for i := range digests {
-				digests[i] = atree.Digest(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				digests[i] = newRandomDigest(r)
 			}
 
 			digesterBuilder.On("Digest", k).Return(mockDigester{digests})
@@ -19984,4 +19950,16 @@ func testExistingInlinedMapSetType(
 	require.Equal(t, expectedCount, childMap2.Count())
 	require.Equal(t, newTypeInfo, childMap2.Type())
 	require.Equal(t, expectedSeed, childMap.Seed())
+}
+
+func newRandomDigests(r *rand.Rand, level int) []atree.Digest {
+	digest := make([]atree.Digest, level)
+	for i := range digest {
+		digest[i] = newRandomDigest(r)
+	}
+	return digest
+}
+
+func newRandomDigest(r *rand.Rand) atree.Digest {
+	return atree.Digest(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 }

--- a/map_wrappervalue_test.go
+++ b/map_wrappervalue_test.go
@@ -1475,10 +1475,7 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 	t.Run("set and remove", func(t *testing.T) {
 		// Insert elements
 
-		var setCount uint64
-		for setCount < minWriteOperationCount {
-			setCount = uint64(r.Intn(maxWriteOperationCount + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		setCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualMapCount += setCount
 
@@ -1502,12 +1499,9 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 		// Remove some elements
 		mapCount := m.Count()
 
-		var removeCount uint64
 		minRemoveCount := mapCount / 2
 		maxRemoveCount := mapCount / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualMapCount -= removeCount
 
@@ -1611,10 +1605,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 	t.Run("set and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount uint64
-		for setCount < minWriteOperationCount {
-			setCount = uint64(r.Intn(maxWriteOperationCount + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		setCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualMapCount += setCount
 
@@ -1637,12 +1628,9 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 
 		mapCount := m.Count()
 
-		var removeCount uint64
 		minRemoveCount := mapCount / 2
 		maxRemoveCount := mapCount / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualMapCount -= removeCount
 
@@ -1673,13 +1661,9 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 
 		mapCount := m.Count()
 
-		var setCount uint64
-		if m.Count() <= 10 {
-			setCount = mapCount
-		} else {
-			for setCount < mapCount/2 {
-				setCount = uint64(r.Intn(int(mapCount + 1))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+		setCount := mapCount
+		if m.Count() > 10 {
+			setCount = getRandomUint64InRange(r, mapCount/2, mapCount)
 		}
 
 		keys := make([]atree.Value, 0, len(expectedValues))
@@ -1714,12 +1698,9 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 
 		mapCount = m.Count()
 
-		var removeCount uint64
 		minRemoveCount := mapCount / 2
 		maxRemoveCount := mapCount / 4 * 3
-		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		removeCount := getRandomUint64InRange(r, minRemoveCount, maxRemoveCount)
 
 		actualMapCount -= removeCount
 
@@ -1832,10 +1813,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 	t.Run("set and remove", func(t *testing.T) {
 		// Insert elements
 
-		var setCount uint64
-		for setCount < minWriteOperationCount {
-			setCount = uint64(r.Intn(maxWriteOperationCount + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		setCount := getRandomUint64InRange(r, minWriteOperationCount, maxWriteOperationCount+1)
 
 		actualMapCount += setCount
 
@@ -1858,10 +1836,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 
 		mapCount := m.Count()
 
-		var removeCount uint64
-		for removeCount < mapCount/2 {
-			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		removeCount := getRandomUint64InRange(r, mapCount/2, mapCount)
 
 		actualMapCount -= removeCount
 
@@ -1892,13 +1867,9 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 
 		mapCount := m.Count()
 
-		var setCount uint64
-		if m.Count() <= 10 {
-			setCount = mapCount
-		} else {
-			for setCount < mapCount/2 {
-				setCount = uint64(r.Intn(int(mapCount + 1))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-			}
+		setCount := mapCount
+		if m.Count() > 10 {
+			setCount = getRandomUint64InRange(r, mapCount/2, mapCount)
 		}
 
 		keys := make([]atree.Value, 0, m.Count())
@@ -1935,10 +1906,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 
 		mapCount = m.Count()
 
-		var removeCount uint64
-		for removeCount < mapCount/2 {
-			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-		}
+		removeCount := getRandomUint64InRange(r, mapCount/2, mapCount)
 
 		actualMapCount -= removeCount
 

--- a/map_wrappervalue_test.go
+++ b/map_wrappervalue_test.go
@@ -1099,7 +1099,7 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 		// Insert new elements to wrapped child map
 
 		k := test_utils.Uint64Value(i)
-		v := test_utils.Uint64Value(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.Uint64Value(r.Intn(256))
 
 		existingStorable, err := wrappedMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.NewSomeValue(v))
 		require.NoError(t, err)
@@ -1318,7 +1318,7 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 		// Insert new elements to wrapped gchild map
 
 		k := test_utils.Uint64Value(i)
-		v := test_utils.Uint64Value(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		v := test_utils.Uint64Value(r.Intn(256))
 
 		existingStorable, err := wrappedMapAtLevel2.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.NewSomeValue(v))
 		require.NoError(t, err)

--- a/map_wrappervalue_test.go
+++ b/map_wrappervalue_test.go
@@ -497,7 +497,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 
 	mapCountTestCases := []struct {
 		name     string
-		mapCount int
+		mapCount uint64
 	}{
 		{name: "small map", mapCount: smallMapCount},
 		{name: "large map", mapCount: largeMapCount},
@@ -527,7 +527,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 
 				// Set WrapperValue
 				expectedValues := make(map[atree.Value]atree.Value)
-				for len(expectedValues) < mapCount {
+				for uint64(len(expectedValues)) < mapCount {
 					k, expectedK := tc.newKey(storage)
 
 					if _, exists := expectedValues[expectedK]; exists {
@@ -543,7 +543,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[expectedK] = expectedV
 				}
 
-				require.Equal(t, uint64(mapCount), m.Count())
+				require.Equal(t, mapCount, m.Count())
 
 				testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -568,7 +568,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 					expectedValues[key] = newExpectedV
 				}
 
-				require.Equal(t, uint64(mapCount), m.Count())
+				require.Equal(t, mapCount, m.Count())
 
 				testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -581,7 +581,7 @@ func TestMapWrapperValueSetAndModify(t *testing.T) {
 
 				m2, err := atree.NewMapWithRootID(storage2, rootSlabID, atree.NewDefaultDigesterBuilder())
 				require.NoError(t, err)
-				require.Equal(t, uint64(mapCount), m2.Count())
+				require.Equal(t, mapCount, m2.Count())
 
 				// Test loaded map
 				testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
@@ -609,7 +609,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 
 	mapCountTestCases := []struct {
 		name     string
-		mapCount int
+		mapCount uint64
 	}{
 		{name: "small map", mapCount: smallMapCount},
 		{name: "large map", mapCount: largeMapCount},
@@ -626,7 +626,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 	removeTestCases := []struct {
 		name               string
 		removeAllElements  bool
-		removeElementCount int
+		removeElementCount uint64
 	}{
 		{name: "remove all elements", removeAllElements: true},
 		{name: "remove 1 element", removeElementCount: 1},
@@ -672,7 +672,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 						expectedValues := make(map[atree.Value]atree.Value)
 
 						// Set WrapperValue in map
-						for len(expectedValues) < mapCount {
+						for uint64(len(expectedValues)) < mapCount {
 							k, expectedK := tc.newKey(storage)
 
 							if _, exists := expectedValues[expectedK]; exists {
@@ -688,7 +688,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 							expectedValues[expectedK] = expectedV
 						}
 
-						require.Equal(t, uint64(mapCount), m.Count())
+						require.Equal(t, mapCount, m.Count())
 
 						testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -714,7 +714,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 								expectedValues[key] = newExpectedV
 							}
 
-							require.Equal(t, uint64(mapCount), m.Count())
+							require.Equal(t, mapCount, m.Count())
 
 							testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 						}
@@ -737,8 +737,8 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 							keys = append(keys[:removeKeyIndex], keys[removeKeyIndex+1:]...)
 						}
 
-						require.Equal(t, uint64(mapCount-removeCount), m.Count())
-						require.Equal(t, mapCount-removeCount, len(expectedValues))
+						require.Equal(t, mapCount-removeCount, m.Count())
+						require.Equal(t, mapCount-removeCount, uint64(len(expectedValues)))
 
 						testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -751,7 +751,7 @@ func TestMapWrapperValueSetAndRemove(t *testing.T) {
 
 						m2, err := atree.NewMapWithRootID(storage2, rootSlabID, atree.NewDefaultDigesterBuilder())
 						require.NoError(t, err)
-						require.Equal(t, uint64(mapCount-removeCount), m2.Count())
+						require.Equal(t, mapCount-removeCount, m2.Count())
 
 						// Test loaded map
 						testMap(t, storage2, typeInfo, address, m2, expectedValues, nil, true)
@@ -778,7 +778,7 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 
 	mapCountTestCases := []struct {
 		name     string
-		mapCount int
+		mapCount uint64
 	}{
 		{name: "small map", mapCount: smallMapCount},
 		{name: "large map", mapCount: largeMapCount},
@@ -824,7 +824,7 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 					expectedValues := make(map[atree.Value]atree.Value)
 
 					// Set WrapperValue to map
-					for len(expectedValues) < mapCount {
+					for uint64(len(expectedValues)) < mapCount {
 						k, expectedK := tc.newKey(storage)
 
 						if _, exists := expectedValues[expectedK]; exists {
@@ -840,7 +840,7 @@ func TestMapWrapperValueReadOnlyIterate(t *testing.T) {
 						expectedValues[expectedK] = expectedV
 					}
 
-					require.Equal(t, uint64(mapCount), m.Count())
+					require.Equal(t, mapCount, m.Count())
 
 					testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -893,7 +893,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 
 	mapCountTestCases := []struct {
 		name     string
-		mapCount int
+		mapCount uint64
 	}{
 		{name: "small map", mapCount: smallMapCount},
 		{name: "large map", mapCount: largeMapCount},
@@ -941,7 +941,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 					expectedValues := make(map[atree.Value]atree.Value)
 
 					// Set WrapperValue in map
-					for len(expectedValues) < mapCount {
+					for uint64(len(expectedValues)) < mapCount {
 						k, expectedK := tc.newKey(storage)
 
 						if _, exists := expectedValues[expectedK]; exists {
@@ -957,7 +957,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 						expectedValues[expectedK] = expectedV
 					}
 
-					require.Equal(t, uint64(mapCount), m.Count())
+					require.Equal(t, mapCount, m.Count())
 
 					testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
@@ -990,7 +990,7 @@ func TestMapWrapperValueIterate(t *testing.T) {
 						count++
 					}
 
-					require.Equal(t, uint64(mapCount), m.Count())
+					require.Equal(t, mapCount, m.Count())
 
 					testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 				})
@@ -1076,7 +1076,7 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 	// Retrieve wrapped child map, and then insert new elements to child map.
 	// Wrapped child map is expected to be unlined at the end of loop.
 
-	const childMapCount = 8
+	const childMapCount = uint64(8)
 	for i := range childMapCount + 1 {
 		// Get element
 		element, err := m.Get(test_utils.CompareValue, test_utils.GetHashInput, test_utils.Uint64Value(0))
@@ -1099,7 +1099,7 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 		// Insert new elements to wrapped child map
 
 		k := test_utils.Uint64Value(i)
-		v := test_utils.Uint64Value(r.Intn(256))
+		v := test_utils.Uint64Value(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		existingStorable, err := wrappedMap.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.NewSomeValue(v))
 		require.NoError(t, err)
@@ -1109,8 +1109,8 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 
 		expectedValues[test_utils.Uint64Value(0)] = test_utils.NewExpectedWrapperValue(expectedWrappedMap)
 
-		require.Equal(t, uint64(i+1), wrappedMap.Count())
-		require.Equal(t, i+1, len(expectedWrappedMap))
+		require.Equal(t, i+1, wrappedMap.Count())
+		require.Equal(t, i+1, uint64(len(expectedWrappedMap)))
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	}
@@ -1120,7 +1120,7 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 	// Retrieve wrapped child map, and then remove elements from child map.
 	// Wrapped child map is expected to be inlined at the end of loop.
 
-	childMapCountAfterRemoval := 2
+	childMapCountAfterRemoval := uint64(2)
 	removeCount := childMapCount - childMapCountAfterRemoval
 
 	for i := range removeCount {
@@ -1144,7 +1144,9 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 
 		// Remove element from wrapped child map
 
-		existingKeyStorable, existingValueStorable, err := wrappedMap.Remove(test_utils.CompareValue, test_utils.GetHashInput, test_utils.Uint64Value(i))
+		key := test_utils.Uint64Value(i)
+
+		existingKeyStorable, existingValueStorable, err := wrappedMap.Remove(test_utils.CompareValue, test_utils.GetHashInput, key)
 		require.NoError(t, err)
 		require.NotNil(t, existingKeyStorable)
 		require.NotNil(t, existingValueStorable)
@@ -1153,9 +1155,9 @@ func TestMapWrapperValueInlineMapAtLevel1(t *testing.T) {
 
 		existingValue, err := existingValueStorable.StoredValue(storage)
 		require.NoError(t, err)
-		testValueEqual(t, expectedWrappedMap[test_utils.Uint64Value(i)], existingValue)
+		testValueEqual(t, expectedWrappedMap[key], existingValue)
 
-		delete(expectedWrappedMap, test_utils.Uint64Value(i))
+		delete(expectedWrappedMap, key)
 
 		expectedValues[test_utils.Uint64Value(0)] = test_utils.NewExpectedWrapperValue(expectedWrappedMap)
 
@@ -1274,7 +1276,7 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild map, and then insert new elements to gchild map.
 	// Wrapped gchild map is expected to be unlined at the end of loop.
 
-	const gchildMapCount = 8
+	const gchildMapCount = uint64(8)
 	for i := range gchildMapCount {
 		// Get element at level 1
 
@@ -1316,7 +1318,7 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 		// Insert new elements to wrapped gchild map
 
 		k := test_utils.Uint64Value(i)
-		v := test_utils.Uint64Value(r.Intn(256))
+		v := test_utils.Uint64Value(r.Intn(256)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		existingStorable, err := wrappedMapAtLevel2.Set(test_utils.CompareValue, test_utils.GetHashInput, k, test_utils.NewSomeValue(v))
 		require.NoError(t, err)
@@ -1328,8 +1330,8 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 			test_utils.ExpectedMapValue{
 				test_utils.Uint64Value(0): test_utils.NewExpectedWrapperValue(expectedWrappedMapAtLevel2)})
 
-		require.Equal(t, uint64(i+1), wrappedMapAtLevel2.Count())
-		require.Equal(t, i+1, len(expectedWrappedMapAtLevel2))
+		require.Equal(t, i+1, wrappedMapAtLevel2.Count())
+		require.Equal(t, i+1, uint64(len(expectedWrappedMapAtLevel2)))
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	}
@@ -1339,7 +1341,7 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 	// Retrieve wrapped gchild map, and then remove elements from gchild map.
 	// Wrapped gchild map is expected to be inlined at the end of loop.
 
-	gchildMapCountAfterRemoval := 2
+	gchildMapCountAfterRemoval := uint64(2)
 	removeCount := gchildMapCount - gchildMapCountAfterRemoval
 
 	for i := range removeCount {
@@ -1380,7 +1382,9 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 
 		// Remove first element from wrapped gchild map
 
-		existingKeyStorable, existingValueStorable, err := wrappedMapAtLevel2.Remove(test_utils.CompareValue, test_utils.GetHashInput, test_utils.Uint64Value(i))
+		key := test_utils.Uint64Value(i)
+
+		existingKeyStorable, existingValueStorable, err := wrappedMapAtLevel2.Remove(test_utils.CompareValue, test_utils.GetHashInput, key)
 		require.NoError(t, err)
 		require.NotNil(t, existingKeyStorable)
 		require.NotNil(t, existingValueStorable)
@@ -1389,9 +1393,9 @@ func TestMapWrapperValueInlineMapAtLevel2(t *testing.T) {
 
 		existingValue, err := existingValueStorable.StoredValue(storage)
 		require.NoError(t, err)
-		testValueEqual(t, expectedWrappedMapAtLevel2[test_utils.Uint64Value(i)], existingValue)
+		testValueEqual(t, expectedWrappedMapAtLevel2[key], existingValue)
 
-		delete(expectedWrappedMapAtLevel2, test_utils.Uint64Value(i))
+		delete(expectedWrappedMapAtLevel2, key)
 
 		expectedValues[test_utils.Uint64Value(0)] = test_utils.NewExpectedWrapperValue(
 			test_utils.ExpectedMapValue{
@@ -1466,14 +1470,14 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 	m, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	actualMapCount := 0
+	actualMapCount := uint64(0)
 
 	t.Run("set and remove", func(t *testing.T) {
 		// Insert elements
 
-		var setCount int
+		var setCount uint64
 		for setCount < minWriteOperationCount {
-			setCount = r.Intn(maxWriteOperationCount + 1)
+			setCount = uint64(r.Intn(maxWriteOperationCount + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount += setCount
@@ -1491,17 +1495,18 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 			expectedValues[k] = expected
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
 		// Remove some elements
+		mapCount := m.Count()
 
-		var removeCount int
-		minRemoveCount := int(m.Count()) / 2
-		maxRemoveCount := int(m.Count()) / 4 * 3
+		var removeCount uint64
+		minRemoveCount := mapCount / 2
+		maxRemoveCount := mapCount / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(m.Count()) + 1)
+			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount -= removeCount
@@ -1523,7 +1528,7 @@ func TestMapWrapperValueModifyNewMapAtLevel1(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1601,14 +1606,14 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 	m, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	actualMapCount := 0
+	actualMapCount := uint64(0)
 
 	t.Run("set and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount int
+		var setCount uint64
 		for setCount < minWriteOperationCount {
-			setCount = r.Intn(maxWriteOperationCount + 1)
+			setCount = uint64(r.Intn(maxWriteOperationCount + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount += setCount
@@ -1624,17 +1629,19 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			expectedValues[k] = expected
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
 		// Remove some elements (including one previously inserted element)
 
-		var removeCount int
-		minRemoveCount := int(m.Count()) / 2
-		maxRemoveCount := int(m.Count()) / 4 * 3
+		mapCount := m.Count()
+
+		var removeCount uint64
+		minRemoveCount := mapCount / 2
+		maxRemoveCount := mapCount / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(m.Count()) + 1)
+			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount -= removeCount
@@ -1656,7 +1663,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1664,12 +1671,14 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 	t.Run("modify retrieved nested container and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount int
+		mapCount := m.Count()
+
+		var setCount uint64
 		if m.Count() <= 10 {
-			setCount = int(m.Count())
+			setCount = mapCount
 		} else {
-			for setCount < int(m.Count())/2 {
-				setCount = r.Intn(int(m.Count()) + 1)
+			for setCount < mapCount/2 {
+				setCount = uint64(r.Intn(int(mapCount + 1))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 		}
 
@@ -1697,17 +1706,19 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			expectedValues[setKey] = modifiedExpectedValue
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
 		// Remove some elements (including some previously set elements)
 
-		var removeCount int
-		minRemoveCount := int(m.Count()) / 2
-		maxRemoveCount := int(m.Count()) / 4 * 3
+		mapCount = m.Count()
+
+		var removeCount uint64
+		minRemoveCount := mapCount / 2
+		maxRemoveCount := mapCount / 4 * 3
 		for removeCount < minRemoveCount || removeCount > maxRemoveCount {
-			removeCount = r.Intn(int(m.Count()))
+			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount -= removeCount
@@ -1724,7 +1735,7 @@ func TestMapWrapperValueModifyNewMapAtLevel2(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1816,14 +1827,14 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 	m, err := atree.NewMap(storage, address, atree.NewDefaultDigesterBuilder(), typeInfo)
 	require.NoError(t, err)
 
-	actualMapCount := 0
+	actualMapCount := uint64(0)
 
 	t.Run("set and remove", func(t *testing.T) {
 		// Insert elements
 
-		var setCount int
+		var setCount uint64
 		for setCount < minWriteOperationCount {
-			setCount = r.Intn(maxWriteOperationCount + 1)
+			setCount = uint64(r.Intn(maxWriteOperationCount + 1)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount += setCount
@@ -1839,15 +1850,17 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			expectedValues[k] = expected
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
 		// Remove some elements
 
-		var removeCount int
-		for removeCount < int(m.Count())/2 {
-			removeCount = r.Intn(int(m.Count()) + 1)
+		mapCount := m.Count()
+
+		var removeCount uint64
+		for removeCount < mapCount/2 {
+			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount -= removeCount
@@ -1869,7 +1882,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})
@@ -1877,12 +1890,14 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 	t.Run("modify retrieved nested container and remove", func(t *testing.T) {
 		// Set elements
 
-		var setCount int
+		mapCount := m.Count()
+
+		var setCount uint64
 		if m.Count() <= 10 {
-			setCount = int(m.Count())
+			setCount = mapCount
 		} else {
-			for setCount < int(m.Count())/2 {
-				setCount = r.Intn(int(m.Count()) + 1)
+			for setCount < mapCount/2 {
+				setCount = uint64(r.Intn(int(mapCount + 1))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 			}
 		}
 
@@ -1912,15 +1927,17 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			expectedValues[key] = modifiedExpectedValue
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 
 		// Remove some elements
 
-		var removeCount int
-		for removeCount < int(m.Count())/2 {
-			removeCount = r.Intn(int(m.Count()))
+		mapCount = m.Count()
+
+		var removeCount uint64
+		for removeCount < mapCount/2 {
+			removeCount = uint64(r.Intn(int(mapCount))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		}
 
 		actualMapCount -= removeCount
@@ -1935,7 +1952,7 @@ func TestMapWrapperValueModifyNewMapAtLevel3(t *testing.T) {
 			keys = append(keys[:index], keys[index+1:]...)
 		}
 
-		require.Equal(t, uint64(actualMapCount), m.Count())
+		require.Equal(t, actualMapCount, m.Count())
 
 		testMap(t, storage, typeInfo, address, m, expectedValues, nil, true)
 	})

--- a/mapcollision_bench_test.go
+++ b/mapcollision_bench_test.go
@@ -66,7 +66,7 @@ func (db *collisionDigesterBuilder) Digest(hip atree.HashInputProvider, value at
 	}, nil
 }
 
-func (db *collisionDigesterBuilder) SetSeed(k1 uint64, k2 uint64) {
+func (db *collisionDigesterBuilder) SetSeed(uint64, uint64) {
 }
 
 type collisionDigester struct {
@@ -134,8 +134,8 @@ func BenchmarkCollisionPerDigest(b *testing.B) {
 			digesterBuilder := NewCollisionDigesterBuilder(collisionPerDigest)
 			keyValues := make(map[atree.Value]atree.Value, mapCount)
 			for i := range mapCount {
-				k := test_utils.Uint64Value(i)
-				v := test_utils.Uint64Value(i)
+				k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 				keyValues[k] = v
 			}
 

--- a/mapcollision_bench_test.go
+++ b/mapcollision_bench_test.go
@@ -134,8 +134,8 @@ func BenchmarkCollisionPerDigest(b *testing.B) {
 			digesterBuilder := NewCollisionDigesterBuilder(collisionPerDigest)
 			keyValues := make(map[atree.Value]atree.Value, mapCount)
 			for i := range mapCount {
-				k := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
-				v := test_utils.Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+				k := test_utils.Uint64Value(i)
+				v := test_utils.Uint64Value(i)
 				keyValues[k] = v
 			}
 

--- a/storage_bench_test.go
+++ b/storage_bench_test.go
@@ -46,7 +46,7 @@ func benchmarkFastCommit(b *testing.B, seed int64, numberOfSlabs int) {
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i))
+		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		id := atree.NewSlabID(addr, index)
 
@@ -87,7 +87,7 @@ func benchmarkNondeterministicFastCommit(b *testing.B, seed int64, numberOfSlabs
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i))
+		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		id := atree.NewSlabID(addr, index)
 
@@ -152,7 +152,7 @@ func benchmarkRetrieve(b *testing.B, seed int64, numberOfSlabs int) {
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i))
+		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		id := atree.NewSlabID(addr, index)
 
@@ -199,7 +199,7 @@ func benchmarkBatchPreload(b *testing.B, seed int64, numberOfSlabs int) {
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i))
+		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 		id := atree.NewSlabID(addr, index)
 

--- a/storage_bench_test.go
+++ b/storage_bench_test.go
@@ -46,7 +46,7 @@ func benchmarkFastCommit(b *testing.B, seed int64, numberOfSlabs int) {
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		binary.BigEndian.PutUint64(index[:], uint64(i))
 
 		id := atree.NewSlabID(addr, index)
 
@@ -87,7 +87,7 @@ func benchmarkNondeterministicFastCommit(b *testing.B, seed int64, numberOfSlabs
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		binary.BigEndian.PutUint64(index[:], uint64(i))
 
 		id := atree.NewSlabID(addr, index)
 
@@ -152,7 +152,7 @@ func benchmarkRetrieve(b *testing.B, seed int64, numberOfSlabs int) {
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		binary.BigEndian.PutUint64(index[:], uint64(i))
 
 		id := atree.NewSlabID(addr, index)
 
@@ -199,7 +199,7 @@ func benchmarkBatchPreload(b *testing.B, seed int64, numberOfSlabs int) {
 		addr := generateRandomAddress(r)
 
 		var index atree.SlabIndex
-		binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		binary.BigEndian.PutUint64(index[:], uint64(i))
 
 		id := atree.NewSlabID(addr, index)
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1225,7 +1225,7 @@ func generateLargeSlab(id atree.SlabID) atree.Slab {
 
 	storables := make([]atree.Storable, elementCount)
 	for i := range storables {
-		storable := test_utils.Uint64Value(uint64(i))
+		storable := test_utils.Uint64Value(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		storables[i] = storable
 	}
 
@@ -5142,7 +5142,7 @@ func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
 		ids := make([]atree.SlabID, numberOfSlabs)
 		for i := range ids {
 			var index atree.SlabIndex
-			binary.BigEndian.PutUint64(index[:], uint64(i))
+			binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			ids[i] = atree.NewSlabID(generateRandomAddress(r), index)
 		}
@@ -5165,7 +5165,7 @@ func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
 
 		for i := range ids {
 			var index atree.SlabIndex
-			binary.BigEndian.PutUint64(index[:], uint64(i))
+			binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 			id := atree.NewSlabID(generateRandomAddress(r), index)
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -1225,7 +1225,7 @@ func generateLargeSlab(id atree.SlabID) atree.Slab {
 
 	storables := make([]atree.Storable, elementCount)
 	for i := range storables {
-		storable := test_utils.Uint64Value(uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		storable := test_utils.Uint64Value(uint64(i))
 		storables[i] = storable
 	}
 
@@ -5142,7 +5142,7 @@ func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
 		ids := make([]atree.SlabID, numberOfSlabs)
 		for i := range ids {
 			var index atree.SlabIndex
-			binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			binary.BigEndian.PutUint64(index[:], uint64(i))
 
 			ids[i] = atree.NewSlabID(generateRandomAddress(r), index)
 		}
@@ -5165,7 +5165,7 @@ func TestStorageBatchPreloadNotFoundSlabs(t *testing.T) {
 
 		for i := range ids {
 			var index atree.SlabIndex
-			binary.BigEndian.PutUint64(index[:], uint64(i)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+			binary.BigEndian.PutUint64(index[:], uint64(i))
 
 			id := atree.NewSlabID(generateRandomAddress(r), index)
 

--- a/storage_test.go
+++ b/storage_test.go
@@ -549,7 +549,7 @@ func TestBasicSlabStorageSlabIDs(t *testing.T) {
 
 	storage := atree.NewBasicSlabStorage(nil, nil, nil, nil)
 
-	// Get slab ids from empty storgae
+	// Get slab ids from empty storage
 	ids := storage.SlabIDs()
 	require.Equal(t, 0, len(ids))
 
@@ -559,7 +559,7 @@ func TestBasicSlabStorageSlabIDs(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Get slab ids from non-empty storgae
+	// Get slab ids from non-empty storage
 	ids = storage.SlabIDs()
 	require.Equal(t, len(wantIDs), len(ids))
 

--- a/test_utils/value_utils.go
+++ b/test_utils/value_utils.go
@@ -257,6 +257,13 @@ var _ atree.Value = Uint64Value(0)
 var _ atree.Storable = Uint64Value(0)
 var _ HashableValue = Uint64Value(0)
 
+func NewUint64ValueFromInteger(i int) Uint64Value {
+	if i < 0 {
+		panic(fmt.Sprintf("expect positive int for Uint64Value, got %d", i))
+	}
+	return Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+}
+
 func (v Uint64Value) ChildStorables() []atree.Storable { return nil }
 
 func (v Uint64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {

--- a/test_utils/value_utils.go
+++ b/test_utils/value_utils.go
@@ -261,7 +261,7 @@ func NewUint64ValueFromInteger(i int) Uint64Value {
 	if i < 0 {
 		panic(fmt.Sprintf("expect positive int for Uint64Value, got %d", i))
 	}
-	return Uint64Value(i) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+	return Uint64Value(i)
 }
 
 func (v Uint64Value) ChildStorables() []atree.Storable { return nil }

--- a/utils_test.go
+++ b/utils_test.go
@@ -76,23 +76,23 @@ func randomValue(r *rand.Rand, maxInlineSize uint64) atree.Value {
 	switch r.Intn(maxSimpleValueType) {
 
 	case uint8Type:
-		return test_utils.Uint8Value(r.Intn(255)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		return test_utils.Uint8Value(r.Intn(255))
 
 	case uint16Type:
-		return test_utils.Uint16Value(r.Intn(6535)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		return test_utils.Uint16Value(r.Intn(6535))
 
 	case uint32Type:
-		return test_utils.Uint32Value(r.Intn(4294967295)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		return test_utils.Uint32Value(r.Intn(4294967295))
 
 	case uint64Type:
-		return test_utils.Uint64Value(r.Intn(1844674407370955161)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		return test_utils.Uint64Value(r.Intn(1844674407370955161))
 
 	case smallStringType: // small string (inlinable)
-		slen := r.Intn(int(maxInlineSize)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		slen := r.Intn(int(maxInlineSize))
 		return test_utils.NewStringValue(randStr(r, slen))
 
 	case largeStringType: // large string (external)
-		slen := r.Intn(1024) + int(maxInlineSize) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+		slen := r.Intn(1024) + int(maxInlineSize)
 		return test_utils.NewStringValue(randStr(r, slen))
 
 	default:
@@ -251,7 +251,7 @@ func testEqualValueIDAndSlabID(t *testing.T, slabID atree.SlabID, valueID atree.
 }
 
 func getRandomArrayIndex(r *rand.Rand, array *atree.Array) uint64 {
-	return uint64(r.Intn(int(array.Count()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+	return uint64(r.Intn(int(array.Count())))
 }
 
 func getRandomArrayIndexes(r *rand.Rand, array *atree.Array, count int) []uint64 {
@@ -275,7 +275,7 @@ func getRandomUint64InRange(r *rand.Rand, minNum uint64, maxNum uint64) uint64 {
 		panic(fmt.Sprintf("min %d >= max %d", minNum, maxNum))
 	}
 	// since minNum < maxNum, maxNum - minNum >= 1
-	return minNum + uint64(r.Intn(int(maxNum-minNum))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+	return minNum + uint64(r.Intn(int(maxNum-minNum)))
 }
 
 type uint64Slice []uint64

--- a/utils_test.go
+++ b/utils_test.go
@@ -71,27 +71,27 @@ func randStr(r *rand.Rand, length int) string {
 	return string(b)
 }
 
-func randomValue(r *rand.Rand, maxInlineSize int) atree.Value {
+func randomValue(r *rand.Rand, maxInlineSize uint64) atree.Value {
 	switch r.Intn(maxSimpleValueType) {
 
 	case uint8Type:
-		return test_utils.Uint8Value(r.Intn(255)) //nolint:gosec
+		return test_utils.Uint8Value(r.Intn(255)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 	case uint16Type:
-		return test_utils.Uint16Value(r.Intn(6535)) //nolint:gosec
+		return test_utils.Uint16Value(r.Intn(6535)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 	case uint32Type:
-		return test_utils.Uint32Value(r.Intn(4294967295)) //nolint:gosec
+		return test_utils.Uint32Value(r.Intn(4294967295)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 	case uint64Type:
-		return test_utils.Uint64Value(r.Intn(1844674407370955161)) //nolint:gosec
+		return test_utils.Uint64Value(r.Intn(1844674407370955161)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 
 	case smallStringType: // small string (inlinable)
-		slen := r.Intn(maxInlineSize)
+		slen := r.Intn(int(maxInlineSize)) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		return test_utils.NewStringValue(randStr(r, slen))
 
 	case largeStringType: // large string (external)
-		slen := r.Intn(1024) + maxInlineSize
+		slen := r.Intn(1024) + int(maxInlineSize) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
 		return test_utils.NewStringValue(randStr(r, slen))
 
 	default:

--- a/utils_test.go
+++ b/utils_test.go
@@ -32,6 +32,16 @@ import (
 	"github.com/onflow/atree/test_utils"
 )
 
+const (
+	uint8Type int = iota
+	uint16Type
+	uint32Type
+	uint64Type
+	smallStringType
+	largeStringType
+	maxSimpleValueType
+)
+
 var (
 	runes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
 )
@@ -62,25 +72,25 @@ func randStr(r *rand.Rand, length int) string {
 }
 
 func randomValue(r *rand.Rand, maxInlineSize int) atree.Value {
-	switch r.Intn(6) {
+	switch r.Intn(maxSimpleValueType) {
 
-	case 0:
-		return test_utils.Uint8Value(r.Intn(255))
+	case uint8Type:
+		return test_utils.Uint8Value(r.Intn(255)) //nolint:gosec
 
-	case 1:
-		return test_utils.Uint16Value(r.Intn(6535))
+	case uint16Type:
+		return test_utils.Uint16Value(r.Intn(6535)) //nolint:gosec
 
-	case 2:
-		return test_utils.Uint32Value(r.Intn(4294967295))
+	case uint32Type:
+		return test_utils.Uint32Value(r.Intn(4294967295)) //nolint:gosec
 
-	case 3:
-		return test_utils.Uint64Value(r.Intn(1844674407370955161))
+	case uint64Type:
+		return test_utils.Uint64Value(r.Intn(1844674407370955161)) //nolint:gosec
 
-	case 4: // small string (inlinable)
+	case smallStringType: // small string (inlinable)
 		slen := r.Intn(maxInlineSize)
 		return test_utils.NewStringValue(randStr(r, slen))
 
-	case 5: // large string (external)
+	case largeStringType: // large string (external)
 		slen := r.Intn(1024) + maxInlineSize
 		return test_utils.NewStringValue(randStr(r, slen))
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -20,6 +20,7 @@ package atree_test
 
 import (
 	"flag"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -248,3 +249,37 @@ func testEqualValueIDAndSlabID(t *testing.T, slabID atree.SlabID, valueID atree.
 	require.Equal(t, sidAddress[:], valueID[:atree.SlabAddressLength])
 	require.Equal(t, sidIndex[:], valueID[atree.SlabAddressLength:])
 }
+
+func getRandomArrayIndex(r *rand.Rand, array *atree.Array) uint64 {
+	return uint64(r.Intn(int(array.Count()))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+}
+
+func getRandomArrayIndexes(r *rand.Rand, array *atree.Array, count int) []uint64 {
+	set := make(map[uint64]struct{})
+	for len(set) < count {
+		n := getRandomArrayIndex(r, array)
+		set[n] = struct{}{}
+	}
+
+	slice := make([]uint64, 0, count)
+	for n := range set {
+		slice = append(slice, n)
+	}
+
+	return slice
+}
+
+// getRandomUint64InRange returns a number in the range of [min, max)
+func getRandomUint64InRange(r *rand.Rand, minNum uint64, maxNum uint64) uint64 {
+	if minNum >= maxNum {
+		panic(fmt.Sprintf("min %d >= max %d", minNum, maxNum))
+	}
+	// since minNum < maxNum, maxNum - minNum >= 1
+	return minNum + uint64(r.Intn(int(maxNum-minNum))) //nolint:gosec // integer overflow conversions (e.g. uint64 -> int (G115), etc.) are OK for tests
+}
+
+type uint64Slice []uint64
+
+func (x uint64Slice) Len() int           { return len(x) }
+func (x uint64Slice) Less(i, j int) bool { return x[i] < x[j] }
+func (x uint64Slice) Swap(i, j int)      { x[i], x[j] = x[j], x[i] }


### PR DESCRIPTION
Updates #464

This PR improves maintainability and also fixes an obscure flakey test panic.

Previously, using `-seed=1740673974985490609` with `go test` caused a test to always panic:

```
$ go test -run TestArrayWrapperValueModifyNewArrayAtLevel3 -seed=1740673974985490609
--- FAIL: TestArrayWrapperValueModifyNewArrayAtLevel3 (0.00s)
    utils_test.go:49: seed: 1740673974985490609
    --- FAIL: TestArrayWrapperValueModifyNewArrayAtLevel3/insert_and_remove (0.00s)
panic: invalid argument to Intn [recovered]
	panic: invalid argument to Intn
```

With this PR, using `-seed=1740673974985490609` with the same test passes.

```
go test -run TestArrayWrapperValueModifyNewArrayAtLevel3 -seed=1740673974985490609
PASS
ok  	github.com/onflow/atree	0.022s
```
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
