### PR TITLE
Change slab size related variables from uint64 to uint32

### DIFF
--- a/array.go
+++ b/array.go
@@ -145,7 +145,7 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 		}
 
 		// Finalize current data slab without appending new element
-		if dataSlab.header.size >= uint32(targetThreshold) {
+		if dataSlab.header.size >= targetThreshold {
 
 			// Generate storage id for next data slab
 			nextID, err := storage.GenerateSlabID(address)
@@ -738,7 +738,7 @@ func (a *Array) setParentUpdater(f parentUpdater) {
 
 // setCallbackWithChild sets up callback function with child value (child)
 // so parent array (a) can be notified when child value is modified.
-func (a *Array) setCallbackWithChild(i uint64, child Value, maxInlineSize uint64) {
+func (a *Array) setCallbackWithChild(i uint64, child Value, maxInlineSize uint32) {
 	// Unwrap child value if needed (e.g. interpreter.SomeValue)
 	unwrappedChild, wrapperSize := unwrapValue(child)
 
@@ -878,7 +878,7 @@ func (a *Array) Inlined() bool {
 	return a.root.Inlined()
 }
 
-func (a *Array) Inlinable(maxInlineSize uint64) bool {
+func (a *Array) Inlinable(maxInlineSize uint32) bool {
 	return a.root.Inlinable(maxInlineSize)
 }
 
@@ -899,7 +899,7 @@ func (a *Array) getMutableElementIndex() map[ValueID]uint64 {
 // Storable returns array a as either:
 // - SlabIDStorable, or
 // - inlined data slab storable
-func (a *Array) Storable(_ SlabStorage, _ Address, maxInlineSize uint64) (Storable, error) {
+func (a *Array) Storable(_ SlabStorage, _ Address, maxInlineSize uint32) (Storable, error) {
 
 	inlined := a.root.Inlined()
 	inlinable := a.root.Inlinable(maxInlineSize)

--- a/array_data_slab.go
+++ b/array_data_slab.go
@@ -249,7 +249,7 @@ func (a *ArrayDataSlab) LendToRight(slab Slab) error {
 	// Left slab size is as close to midPoint as possible while right slab size >= minThreshold
 	for i := len(a.elements) - 1; i >= 0; i-- {
 		elemSize := a.elements[i].ByteSize()
-		if leftSize-elemSize < midPoint && size-leftSize >= uint32(minThreshold) {
+		if leftSize-elemSize < midPoint && size-leftSize >= minThreshold {
 			break
 		}
 		leftSize -= elemSize
@@ -287,7 +287,7 @@ func (a *ArrayDataSlab) BorrowFromRight(slab Slab) error {
 	for _, e := range rightSlab.elements {
 		elemSize := e.ByteSize()
 		if leftSize+elemSize > midPoint {
-			if size-leftSize-elemSize >= uint32(minThreshold) {
+			if size-leftSize-elemSize >= minThreshold {
 				// Include this element in left slab
 				leftSize += elemSize
 				leftCount++
@@ -314,15 +314,15 @@ func (a *ArrayDataSlab) BorrowFromRight(slab Slab) error {
 }
 
 func (a *ArrayDataSlab) IsFull() bool {
-	return a.header.size > uint32(maxThreshold)
+	return a.header.size > maxThreshold
 }
 
 // IsUnderflow returns the number of bytes needed for the data slab
 // to reach the min threshold.
 // Returns true if the min threshold has not been reached yet.
 func (a *ArrayDataSlab) IsUnderflow() (uint32, bool) {
-	if uint32(minThreshold) > a.header.size {
-		return uint32(minThreshold) - a.header.size, true
+	if minThreshold > a.header.size {
+		return minThreshold - a.header.size, true
 	}
 	return 0, false
 }
@@ -333,13 +333,13 @@ func (a *ArrayDataSlab) CanLendToLeft(size uint32) bool {
 	if len(a.elements) < 2 {
 		return false
 	}
-	if a.header.size-size < uint32(minThreshold) {
+	if a.header.size-size < minThreshold {
 		return false
 	}
 	lendSize := uint32(0)
 	for i := range a.elements {
 		lendSize += a.elements[i].ByteSize()
-		if a.header.size-lendSize < uint32(minThreshold) {
+		if a.header.size-lendSize < minThreshold {
 			return false
 		}
 		if lendSize >= size {
@@ -355,13 +355,13 @@ func (a *ArrayDataSlab) CanLendToRight(size uint32) bool {
 	if len(a.elements) < 2 {
 		return false
 	}
-	if a.header.size-size < uint32(minThreshold) {
+	if a.header.size-size < minThreshold {
 		return false
 	}
 	lendSize := uint32(0)
 	for i := len(a.elements) - 1; i >= 0; i-- {
 		lendSize += a.elements[i].ByteSize()
-		if a.header.size-lendSize < uint32(minThreshold) {
+		if a.header.size-lendSize < minThreshold {
 			return false
 		}
 		if lendSize >= size {
@@ -376,7 +376,7 @@ func (a *ArrayDataSlab) CanLendToRight(size uint32) bool {
 // Inlinable returns true if
 // - array data slab is root slab
 // - size of inlined array data slab <= maxInlineSize
-func (a *ArrayDataSlab) Inlinable(maxInlineSize uint64) bool {
+func (a *ArrayDataSlab) Inlinable(maxInlineSize uint32) bool {
 	if a.extraData == nil {
 		// Non-root data slab is not inlinable.
 		return false
@@ -395,7 +395,7 @@ func (a *ArrayDataSlab) Inlinable(maxInlineSize uint64) bool {
 	}
 
 	// Inlined byte size must be less than max inline size.
-	return uint64(inlinedSize) <= maxInlineSize
+	return inlinedSize <= maxInlineSize
 }
 
 // Inline converts not-inlined ArrayDataSlab to inlined ArrayDataSlab and removes it from storage.

--- a/array_metadata_slab.go
+++ b/array_metadata_slab.go
@@ -773,29 +773,29 @@ func (a *ArrayMetaDataSlab) BorrowFromRight(slab Slab) error {
 }
 
 func (a ArrayMetaDataSlab) IsFull() bool {
-	return a.header.size > uint32(maxThreshold)
+	return a.header.size > maxThreshold
 }
 
 func (a ArrayMetaDataSlab) IsUnderflow() (uint32, bool) {
-	if uint32(minThreshold) > a.header.size {
-		return uint32(minThreshold) - a.header.size, true
+	if minThreshold > a.header.size {
+		return minThreshold - a.header.size, true
 	}
 	return 0, false
 }
 
 func (a *ArrayMetaDataSlab) CanLendToLeft(size uint32) bool {
 	n := uint32(math.Ceil(float64(size) / arraySlabHeaderSize))
-	return a.header.size-arraySlabHeaderSize*n > uint32(minThreshold)
+	return a.header.size-arraySlabHeaderSize*n > minThreshold
 }
 
 func (a *ArrayMetaDataSlab) CanLendToRight(size uint32) bool {
 	n := uint32(math.Ceil(float64(size) / arraySlabHeaderSize))
-	return a.header.size-arraySlabHeaderSize*n > uint32(minThreshold)
+	return a.header.size-arraySlabHeaderSize*n > minThreshold
 }
 
 // Inline operations
 
-func (a *ArrayMetaDataSlab) Inlinable(_ uint64) bool {
+func (a *ArrayMetaDataSlab) Inlinable(_ uint32) bool {
 	return false
 }
 

--- a/array_slab.go
+++ b/array_slab.go
@@ -50,7 +50,7 @@ type ArraySlab interface {
 	PopIterate(SlabStorage, ArrayPopIterationFunc) error
 
 	Inlined() bool
-	Inlinable(maxInlineSize uint64) bool
+	Inlinable(maxInlineSize uint32) bool
 	Inline(SlabStorage) error
 	Uninline(SlabStorage) error
 }

--- a/array_test.go
+++ b/array_test.go
@@ -5024,7 +5024,7 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	// Size of root data slab with two elements of max inlined size is target slab size minus
 	// slab id size (next slab id is omitted in root slab), and minus 1 byte
 	// (for rounding when computing max inline array element size).
-	require.Equal(t, atree.TargetSlabSize()-atree.SlabIDLength-1, uint64(GetArrayRootSlabByteSize(array)))
+	require.Equal(t, atree.TargetSlabSize()-atree.SlabIDLength-1, GetArrayRootSlabByteSize(array))
 
 	testArray(t, storage, typeInfo, address, array, expectedValues, false)
 }

--- a/array_verify.go
+++ b/array_verify.go
@@ -275,7 +275,7 @@ func (v *arrayVerifier) verifyDataSlab(
 		}
 
 		// Verify element size <= inline size
-		if e.ByteSize() > uint32(maxInlineArrayElementSize) {
+		if e.ByteSize() > maxInlineArrayElementSize {
 			return 0, nil, nil, NewFatalError(fmt.Errorf("data slab %s element %s size %d is too large, want < %d",
 				id, e, e.ByteSize(), maxInlineArrayElementSize))
 		}
@@ -284,7 +284,7 @@ func (v *arrayVerifier) verifyDataSlab(
 		case SlabIDStorable:
 			// Verify not-inlined element > inline size, or can't be inlined
 			if v.inlineEnabled {
-				err = verifyNotInlinedValueStatusAndSize(value, uint32(maxInlineArrayElementSize))
+				err = verifyNotInlinedValueStatusAndSize(value, maxInlineArrayElementSize)
 				if err != nil {
 					return 0, nil, nil, err
 				}

--- a/cmd/smoke/utils.go
+++ b/cmd/smoke/utils.go
@@ -346,7 +346,7 @@ func newComposite(
 	return expectedValues, m, nil
 }
 
-func unwrapValue(v atree.Value) (atree.Value, uint64) {
+func unwrapValue(v atree.Value) (atree.Value, uint32) {
 	switch v := v.(type) {
 	case atree.WrapperValue:
 		return v.UnwrapAtreeValue()

--- a/map_data_slab.go
+++ b/map_data_slab.go
@@ -229,7 +229,7 @@ func (m *MapDataSlab) IsFull() bool {
 	if m.anySize {
 		return false
 	}
-	return m.header.size > uint32(maxThreshold)
+	return m.header.size > maxThreshold
 }
 
 // IsUnderflow returns the number of bytes needed for the data slab
@@ -239,8 +239,8 @@ func (m *MapDataSlab) IsUnderflow() (uint32, bool) {
 	if m.anySize {
 		return 0, false
 	}
-	if uint32(minThreshold) > m.header.size {
-		return uint32(minThreshold) - m.header.size, true
+	if minThreshold > m.header.size {
+		return minThreshold - m.header.size, true
 	}
 	return 0, false
 }
@@ -272,7 +272,7 @@ func (m *MapDataSlab) Inlined() bool {
 // Inlinable returns true if
 // - map data slab is root slab
 // - size of inlined map data slab <= maxInlineSize
-func (m *MapDataSlab) Inlinable(maxInlineSize uint64) bool {
+func (m *MapDataSlab) Inlinable(maxInlineSize uint32) bool {
 	if m.extraData == nil {
 		// Non-root data slab is not inlinable.
 		return false
@@ -281,7 +281,7 @@ func (m *MapDataSlab) Inlinable(maxInlineSize uint64) bool {
 	inlinedSize := inlinedMapDataSlabPrefixSize + m.Size()
 
 	// Inlined byte size must be less than max inline size.
-	return uint64(inlinedSize) <= maxInlineSize
+	return inlinedSize <= maxInlineSize
 }
 
 // Inline converts not-inlined MapDataSlab to inlined MapDataSlab and removes it from storage.

--- a/map_element.go
+++ b/map_element.go
@@ -112,7 +112,7 @@ func newSingleElement(storage SlabStorage, address Address, key Value, value Val
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get key's storable")
 	}
 
-	vs, err := value.Storable(storage, address, maxInlineMapValueSize(uint64(ks.ByteSize())))
+	vs, err := value.Storable(storage, address, maxInlineMapValueSize(ks.ByteSize()))
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by Value interface.
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -179,7 +179,7 @@ func (e *singleElement) Set(
 	if equal {
 		existingMapValueStorable := e.value
 
-		valueStorable, err := value.Storable(storage, address, maxInlineMapValueSize(uint64(e.key.ByteSize())))
+		valueStorable, err := value.Storable(storage, address, maxInlineMapValueSize(e.key.ByteSize()))
 		if err != nil {
 			// Wrap err as external error (if needed) because err is returned by Value interface.
 			return nil, nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
@@ -355,7 +355,7 @@ func (e *inlineCollisionGroup) Set(
 	if level == 1 {
 		// Export oversized inline collision group to separate slab (external collision group)
 		// for first level collision.
-		if e.Size() > uint32(maxInlineMapElementSize) {
+		if e.Size() > maxInlineMapElementSize {
 
 			id, err := storage.GenerateSlabID(address)
 			if err != nil {

--- a/map_elements_hashkey.go
+++ b/map_elements_hashkey.go
@@ -514,7 +514,7 @@ func (e *hkeyElements) LendToRight(re elements) error {
 	// Left elements size is as close to midPoint as possible while right elements size >= minThreshold
 	for i := len(e.elems) - 1; i >= 0; i-- {
 		elemSize := e.elems[i].Size() + digestSize
-		if leftSize-elemSize < midPoint && size-leftSize >= uint32(minSize) {
+		if leftSize-elemSize < midPoint && size-leftSize >= minSize {
 			break
 		}
 		leftSize -= elemSize
@@ -559,7 +559,7 @@ func (e *hkeyElements) BorrowFromRight(re elements) error {
 	for _, elem := range rightElements.elems {
 		elemSize := elem.Size() + digestSize
 		if leftSize+elemSize > midPoint {
-			if size-leftSize-elemSize >= uint32(minSize) {
+			if size-leftSize-elemSize >= minSize {
 				// Include this element in left elements
 				leftSize += elemSize
 				leftCount++
@@ -594,14 +594,14 @@ func (e *hkeyElements) CanLendToLeft(size uint32) bool {
 	}
 
 	minSize := minThreshold - mapDataSlabPrefixSize
-	if e.Size()-size < uint32(minSize) {
+	if e.Size()-size < minSize {
 		return false
 	}
 
 	lendSize := uint32(0)
 	for i := range e.elems {
 		lendSize += e.elems[i].Size() + digestSize
-		if e.Size()-lendSize < uint32(minSize) {
+		if e.Size()-lendSize < minSize {
 			return false
 		}
 		if lendSize >= size {
@@ -621,14 +621,14 @@ func (e *hkeyElements) CanLendToRight(size uint32) bool {
 	}
 
 	minSize := minThreshold - mapDataSlabPrefixSize
-	if e.Size()-size < uint32(minSize) {
+	if e.Size()-size < minSize {
 		return false
 	}
 
 	lendSize := uint32(0)
 	for i := len(e.elems) - 1; i >= 0; i-- {
 		lendSize += e.elems[i].Size() + digestSize
-		if e.Size()-lendSize < uint32(minSize) {
+		if e.Size()-lendSize < minSize {
 			return false
 		}
 		if lendSize >= size {

--- a/map_elements_nokey.go
+++ b/map_elements_nokey.go
@@ -132,7 +132,7 @@ func (e *singleElements) Set(
 			existingKeyStorable := elem.key
 			existingValueStorable := elem.value
 
-			vs, err := value.Storable(storage, address, maxInlineMapValueSize(uint64(elem.key.ByteSize())))
+			vs, err := value.Storable(storage, address, maxInlineMapValueSize(elem.key.ByteSize()))
 			if err != nil {
 				// Wrap err as external error (if needed) because err is returned by Value interface.
 				return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")

--- a/map_metadata_slab.go
+++ b/map_metadata_slab.go
@@ -677,24 +677,24 @@ func (m *MapMetaDataSlab) BorrowFromRight(slab Slab) error {
 }
 
 func (m MapMetaDataSlab) IsFull() bool {
-	return m.header.size > uint32(maxThreshold)
+	return m.header.size > maxThreshold
 }
 
 func (m MapMetaDataSlab) IsUnderflow() (uint32, bool) {
-	if uint32(minThreshold) > m.header.size {
-		return uint32(minThreshold) - m.header.size, true
+	if minThreshold > m.header.size {
+		return minThreshold - m.header.size, true
 	}
 	return 0, false
 }
 
 func (m *MapMetaDataSlab) CanLendToLeft(size uint32) bool {
 	n := uint32(math.Ceil(float64(size) / mapSlabHeaderSize))
-	return m.header.size-mapSlabHeaderSize*n > uint32(minThreshold)
+	return m.header.size-mapSlabHeaderSize*n > minThreshold
 }
 
 func (m *MapMetaDataSlab) CanLendToRight(size uint32) bool {
 	n := uint32(math.Ceil(float64(size) / mapSlabHeaderSize))
-	return m.header.size-mapSlabHeaderSize*n > uint32(minThreshold)
+	return m.header.size-mapSlabHeaderSize*n > minThreshold
 }
 
 // Inline operations
@@ -703,7 +703,7 @@ func (m *MapMetaDataSlab) Inlined() bool {
 	return false
 }
 
-func (m *MapMetaDataSlab) Inlinable(_ uint64) bool {
+func (m *MapMetaDataSlab) Inlinable(_ uint32) bool {
 	return false
 }
 

--- a/map_slab.go
+++ b/map_slab.go
@@ -86,7 +86,7 @@ type MapSlab interface {
 	PopIterate(SlabStorage, MapPopIterationFunc) error
 
 	Inlined() bool
-	Inlinable(maxInlineSize uint64) bool
+	Inlinable(maxInlineSize uint32) bool
 	Inline(SlabStorage) error
 	Uninline(SlabStorage) error
 }

--- a/map_test.go
+++ b/map_test.go
@@ -14328,7 +14328,7 @@ func TestMapMaxInlineElement(t *testing.T) {
 	// Size of root data slab with two elements (key+value pairs) of
 	// max inlined size is target slab size minus
 	// slab id size (next slab id is omitted in root slab)
-	require.Equal(t, atree.TargetSlabSize()-atree.SlabIDLength, uint64(GetMapRootSlabByteSize(m)))
+	require.Equal(t, atree.TargetSlabSize()-atree.SlabIDLength, GetMapRootSlabByteSize(m))
 
 	testMap(t, storage, typeInfo, address, m, keyValues, nil, false)
 }
@@ -20033,7 +20033,7 @@ func TestMapDataSlabIterate(t *testing.T) {
 			ks, err := k.Storable(storage, address, atree.MaxInlineMapKeySize())
 			require.NoError(t, err)
 
-			vs, err := v.Storable(storage, address, atree.MaxInlineMapValueSize(uint64(ks.ByteSize())))
+			vs, err := v.Storable(storage, address, atree.MaxInlineMapValueSize(ks.ByteSize()))
 			require.NoError(t, err)
 
 			keyValueStorables = append(keyValueStorables, ks, vs)
@@ -20118,7 +20118,7 @@ func TestMapDataSlabIterate(t *testing.T) {
 				ks, err := k.Storable(storage, address, atree.MaxInlineMapKeySize())
 				require.NoError(t, err)
 
-				vs, err := v.Storable(storage, address, atree.MaxInlineMapValueSize(uint64(ks.ByteSize())))
+				vs, err := v.Storable(storage, address, atree.MaxInlineMapValueSize(ks.ByteSize()))
 				require.NoError(t, err)
 
 				keyValueStorables = append(keyValueStorables, ks, vs)

--- a/map_verify.go
+++ b/map_verify.go
@@ -489,7 +489,7 @@ func (v *mapVerifier) verifyHkeyElements(
 
 		// Verify element size is <= inline size
 		if digestLevel == 0 {
-			if e.Size() > uint32(maxInlineMapElementSize) {
+			if e.Size() > maxInlineMapElementSize {
 				return 0, 0, NewFatalError(
 					fmt.Errorf("data slab %d element %s size %d is too large, want < %d",
 						id, e, e.Size(), maxInlineMapElementSize))
@@ -588,7 +588,7 @@ func (v *mapVerifier) verifySingleElements(
 		}
 
 		// Verify element size is <= inline size
-		if e.Size() > uint32(maxInlineMapElementSize) {
+		if e.Size() > maxInlineMapElementSize {
 			return 0, 0, NewFatalError(
 				fmt.Errorf("data slab %d element %s size %d is too large, want < %d",
 					id, e, e.Size(), maxInlineMapElementSize))
@@ -622,7 +622,7 @@ func (v *mapVerifier) verifySingleElement(
 	err error,
 ) {
 	// Verify key storable's size is less than size limit
-	if e.key.ByteSize() > uint32(maxInlineMapKeySize) {
+	if e.key.ByteSize() > maxInlineMapKeySize {
 		return 0, 0, NewFatalError(
 			fmt.Errorf(
 				"map element key %s size %d exceeds size limit %d",
@@ -631,8 +631,8 @@ func (v *mapVerifier) verifySingleElement(
 	}
 
 	// Verify value storable's size is less than size limit
-	valueSizeLimit := maxInlineMapValueSize(uint64(e.key.ByteSize()))
-	if e.value.ByteSize() > uint32(valueSizeLimit) {
+	valueSizeLimit := maxInlineMapValueSize(e.key.ByteSize())
+	if e.value.ByteSize() > valueSizeLimit {
 		return 0, 0, NewFatalError(
 			fmt.Errorf(
 				"map element value %s size %d exceeds size limit %d",
@@ -664,7 +664,7 @@ func (v *mapVerifier) verifySingleElement(
 	case SlabIDStorable:
 		// Verify not-inlined value > inline size, or can't be inlined
 		if v.inlineEnabled {
-			err = verifyNotInlinedValueStatusAndSize(vv, uint32(valueSizeLimit))
+			err = verifyNotInlinedValueStatusAndSize(vv, valueSizeLimit)
 			if err != nil {
 				return 0, 0, err
 			}

--- a/storage_test.go
+++ b/storage_test.go
@@ -1389,7 +1389,7 @@ func (nonStorable) ChildStorables() []atree.Storable {
 	return nil
 }
 
-func (v nonStorable) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v nonStorable) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 

--- a/test_utils/expected_value_utils.go
+++ b/test_utils/expected_value_utils.go
@@ -31,7 +31,7 @@ type ExpectedArrayValue []atree.Value
 
 var _ atree.Value = &ExpectedArrayValue{}
 
-func (v ExpectedArrayValue) Storable(atree.SlabStorage, atree.Address, uint64) (atree.Storable, error) {
+func (v ExpectedArrayValue) Storable(atree.SlabStorage, atree.Address, uint32) (atree.Storable, error) {
 	panic(atree.NewUnreachableError())
 }
 
@@ -41,7 +41,7 @@ type ExpectedMapValue map[atree.Value]atree.Value
 
 var _ atree.Value = &ExpectedMapValue{}
 
-func (v ExpectedMapValue) Storable(atree.SlabStorage, atree.Address, uint64) (atree.Storable, error) {
+func (v ExpectedMapValue) Storable(atree.SlabStorage, atree.Address, uint32) (atree.Storable, error) {
 	panic(atree.NewUnreachableError())
 }
 
@@ -57,7 +57,7 @@ func NewExpectedWrapperValue(value atree.Value) ExpectedWrapperValue {
 	return ExpectedWrapperValue{value}
 }
 
-func (v ExpectedWrapperValue) Storable(atree.SlabStorage, atree.Address, uint64) (atree.Storable, error) {
+func (v ExpectedWrapperValue) Storable(atree.SlabStorage, atree.Address, uint32) (atree.Storable, error) {
 	panic(atree.NewUnreachableError())
 }
 

--- a/test_utils/value_utils.go
+++ b/test_utils/value_utils.go
@@ -57,7 +57,7 @@ func (v Uint8Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (v Uint8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Uint8Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 
@@ -122,7 +122,7 @@ func (v Uint16Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (v Uint16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Uint16Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 
@@ -186,7 +186,7 @@ func (v Uint32Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (v Uint32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Uint32Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 
@@ -270,7 +270,7 @@ func (v Uint64Value) StoredValue(_ atree.SlabStorage) (atree.Value, error) {
 	return v, nil
 }
 
-func (v Uint64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint64) (atree.Storable, error) {
+func (v Uint64Value) Storable(_ atree.SlabStorage, _ atree.Address, _ uint32) (atree.Storable, error) {
 	return v, nil
 }
 
@@ -383,8 +383,8 @@ func (v StringValue) Copy() atree.Storable {
 	return v
 }
 
-func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
-	if uint64(v.ByteSize()) > maxInlineSize {
+func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
+	if v.ByteSize() > maxInlineSize {
 		return atree.NewStorableSlab(storage, address, v)
 	}
 
@@ -471,7 +471,7 @@ func NewSomeValue(v atree.Value) SomeValue {
 func (v SomeValue) Storable(
 	storage atree.SlabStorage,
 	address atree.Address,
-	maxInlineSize uint64,
+	maxInlineSize uint32,
 ) (atree.Storable, error) {
 
 	// SomeStorable returned from this function can be encoded in two ways:
@@ -489,7 +489,7 @@ func (v SomeValue) Storable(
 
 	// Reduce maxInlineSize for non-SomeValue to make sure
 	// that SomeStorable wrapper is always encoded inline.
-	maxInlineSize -= uint64(someStorableEncodedPrefixSize)
+	maxInlineSize -= someStorableEncodedPrefixSize
 
 	nonSomeValueStorable, err := nonSomeValue.Storable(
 		storage,
@@ -539,19 +539,19 @@ func (v SomeValue) String() string {
 	return fmt.Sprintf("SomeValue(%s)", v.Value)
 }
 
-func (v SomeValue) UnwrapAtreeValue() (atree.Value, uint64) {
+func (v SomeValue) UnwrapAtreeValue() (atree.Value, uint32) {
 	nonSomeValue, nestedLevels := v.nonSomeValue()
 
 	someStorableEncodedPrefixSize := getSomeStorableEncodedPrefixSize(nestedLevels)
 
 	wv, ok := nonSomeValue.(atree.WrapperValue)
 	if !ok {
-		return nonSomeValue, uint64(someStorableEncodedPrefixSize)
+		return nonSomeValue, someStorableEncodedPrefixSize
 	}
 
 	unwrappedValue, wrapperSize := wv.UnwrapAtreeValue()
 
-	return unwrappedValue, wrapperSize + uint64(someStorableEncodedPrefixSize)
+	return unwrappedValue, wrapperSize + someStorableEncodedPrefixSize
 }
 
 // nonSomeValue returns a non-SomeValue and nested levels of SomeValue reached
@@ -592,7 +592,7 @@ func NewMutableValue(storableSize uint32) *MutableValue {
 	}
 }
 
-func (v *MutableValue) Storable(atree.SlabStorage, atree.Address, uint64) (atree.Storable, error) {
+func (v *MutableValue) Storable(atree.SlabStorage, atree.Address, uint32) (atree.Storable, error) {
 	return v.storable, nil
 }
 
@@ -613,7 +613,7 @@ func NewHashableMap(m *atree.OrderedMap) *HashableMap {
 	return &HashableMap{m}
 }
 
-func (v *HashableMap) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint64) (atree.Storable, error) {
+func (v *HashableMap) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
 	return v.m.Storable(storage, address, maxInlineSize)
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -72,7 +72,7 @@ func randStr(r *rand.Rand, length int) string {
 	return string(b)
 }
 
-func randomValue(r *rand.Rand, maxInlineSize uint64) atree.Value {
+func randomValue(r *rand.Rand, maxInlineSize uint32) atree.Value {
 	switch r.Intn(maxSimpleValueType) {
 
 	case uint8Type:


### PR DESCRIPTION
Currently, we use frequent type casting when comparing slab size with target slab size, because 
some slab size related variables, such as `targetThreshold`, `minThreshold`, `maxThreshold`, are `uint64`, but `ArraySlabHeader.size` and `MapSlabHeader.size` are `uint32`.

This PR refactors slab size related variables to use `uint32` to simplify code and be explicit about the supported max slab size (`math.MaxUint32`).

This PR also modifies some exported function parameters and return types to be consistent with the changes.  So client software needs to modify code calling the updated functions.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
