### PR TITLE
fix: typos in documentation files

### DIFF
--- a/array.go
+++ b/array.go
@@ -147,7 +147,7 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 		// Finalize current data slab without appending new element
 		if dataSlab.header.size >= uint32(targetThreshold) {
 
-			// Generate storge id for next data slab
+			// Generate storage id for next data slab
 			nextID, err := storage.GenerateSlabID(address)
 			if err != nil {
 				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
@@ -279,7 +279,7 @@ func nextLevelArraySlabs(storage SlabStorage, address Address, slabs []ArraySlab
 
 	nextLevelSlabsIndex := 0
 
-	// Generate storge id
+	// Generate storage id
 	id, err := storage.GenerateSlabID(address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
@@ -302,7 +302,7 @@ func nextLevelArraySlabs(storage SlabStorage, address Address, slabs []ArraySlab
 			slabs[nextLevelSlabsIndex] = metaSlab
 			nextLevelSlabsIndex++
 
-			// Generate storge id for next meta data slab
+			// Generate storage id for next meta data slab
 			id, err = storage.GenerateSlabID(address)
 			if err != nil {
 				// Wrap err as external error (if needed) because err is returned by SlabStorage interface.

--- a/blake3_regression_test.go
+++ b/blake3_regression_test.go
@@ -188,7 +188,7 @@ func checksumVaryingEndPosNoSeed(t *testing.T, cryptoHash512 hash.Hash, data []b
 // produced from SHA-512 in a feedback loop. SHA-512 is used instead
 // of SHAKE-256 XOF or a stream cipher because SHA-512 is bundled with
 // Go and is available in most languages. One reason a simple PRNG
-// isn't used here is because different implementions in different
+// isn't used here is because different implementations in different
 // programming languages are sometimes incompatible due to errors
 // (like SplitMix64). SHA-512 will be compatible everywhere.
 // For BLAKE3, we should use at least 64KiB because implementations

--- a/errors.go
+++ b/errors.go
@@ -442,7 +442,7 @@ func (e *CollisionLimitError) Error() string {
 }
 
 // MapElementCountError is a fatal error returned when element count is unexpected.
-// It is an implemtation error.
+// It is an implementation error.
 type MapElementCountError struct {
 	msg string
 }


### PR DESCRIPTION
This PR fixes several misspelled words in the docs/comments  
(e.g. "storge" -> "storage" and "implemtation" -> "implementation").