### PR TITLE
Update "Guidelines for Responsible Disclosure" in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,6 +10,6 @@ If you care about making a difference, please follow the guidelines below.
 
 We ask that all researchers adhere to these guidelines [here](https://flow.com/flow-responsible-disclosure).
 
-Currently, Atree does not officially support 32-bit platforms. If a vulnerability requires compiling the software for a 32-bit platform, then it should only be reported if the affected software claims to support 32-bit platforms.
+Currently, Atree does not officially support 32-bit platforms. If a vulnerability requires compiling the software for a 32-bit platform, then it should only be reported if the affected software officially supports 32-bit platforms.
 
 Please include the name and version of the tool that detected the issue (if applicable).  This can help us identify buggy or noisy vulnerability detectors, and identify duplicate reports more efficiently.


### PR DESCRIPTION
Updates https://github.com/onflow/flow-go/issues/8042

This PR adds this text to the "Guidelines for Responsible Disclosure" in SECURITY.md:

> Currently, Atree does not officially support 32-bit platforms. If a vulnerability requires compiling the software for a 32-bit platform, then it should only be reported if the affected software officially supports 32-bit platforms.

> Please include the name and version of the tool that detected the issue (if applicable).  This can help us identify buggy or noisy vulnerability detectors, and identify duplicate reports more efficiently.

While at it, added a missing period at the end of a sentence.

For more info, see https://github.com/onflow/flow-go/issues/8042.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
