### PR TITLE
Add support for iterating over map data slab elements

### DIFF
--- a/map_element.go
+++ b/map_element.go
@@ -80,6 +80,8 @@ type element interface {
 	Count(storage SlabStorage) (uint32, error)
 
 	PopIterate(SlabStorage, MapPopIterationFunc) error
+
+	Iterate(SlabStorage, func(key MapKey, value MapValue) error) error
 }
 
 // elementGroup is a group of elements that must stay together during splitting or rebalancing.
@@ -267,6 +269,10 @@ func (e *singleElement) PopIterate(_ SlabStorage, fn MapPopIterationFunc) error 
 	return nil
 }
 
+func (e *singleElement) Iterate(_ SlabStorage, fn func(key MapKey, value MapValue) error) error {
+	return fn(e.key, e.value)
+}
+
 func (e *singleElement) String() string {
 	return fmt.Sprintf("%s:%s", e.key, e.value)
 }
@@ -437,6 +443,10 @@ func (e *inlineCollisionGroup) Count(_ SlabStorage) (uint32, error) {
 func (e *inlineCollisionGroup) PopIterate(storage SlabStorage, fn MapPopIterationFunc) error {
 	// Don't need to wrap error as external error because err is already categorized by elements.PopIterate().
 	return e.elements.PopIterate(storage, fn)
+}
+
+func (e *inlineCollisionGroup) Iterate(storage SlabStorage, fn func(key MapKey, value MapValue) error) error {
+	return e.elements.Iterate(storage, fn)
 }
 
 func (e *inlineCollisionGroup) String() string {
@@ -637,6 +647,20 @@ func (e *externalCollisionGroup) PopIterate(storage SlabStorage, fn MapPopIterat
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
 		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", e.slabID))
 	}
+	return nil
+}
+
+func (e *externalCollisionGroup) Iterate(storage SlabStorage, fn func(key MapKey, value MapValue) error) error {
+	elements, err := e.Elements(storage)
+	if err != nil {
+		return err
+	}
+
+	err = elements.Iterate(storage, fn)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/map_elements.go
+++ b/map_elements.go
@@ -88,6 +88,8 @@ type elements interface {
 	Size() uint32
 
 	PopIterate(SlabStorage, MapPopIterationFunc) error
+
+	Iterate(SlabStorage, func(MapKey, MapValue) error) error
 }
 
 func firstKeyInMapSlab(storage SlabStorage, slab MapSlab) (MapKey, error) {

--- a/map_elements_hashkey.go
+++ b/map_elements_hashkey.go
@@ -422,6 +422,7 @@ func (e *hkeyElements) Iterate(storage SlabStorage, fn func(key MapKey, value Ma
 	for _, elem := range e.elems {
 		err := elem.Iterate(storage, fn)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by element.Iterate().
 			return err
 		}
 	}

--- a/map_elements_hashkey.go
+++ b/map_elements_hashkey.go
@@ -418,6 +418,16 @@ func (e *hkeyElements) PopIterate(storage SlabStorage, fn MapPopIterationFunc) e
 	return nil
 }
 
+func (e *hkeyElements) Iterate(storage SlabStorage, fn func(key MapKey, value MapValue) error) error {
+	for _, elem := range e.elems {
+		err := elem.Iterate(storage, fn)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Slab operations (split, merge, and lend/borrow)
 
 func (e *hkeyElements) Merge(elems elements) error {

--- a/map_elements_nokey.go
+++ b/map_elements_nokey.go
@@ -229,6 +229,7 @@ func (e *singleElements) Iterate(storage SlabStorage, fn func(MapKey, MapValue) 
 
 		err := elem.Iterate(storage, fn)
 		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by element.Iterate().
 			return err
 		}
 	}

--- a/map_elements_nokey.go
+++ b/map_elements_nokey.go
@@ -222,6 +222,20 @@ func (e *singleElements) PopIterate(storage SlabStorage, fn MapPopIterationFunc)
 	return nil
 }
 
+func (e *singleElements) Iterate(storage SlabStorage, fn func(MapKey, MapValue) error) error {
+
+	for i := range e.elems {
+		elem := e.elems[i]
+
+		err := elem.Iterate(storage, fn)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Slab operations (split, merge, and lend/borrow)
 
 func (e *singleElements) Merge(_ elements) error {


### PR DESCRIPTION
## Description

Mostly useful for debugging.

TODO:
- [x] Tests. IDK how to manually create a map data slab, it seems like the construction is not exported
- [x] Error wrapping. The `PopIterate` functions sometimes wrap, sometimes have comments stating wrapping is not necessary. It is not quite clear to me

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
