### PR TITLE
Use go1.21 clear() instead of loops to clear elements

### DIFF
--- a/array_data_slab.go
+++ b/array_data_slab.go
@@ -265,10 +265,8 @@ func (a *ArrayDataSlab) LendToRight(slab Slab) error {
 	rightSlab.header.count = count - leftCount
 
 	// Update left slab
-	// NOTE: prevent memory leak
-	for i := leftCount; i < uint32(len(a.elements)); i++ {
-		a.elements[i] = nil
-	}
+	// NOTE: clear to prevent memory leak
+	clear(a.elements[leftCount:])
 	a.elements = a.elements[:leftCount]
 	a.header.size = leftSize
 	a.header.count = leftCount

--- a/map_elements_hashkey.go
+++ b/map_elements_hashkey.go
@@ -431,10 +431,8 @@ func (e *hkeyElements) Merge(elems elements) error {
 	e.elems = append(e.elems, rElems.elems...)
 	e.size += rElems.Size() - hkeyElementsPrefixSize
 
-	// Set merged elements to nil to prevent memory leak
-	for i := range rElems.elems {
-		rElems.elems[i] = nil
-	}
+	// Set merged elements to nil to prevent memory leak.
+	clear(rElems.elems)
 
 	return nil
 }
@@ -473,13 +471,10 @@ func (e *hkeyElements) Split() (elements, elements, error) {
 	rightElements.size = dataSize - leftSize + hkeyElementsPrefixSize
 
 	e.hkeys = e.hkeys[:leftCount]
+	// NOTE: prevent memory leak
+	clear(e.elems[leftCount:])
 	e.elems = e.elems[:leftCount]
 	e.size = hkeyElementsPrefixSize + leftSize
-
-	// NOTE: prevent memory leak
-	for i := leftCount; i < len(e.hkeys); i++ {
-		e.elems[i] = nil
-	}
 
 	return e, rightElements, nil
 }
@@ -521,9 +516,7 @@ func (e *hkeyElements) LendToRight(re elements) error {
 
 	// Update left slab
 	// NOTE: prevent memory leak
-	for i := leftCount; i < len(e.elems); i++ {
-		e.elems[i] = nil
-	}
+	clear(e.elems[leftCount:])
 	e.hkeys = e.hkeys[:leftCount]
 	e.elems = e.elems[:leftCount]
 	e.size = hkeyElementsPrefixSize + leftSize


### PR DESCRIPTION
Updates #464

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
