### PR TITLE
Bump fxamacker/cbor to latest feature/stream-mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onflow/atree
 go 1.23
 
 require (
-	github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12
+	github.com/fxamacker/cbor/v2 v2.7.1-0.20250321215404-00478930d2f8
 	github.com/fxamacker/circlehash v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/blake3 v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onflow/atree
 go 1.23
 
 require (
-	github.com/fxamacker/cbor/v2 v2.7.1-0.20250321215404-00478930d2f8
+	github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829
 	github.com/fxamacker/circlehash v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/blake3 v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onflow/atree
 go 1.23
 
 require (
-	github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f
+	github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12
 	github.com/fxamacker/circlehash v0.3.0
 	github.com/stretchr/testify v1.10.0
 	github.com/zeebo/blake3 v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12 h1:6vdtsOwDPaDihHIbtNg1OwK9M6EDXyk6j+qBbWN1vdI=
-github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/fxamacker/cbor/v2 v2.7.1-0.20250321215404-00478930d2f8 h1:LqXKCYr0aEtroUzj8uG0cWtEe+u/P269KvaL6jYLors=
+github.com/fxamacker/cbor/v2 v2.7.1-0.20250321215404-00478930d2f8/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f h1:dxTR4AaxCwuQv9LAVTAC2r1szlS+epeuPT5ClLKT6ZY=
-github.com/fxamacker/cbor/v2 v2.4.1-0.20220515183430-ad2eae63303f/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
+github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12 h1:6vdtsOwDPaDihHIbtNg1OwK9M6EDXyk6j+qBbWN1vdI=
+github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fxamacker/cbor/v2 v2.7.1-0.20250321215404-00478930d2f8 h1:LqXKCYr0aEtroUzj8uG0cWtEe+u/P269KvaL6jYLors=
-github.com/fxamacker/cbor/v2 v2.7.1-0.20250321215404-00478930d2f8/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829 h1:qOglMkJ5YBwog/GU/NXhP9gFqxUGMuqnmCkbj65JMhk=
+github.com/fxamacker/cbor/v2 v2.8.1-0.20250402194037-6f932b086829/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/fxamacker/circlehash v0.3.0 h1:XKdvTtIJV9t7DDUtsf0RIpC1OcxZtPbmgIH7ekx28WA=
 github.com/fxamacker/circlehash v0.3.0/go.mod h1:3aq3OfVvsWtkWMb6A1owjOQFA+TLsD5FgJflnaQwtMM=
 github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=


### PR DESCRIPTION
Closes #539 
Updates https://github.com/onflow/flow-go/issues/7221
Requires fxamacker/cbor#640, fxamacker/cbor#650

This PR bumps version of `fxamacker/cbor` to use the updated `feature/stream-mode` branch based on `fxamacker/cbor` from v2.4.0 to v2.8.0.

For more info about changes between cbor v2.4.0 and v2.8.0, see [fxamacker/cbor/releases](https://github.com/fxamacker/cbor/releases).

IMPORTANT: Do not merge this to main branch until this update passes tests:
- [x] atree CI tests
- [x] atree smoke testing
- [x] flow-go backward compatibility tests for testnet (100K and 1M blocks)
- [x] flow-go backward compatibility tests for mainnet (100K and 1M blocks)
- [x] tests (integration tests) in repos using atree:
  - [x] cadence CI tests
  - [x] flow-go CI tests

This PR and atree testing is done as of April 2.  I'm postponing merging this until other repos related to onflow/flow-go#7221 are ready to merge too.

### Example program with dependencies using different versions of fxamacker/cbor/v2

Confirmed a simple program with dependencies using different versions of fxamacker/cbor/v2 will only include the latest version (e.g., v2.7.1-0.20250319155730-379167c29d12 in the PoC).

I used `go get` on the last commit of this PR like this when testing example programs:

`$ go get github.com/onflow/atree@3b2c3017dce96aaa9db324cae7708b07765f9752`

`$ cat go.mod`

```
module foo

go 1.23.7

require (
	github.com/fxamacker/cbor/v2 v2.7.1-0.20250319155730-379167c29d12
	github.com/onflow/atree v0.9.1-0.20250319161108-3b2c3017dce9
	...
)

// NOTE: replace directive is not needed.
...
```

The compiled example program specifying cbor v2.7.1-0.2025... (feature branch) having dependencies specifying cbor v2.7.0 (main branch) will use v2.7.1-0.2025...

This approach is backward compatible and avoids bloating the executable because only one version of fxamacker/cbor is compiled into the executable.


______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
