### PR TITLE
Refactor to simplify merging child slabs in array

### DIFF
--- a/array_metadata_slab.go
+++ b/array_metadata_slab.go
@@ -644,23 +644,24 @@ func (a *ArrayMetaDataSlab) updateChildrenHeadersAfterMerge(
 	leftSlabIndex int,
 	rightSlabIndex int,
 ) {
-	// Update right slab header
-	a.childrenHeaders[rightSlabIndex] = mergedSlabHeader
+	// Update left slab header
+	a.childrenHeaders[leftSlabIndex] = mergedSlabHeader
 
-	// Remove left slab header
+	// Remove right slab header
 	a.childrenHeaders = slices.Delete[[]ArraySlabHeader](
 		a.childrenHeaders,
-		leftSlabIndex,
 		rightSlabIndex,
+		rightSlabIndex+1,
 	)
 
-	// NOTE: right slab count sum is unchanged
+	// Update left slab count sum
+	a.childrenCountSum[leftSlabIndex] = a.childrenCountSum[rightSlabIndex]
 
-	// Remove left slab count sum
+	// Remove right slab count sum
 	a.childrenCountSum = slices.Delete[[]uint32](
 		a.childrenCountSum,
-		leftSlabIndex,
 		rightSlabIndex,
+		rightSlabIndex+1,
 	)
 }
 

--- a/array_metadata_slab.go
+++ b/array_metadata_slab.go
@@ -622,7 +622,7 @@ func (a *ArrayMetaDataSlab) updateChildrenHeadersAfterMerge(
 	a.childrenHeaders[leftSlabIndex] = mergedSlabHeader
 
 	// Remove right slab header
-	a.childrenHeaders = slices.Delete[[]ArraySlabHeader](
+	a.childrenHeaders = slices.Delete(
 		a.childrenHeaders,
 		rightSlabIndex,
 		rightSlabIndex+1,
@@ -632,7 +632,7 @@ func (a *ArrayMetaDataSlab) updateChildrenHeadersAfterMerge(
 	a.childrenCountSum[leftSlabIndex] = a.childrenCountSum[rightSlabIndex]
 
 	// Remove right slab count sum
-	a.childrenCountSum = slices.Delete[[]uint32](
+	a.childrenCountSum = slices.Delete(
 		a.childrenCountSum,
 		rightSlabIndex,
 		rightSlabIndex+1,

--- a/array_metadata_slab.go
+++ b/array_metadata_slab.go
@@ -533,64 +533,38 @@ func (a *ArrayMetaDataSlab) MergeOrRebalanceChildSlab(
 
 	// Child can't rebalance with any sibling.  It must merge with one sibling.
 
+	var leftSlab, rightSlab ArraySlab
+	var leftSlabIndex, rightSlabIndex int
+
 	if leftSib == nil {
 		// Merge (left) child slab with rightSib
 
-		leftSlabIndex := childHeaderIndex
-		rightSlabIndex := childHeaderIndex + 1
+		leftSlab, rightSlab = child, rightSib
+		leftSlabIndex, rightSlabIndex = childHeaderIndex, childHeaderIndex+1
 
-		return a.mergeChildren(
-			storage,
-			child,
-			rightSib,
-			leftSlabIndex,
-			rightSlabIndex,
-		)
-	}
-
-	if rightSib == nil {
+	} else if rightSib == nil {
 		// Merge leftSib with (right) child slab
 
-		leftSlabIndex := childHeaderIndex - 1
-		rightSlabIndex := childHeaderIndex
+		leftSlab, rightSlab = leftSib, child
+		leftSlabIndex, rightSlabIndex = childHeaderIndex-1, childHeaderIndex
 
-		return a.mergeChildren(
-			storage,
-			leftSib,
-			child,
-			leftSlabIndex,
-			rightSlabIndex,
-		)
-	}
-
-	// Merge with smaller sib
-
-	if leftSib.ByteSize() < rightSib.ByteSize() {
+	} else if leftSib.ByteSize() < rightSib.ByteSize() { // Merge with smaller sib
 		// Merge leftSib with (right) child slab
 
-		leftSlabIndex := childHeaderIndex - 1
-		rightSlabIndex := childHeaderIndex
+		leftSlab, rightSlab = leftSib, child
+		leftSlabIndex, rightSlabIndex = childHeaderIndex-1, childHeaderIndex
 
-		return a.mergeChildren(
-			storage,
-			leftSib,
-			child,
-			leftSlabIndex,
-			rightSlabIndex,
-		)
+	} else { // leftSib.ByteSize > rightSib.ByteSize
+		// Merge (left) child slab with rightSib
+
+		leftSlab, rightSlab = child, rightSib
+		leftSlabIndex, rightSlabIndex = childHeaderIndex, childHeaderIndex+1
 	}
-
-	// leftSib.ByteSize > rightSib.ByteSize
-
-	// Merge (left) child slab with rightSib
-
-	leftSlabIndex := childHeaderIndex
-	rightSlabIndex := childHeaderIndex + 1
 
 	return a.mergeChildren(
 		storage,
-		child,
-		rightSib,
+		leftSlab,
+		rightSlab,
 		leftSlabIndex,
 		rightSlabIndex,
 	)


### PR DESCRIPTION
Updates #464

Currently, `ArrayMetaDataSlab.MergeOrRebalanceChildSlab()` is complicated with over 300 lines of code.

This PR refactors merging in this function by adding new two helper functions `mergeChildren()` and `updateChildrenHeadersAfterMerge()`.

This PR also uses go1.21 `slices` package to simplify slice operations.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
