### PR TITLE
Rename cbor feature branch dep for downstream compatability

### DIFF
--- a/array_data_slab_decode.go
+++ b/array_data_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 func newArrayDataSlabFromData(

--- a/array_data_slab_decode.go
+++ b/array_data_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 func newArrayDataSlabFromData(

--- a/array_extradata.go
+++ b/array_extradata.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 type ArrayExtraData struct {

--- a/array_extradata.go
+++ b/array_extradata.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 type ArrayExtraData struct {

--- a/array_metadata_slab_decode.go
+++ b/array_metadata_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"encoding/binary"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 func newArrayMetaDataSlabFromData(

--- a/array_metadata_slab_decode.go
+++ b/array_metadata_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"encoding/binary"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 func newArrayMetaDataSlabFromData(

--- a/array_serialization_verify.go
+++ b/array_serialization_verify.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 // VerifyArraySerialization traverses array tree and verifies serialization

--- a/array_serialization_verify.go
+++ b/array_serialization_verify.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 // VerifyArraySerialization traverses array tree and verifies serialization

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onflow/atree"
 	"github.com/onflow/atree/test_utils"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 const maxStatusLength = 128

--- a/cmd/smoke/main.go
+++ b/cmd/smoke/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onflow/atree"
 	"github.com/onflow/atree/test_utils"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 const maxStatusLength = 128

--- a/cmd/smoke/typeinfo.go
+++ b/cmd/smoke/typeinfo.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/onflow/atree"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 const (

--- a/cmd/smoke/typeinfo.go
+++ b/cmd/smoke/typeinfo.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/onflow/atree"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 const (

--- a/compactmap_extradata.go
+++ b/compactmap_extradata.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 // compactMapExtraData is used for inlining compact values.

--- a/compactmap_extradata.go
+++ b/compactmap_extradata.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"strings"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 // compactMapExtraData is used for inlining compact values.

--- a/decode.go
+++ b/decode.go
@@ -18,7 +18,9 @@
 
 package atree
 
-import "github.com/fxamacker/cbor/v2"
+import (
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
+)
 
 type StorableDecoder func(
 	decoder *cbor.StreamDecoder,

--- a/decode.go
+++ b/decode.go
@@ -19,7 +19,7 @@
 package atree
 
 import (
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 type StorableDecoder func(

--- a/encode.go
+++ b/encode.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"math"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 // Encoder writes atree slabs to io.Writer.

--- a/encode.go
+++ b/encode.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 // Encoder writes atree slabs to io.Writer.

--- a/extradata.go
+++ b/extradata.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"sync"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 type ExtraData interface {
@@ -55,7 +55,6 @@ func newInlinedExtraDataFromData(
 	decodeStorable StorableDecoder,
 	defaultDecodeTypeInfo TypeInfoDecoder,
 ) ([]ExtraData, []byte, error) {
-
 	dec := decMode.NewByteStreamDecoder(data)
 
 	count, err := dec.DecodeArrayHead()
@@ -64,7 +63,13 @@ func newInlinedExtraDataFromData(
 	}
 
 	if count != inlinedExtraDataArrayCount {
-		return nil, nil, NewDecodingError(fmt.Errorf("failed to decode inlined extra data: expect %d elements, got %d elements", inlinedExtraDataArrayCount, count))
+		return nil, nil, NewDecodingError(
+			fmt.Errorf(
+				"failed to decode inlined extra data: expect %d elements, got %d elements",
+				inlinedExtraDataArrayCount,
+				count,
+			),
+		)
 	}
 
 	// element 0: array of duplicate type info
@@ -90,7 +95,9 @@ func newInlinedExtraDataFromData(
 	}
 
 	if extraDataCount == 0 {
-		return nil, nil, NewDecodingError(fmt.Errorf("failed to decode inlined extra data: expect at least one inlined extra data"))
+		return nil, nil, NewDecodingError(
+			fmt.Errorf("failed to decode inlined extra data: expect at least one inlined extra data"),
+		)
 	}
 
 	inlinedExtraData := make([]ExtraData, extraDataCount)
@@ -123,7 +130,9 @@ func newInlinedExtraDataFromData(
 			}
 
 		default:
-			return nil, nil, NewDecodingError(fmt.Errorf("failed to decode inlined extra data: unsupported tag number %d", tagNum))
+			return nil, nil, NewDecodingError(
+				fmt.Errorf("failed to decode inlined extra data: unsupported tag number %d", tagNum),
+			)
 		}
 	}
 
@@ -145,7 +154,6 @@ var typeInfoRefTagHeadAndTagNumber = []byte{0xd8, CBORTagTypeInfoRef}
 //	| [+ inlined type info] | [+ inlined extra data] |
 //	+-----------------------+------------------------+
 func (ied *InlinedExtraData) Encode(enc *Encoder) error {
-
 	typeInfos, typeInfoIndexes := ied.findDuplicateTypeInfo()
 
 	var err error
@@ -331,7 +339,6 @@ func (ied *InlinedExtraData) addCompactMapExtraData(
 	digests []Digest,
 	keys []ComparableStorable,
 ) (int, []ComparableStorable, error) {
-
 	encodedTypeInfo, err := getEncodedTypeInfo(data.TypeInfo)
 	if err != nil {
 		// err is already categorized by getEncodedTypeInfo().

--- a/extradata.go
+++ b/extradata.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 type ExtraData interface {

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module github.com/onflow/atree
 
 go 1.23
 
+replace github.com/fxamacker/cbor/v2/cborstream => github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f
+
 require (
-	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f
+	github.com/fxamacker/cbor/v2/cborstream v0.0.0-00010101000000-000000000000
 	github.com/fxamacker/circlehash v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/blake3 v0.2.4
@@ -12,6 +14,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,8 @@ module github.com/onflow/atree
 
 go 1.23
 
-replace github.com/fxamacker/cbor/v2/cborstream => github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f
-
 require (
-	github.com/fxamacker/cbor/v2/cborstream v0.0.0-00010101000000-000000000000
+	github.com/SophisticaSean/cbor/v2 v2.4.2-stream
 	github.com/fxamacker/circlehash v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/blake3 v0.2.4
@@ -14,7 +12,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
+github.com/SophisticaSean/cbor/v2 v2.4.2-stream h1:rYNWviV56oeoRM7rGyDhy4ghneYsmcoA9S2ohhJbUVc=
+github.com/SophisticaSean/cbor/v2 v2.4.2-stream/go.mod h1:Vn5D8e+oeCLKEY+KK3/mxiPDQ9U0l/FlkAImmMcFWmE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f h1:dxTR4AaxCwuQv9LAVTAC2r1szlS+epeuPT5ClLKT6ZY=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
-github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
-github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f h1:dxTR4AaxCwuQv9LAVTAC2r1szlS+epeuPT5ClLKT6ZY=
 github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
+github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=

--- a/map_data_slab_decode.go
+++ b/map_data_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 func newMapDataSlabFromData(

--- a/map_data_slab_decode.go
+++ b/map_data_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 func newMapDataSlabFromData(

--- a/map_element_decode.go
+++ b/map_element_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 func newElementFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDecoder, slabID SlabID, inlinedExtraData []ExtraData) (element, error) {

--- a/map_element_decode.go
+++ b/map_element_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 func newElementFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDecoder, slabID SlabID, inlinedExtraData []ExtraData) (element, error) {

--- a/map_elements_decode.go
+++ b/map_elements_decode.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 func newElementsFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDecoder, slabID SlabID, inlinedExtraData []ExtraData) (elements, error) {

--- a/map_elements_decode.go
+++ b/map_elements_decode.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 func newElementsFromData(cborDec *cbor.StreamDecoder, decodeStorable StorableDecoder, slabID SlabID, inlinedExtraData []ExtraData) (elements, error) {

--- a/map_extradata.go
+++ b/map_extradata.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 type MapExtraData struct {

--- a/map_extradata.go
+++ b/map_extradata.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 type MapExtraData struct {

--- a/map_metadata_slab_decode.go
+++ b/map_metadata_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"encoding/binary"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 func newMapMetaDataSlabFromData(

--- a/map_metadata_slab_decode.go
+++ b/map_metadata_slab_decode.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"encoding/binary"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 func newMapMetaDataSlabFromData(

--- a/map_serialization_verify.go
+++ b/map_serialization_verify.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 // VerifyMapSerialization traverses ordered map tree and verifies serialization

--- a/map_serialization_verify.go
+++ b/map_serialization_verify.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 // VerifyMapSerialization traverses ordered map tree and verifies serialization

--- a/slab_id_storable.go
+++ b/slab_id_storable.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 type SlabIDStorable SlabID

--- a/slab_id_storable.go
+++ b/slab_id_storable.go
@@ -21,7 +21,7 @@ package atree
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 type SlabIDStorable SlabID

--- a/storage.go
+++ b/storage.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 const LedgerBaseStorageSlabPrefix = "$"

--- a/storage.go
+++ b/storage.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"sync"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
 const LedgerBaseStorageSlabPrefix = "$"

--- a/storage_bench_test.go
+++ b/storage_bench_test.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"testing"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"

--- a/storage_bench_test.go
+++ b/storage_bench_test.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"

--- a/storage_test.go
+++ b/storage_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"

--- a/storage_test.go
+++ b/storage_test.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"testing"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"

--- a/test_utils/storable_utils.go
+++ b/test_utils/storable_utils.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 
 	"github.com/onflow/atree"
 )

--- a/test_utils/storable_utils.go
+++ b/test_utils/storable_utils.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"math"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 
 	"github.com/onflow/atree"
 )

--- a/test_utils/typeinfo_utils.go
+++ b/test_utils/typeinfo_utils.go
@@ -21,7 +21,7 @@ package test_utils
 import (
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 
 	"github.com/onflow/atree"
 )

--- a/test_utils/typeinfo_utils.go
+++ b/test_utils/typeinfo_utils.go
@@ -21,7 +21,7 @@ package test_utils
 import (
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 
 	"github.com/onflow/atree"
 )

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -19,71 +19,118 @@
 package atree
 
 import (
-	"bytes"
 	"fmt"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 )
 
-type TypeInfo interface {
-	Encode(*cbor.StreamEncoder) error
-	IsComposite() bool
-	Copy() TypeInfo
-}
-
-type TypeInfoDecoder func(
-	decoder *cbor.StreamDecoder,
-) (
-	TypeInfo,
-	error,
-)
-
-// encodeTypeInfo encodes TypeInfo either:
-// - as is (for TypeInfo in root slab extra data section), or
-// - as index of inlined TypeInfos (for TypeInfo in inlined slab extra data section)
-type encodeTypeInfo func(*Encoder, TypeInfo) error
-
-// defaultEncodeTypeInfo encodes TypeInfo as is.
-func defaultEncodeTypeInfo(enc *Encoder, typeInfo TypeInfo) error {
-	return typeInfo.Encode(enc.CBOR)
-}
-
-func decodeTypeInfoRefIfNeeded(inlinedTypeInfo []TypeInfo, defaultTypeInfoDecoder TypeInfoDecoder) TypeInfoDecoder {
-	if len(inlinedTypeInfo) == 0 {
-		return defaultTypeInfoDecoder
+func newElementFromData(
+	cborDec *cbor.StreamDecoder,
+	decodeStorable StorableDecoder,
+	slabID SlabID,
+	inlinedExtraData []ExtraData,
+) (element, error) {
+	nt, err := cborDec.NextType()
+	if err != nil {
+		return nil, NewDecodingError(err)
 	}
 
-	return func(decoder *cbor.StreamDecoder) (TypeInfo, error) {
-		rawTypeInfo, err := decoder.DecodeRawBytes()
+	switch nt {
+	case cbor.ArrayType:
+		// Don't need to wrap error as external error because err is already categorized by newSingleElementFromData().
+		return newSingleElementFromData(cborDec, decodeStorable, slabID, inlinedExtraData)
+
+	case cbor.TagType:
+		tagNum, err := cborDec.DecodeTagNumber()
 		if err != nil {
-			return nil, NewDecodingError(fmt.Errorf("failed to decode raw type info: %w", err))
+			return nil, NewDecodingError(err)
+		}
+		switch tagNum {
+		case CBORTagInlineCollisionGroup:
+			// Don't need to wrap error as external error because err is already categorized by newInlineCollisionGroupFromData().
+			return newInlineCollisionGroupFromData(cborDec, decodeStorable, slabID, inlinedExtraData)
+		case CBORTagExternalCollisionGroup:
+			// Don't need to wrap error as external error because err is already categorized by newExternalCollisionGroupFromData().
+			return newExternalCollisionGroupFromData(cborDec, decodeStorable, slabID, inlinedExtraData)
+		default:
+			return nil, NewDecodingError(fmt.Errorf("failed to decode element: unrecognized tag number %d", tagNum))
 		}
 
-		if len(rawTypeInfo) > len(typeInfoRefTagHeadAndTagNumber) &&
-			bytes.Equal(
-				rawTypeInfo[:len(typeInfoRefTagHeadAndTagNumber)],
-				typeInfoRefTagHeadAndTagNumber) {
-
-			// Type info is encoded as type info ref.
-
-			var index uint64
-
-			err = cbor.Unmarshal(rawTypeInfo[len(typeInfoRefTagHeadAndTagNumber):], &index)
-			if err != nil {
-				return nil, NewDecodingError(err)
-			}
-
-			if index >= uint64(len(inlinedTypeInfo)) {
-				return nil, NewDecodingError(fmt.Errorf("failed to decode type info ref: expect index < %d, got %d", len(inlinedTypeInfo), index))
-			}
-
-			return inlinedTypeInfo[int(index)], nil
-		}
-
-		// Decode type info as is.
-
-		dec := cbor.NewByteStreamDecoder(rawTypeInfo)
-
-		return defaultTypeInfoDecoder(dec)
+	default:
+		return nil, NewDecodingError(fmt.Errorf("failed to decode element: unrecognized CBOR type %s", nt))
 	}
+}
+
+func newSingleElementFromData(
+	cborDec *cbor.StreamDecoder,
+	decodeStorable StorableDecoder,
+	slabID SlabID,
+	inlinedExtraData []ExtraData,
+) (*singleElement, error) {
+	elemCount, err := cborDec.DecodeArrayHead()
+	if err != nil {
+		return nil, NewDecodingError(err)
+	}
+
+	if elemCount != 2 {
+		return nil, NewDecodingError(
+			fmt.Errorf("failed to decode single element: expect array of 2 elements, got %d elements", elemCount),
+		)
+	}
+
+	key, err := decodeStorable(cborDec, slabID, inlinedExtraData)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode key's storable")
+	}
+
+	value, err := decodeStorable(cborDec, slabID, inlinedExtraData)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode value's storable")
+	}
+
+	return &singleElement{
+		key:   key,
+		value: value,
+		size:  singleElementPrefixSize + key.ByteSize() + value.ByteSize(),
+	}, nil
+}
+
+func newInlineCollisionGroupFromData(
+	cborDec *cbor.StreamDecoder,
+	decodeStorable StorableDecoder,
+	slabID SlabID,
+	inlinedExtraData []ExtraData,
+) (*inlineCollisionGroup, error) {
+	elements, err := newElementsFromData(cborDec, decodeStorable, slabID, inlinedExtraData)
+	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by newElementsFromData().
+		return nil, err
+	}
+
+	return &inlineCollisionGroup{elements}, nil
+}
+
+func newExternalCollisionGroupFromData(
+	cborDec *cbor.StreamDecoder,
+	decodeStorable StorableDecoder,
+	slabID SlabID,
+	inlinedExtraData []ExtraData,
+) (*externalCollisionGroup, error) {
+	storable, err := decodeStorable(cborDec, slabID, inlinedExtraData)
+	if err != nil {
+		// Wrap err as external error (if needed) because err is returned by StorableDecoder callback.
+		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to decode Storable")
+	}
+
+	idStorable, ok := storable.(SlabIDStorable)
+	if !ok {
+		return nil, NewDecodingError(fmt.Errorf("failed to decode external collision group: expect slab ID, got %T", storable))
+	}
+
+	return &externalCollisionGroup{
+		slabID: SlabID(idStorable),
+		size:   externalCollisionGroupPrefixSize + idStorable.ByteSize(),
+	}, nil
 }

--- a/typeinfo.go
+++ b/typeinfo.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 )
 
 type TypeInfo interface {

--- a/utils_test.go
+++ b/utils_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fxamacker/cbor/v2"
+	cbor "github.com/fxamacker/cbor/v2/cborstream"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"

--- a/utils_test.go
+++ b/utils_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	cbor "github.com/fxamacker/cbor/v2/cborstream"
+	"github.com/SophisticaSean/cbor/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/onflow/atree"


### PR DESCRIPTION
## Description

Atree depends on a feature branch version of `cbor` `feature/stream`, unfortunately other dependencies are using the master/main branch release version of `cbor`. If these come into contact in a repo there's no way around the dep mismatch. This renames the import of the pinned feature-branch version of `cbor` to `cborstream` so that downstream deps can still use the most recent cbor without conflict.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
