### PR TITLE
Fix smoke test memory usage

### DIFF
--- a/cmd/smoke/array.go
+++ b/cmd/smoke/array.go
@@ -133,6 +133,7 @@ func testArray(
 	storage *atree.PersistentSlabStorage,
 	address atree.Address,
 	status *arrayStatus,
+	clearStorage func(),
 ) {
 
 	typeInfo := newArrayTypeInfo()
@@ -178,8 +179,7 @@ func testArray(
 				return
 			}
 
-			storage.DropDeltas()
-			storage.DropCache()
+			clearStorage()
 
 			// Load root slab from storage and cache it in read cache
 			rootID := array.SlabID()

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -144,6 +144,15 @@ func main() {
 		decodeTypeInfo,
 	)
 
+	clearStorage := func() {
+		// Clear storage deltas and cache
+		storage.DropDeltas()
+		storage.DropCache()
+
+		// Clear base storage reports
+		baseStorage.ResetReporter()
+	}
+
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	switch flagType {
@@ -161,7 +170,7 @@ func main() {
 
 		go updateStatus(sigc, status)
 
-		testArray(storage, address, status)
+		testArray(storage, address, status, clearStorage)
 
 	case "map":
 		var msg string
@@ -176,7 +185,7 @@ func main() {
 
 		go updateStatus(sigc, status)
 
-		testMap(storage, address, status)
+		testMap(storage, address, status, clearStorage)
 	}
 
 }

--- a/cmd/smoke/map.go
+++ b/cmd/smoke/map.go
@@ -112,6 +112,7 @@ func testMap(
 	storage *atree.PersistentSlabStorage,
 	address atree.Address,
 	status *mapStatus,
+	clearStorage func(),
 ) {
 	typeInfo := newMapTypeInfo()
 
@@ -155,8 +156,7 @@ func testMap(
 				return
 			}
 
-			storage.DropDeltas()
-			storage.DropCache()
+			clearStorage()
 
 			expectedValues = make(map[atree.Value]atree.Value, flagMaxLength)
 


### PR DESCRIPTION
Closes #535

Longer runs of smoke tests were detecting excessive memory use due to different tests reusing same code (to reduce duplicate test code) since PR #506 (refactor smoke tests).

This PR resolved this problem and updated smoke tests have been running since Sunday afternoon on March 9 with no problems detected (as of March 10).
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
