### PR TITLE
Add "Flow Rewards" section to Atree Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,8 @@ Before submitting a security report, please review your source code included in 
 
 # Flow Rewards
 
-Security reports that follow the guidelines and meet other conditions of the vulnerability disclosure program might qualify for Flow Protocol Rewards.
+Security reports that follow the guidelines and meet other requirements of the vulnerability disclosure program might qualify for Flow Protocol Rewards.
 
-Security reports should not evaluate Atree as a standalone component, because Atree relies on some limits and security guarantees provided by other components, i.e. in the [Cadence programming language](https://github.com/onflow/cadence) and the [Flow node software](https://github.com/onflow/flow-go).  
+Security reports should not evaluate Atree as a standalone component, because Atree relies on some limits and security guarantees provided by other components, i.e. in the [Cadence programming language](https://github.com/onflow/cadence) and the [Flow node software](https://github.com/onflow/flow-go).
+
 Before submitting a report, please try to reproduce the vulnerability using a Cadence script or transaction using an unmodified [Flow Emulator](https://github.com/onflow/flow-emulator). See the [documentation](https://developers.flow.com/build/tools/emulator) on how to install and use it.


### PR DESCRIPTION
This PR adds a "Flow Rewards" section to SECURITY.md with some text paraphrased from some of @j1010001 ideas today, which might reduce security-related noise while still encouraging valid security reports.

Thanks @j1010001! 👍 

### Caveats

- If we make the text too strict, we may risk discouraging valid security reports.
- If we make the text too relaxed, we may spend more time reviewing and disqualifying invalid security reports.

______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
