### PR TITLE
Add two new functions to optimize atree array and Go []byte conversions

### DIFF
--- a/array_conversion.go
+++ b/array_conversion.go
@@ -1,0 +1,159 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree
+
+import (
+	"reflect"
+)
+
+// ByteStorable is a type constraint that permits any type that
+// implements Storable interface and has byte underlying type.
+type ByteStorable interface {
+	~byte
+	Storable
+}
+
+// ByteArrayToByteSlice converts an array to []byte if the array elements are of ByteStorable type.
+// ByteArrayToByteSlice returns UnexpectedElementTypeError error if any array element is not of ByteStorable type.
+func ByteArrayToByteSlice[T ByteStorable](array *Array) ([]byte, error) {
+	if array.Count() == 0 {
+		return nil, nil
+	}
+
+	// Get first array data slab for traversal.
+	slab, err := firstArrayDataSlab(array.Storage, array.root)
+	if err != nil {
+		// Don't need to wrap error as external error because err is already categorized by firstArrayDataSlab().
+		return nil, err
+	}
+
+	data := make([]byte, 0, array.Count())
+
+	// Traverse array data slabs to construct []byte.
+	for {
+		for _, e := range slab.elements {
+			b, ok := e.(T)
+			if !ok {
+				return nil, NewUnexpectedElementTypeError(reflect.TypeFor[T](), reflect.TypeOf(e))
+			}
+			data = append(data, byte(b))
+		}
+
+		if slab.next == SlabIDUndefined {
+			break
+		}
+
+		nextSlab, err := getArraySlab(array.Storage, slab.next)
+		if err != nil {
+			// Don't need to wrap error as external error because err is already categorized by getArraySlab().
+			return nil, err
+		}
+
+		slab = nextSlab.(*ArrayDataSlab)
+	}
+
+	return data, nil
+}
+
+// ByteStorableValue is a type constraint that permits any type that
+// implements Storable and Value interfaces, and has byte underlying type.
+type ByteStorableValue interface {
+	~byte
+	Storable
+	Value
+}
+
+const (
+	byteStorableCBORTagSize  = 2
+	byteStorableCBORDataSize = 2
+)
+
+// ByteSliceToByteArray converts []byte to an array.
+func ByteSliceToByteArray[T ByteStorableValue](
+	storage SlabStorage,
+	address Address,
+	typeInfo TypeInfo,
+	data []byte,
+	estimatedByteStorableSize uint32,
+) (*Array, error) {
+	if len(data) == 0 {
+		return NewArray(storage, address, typeInfo)
+	}
+
+	if estimatedByteStorableSize == 0 {
+		estimatedByteStorableSize = byteStorableCBORTagSize + byteStorableCBORDataSize
+	}
+
+	estimatedEncodedDataSize := int(estimatedByteStorableSize) * len(data)
+
+	// If data can fit into a single data slab, create a new array with root data slab directly.
+	if estimatedEncodedDataSize+arrayRootDataSlabPrefixSize < int(targetThreshold) {
+
+		elementSize := uint32(0)
+		elements := make([]Storable, len(data))
+		for i, b := range data {
+			e := T(b)
+			elements[i] = e
+			elementSize += e.ByteSize()
+		}
+
+		if elementSize+arrayRootDataSlabPrefixSize < targetThreshold {
+			return newArrayWithElements(storage, address, typeInfo, elements, elementSize)
+		}
+	}
+
+	// Since data is too large to fit into a single data slab, call
+	// NewArrayFromBatchData() to create an array with multiple slabs.
+
+	index := 0
+	return NewArrayFromBatchData(
+		storage,
+		address,
+		typeInfo,
+		func() (Value, error) {
+			if index == len(data) {
+				return nil, nil
+			}
+			v := data[index]
+			index++
+			return T(v), nil
+		})
+}
+
+func newArrayWithElements(
+	storage SlabStorage,
+	address Address,
+	typeInfo TypeInfo,
+	elements []Storable,
+	elementSize uint32,
+) (*Array, error) {
+	// Create an empty array.
+	array, err := NewArray(storage, address, typeInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	// Modify array root slab to include elements.
+	root := array.root.(*ArrayDataSlab)
+	root.elements = elements
+	root.header.count = uint32(len(elements))
+	root.header.size += elementSize
+
+	return array, nil
+}

--- a/array_conversion_test.go
+++ b/array_conversion_test.go
@@ -1,0 +1,180 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/onflow/atree"
+	testutils "github.com/onflow/atree/test_utils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversionBetweenByteArrayAndByteSlice(t *testing.T) {
+	t.Parallel()
+
+	typeInfo := testutils.NewSimpleTypeInfo(42)
+	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+	estimatedElementSize := testutils.Uint8Value(math.MaxUint8).ByteSize()
+
+	t.Run("empty byte array", func(t *testing.T) {
+		storage := newTestPersistentStorage(t)
+
+		array, err := atree.NewArray(storage, address, typeInfo)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), array.Count())
+
+		// Convert atree array to []byte.
+		data, err := atree.ByteArrayToByteSlice[testutils.Uint8Value](array)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(data))
+
+		// Convert []byte to atree array.
+		convertedArray, err := atree.ByteSliceToByteArray[testutils.Uint8Value](storage, address, typeInfo, data, estimatedElementSize)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), convertedArray.Count())
+
+		testArray(t, storage, typeInfo, address, convertedArray, nil, false, 2)
+	})
+
+	t.Run("single-slab byte array", func(t *testing.T) {
+		const arrayCount = 10
+
+		storage := newTestPersistentStorage(t)
+
+		array, err := atree.NewArray(storage, address, typeInfo)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), array.Count())
+
+		expectedByteSlice := make([]byte, arrayCount)
+		expectedValues := make(testutils.ExpectedArrayValue, arrayCount)
+		for i := range arrayCount {
+			b := byte(i)
+			expectedByteSlice[i] = b
+
+			v := testutils.Uint8Value(b)
+			expectedValues[i] = testutils.Uint8Value(b)
+
+			err = array.Append(v)
+			require.NoError(t, err)
+		}
+		require.Equal(t, uint64(arrayCount), array.Count())
+		require.True(t, atree.GetArrayRootSlab(array).IsData())
+
+		// Convert atree array to []byte.
+		data, err := atree.ByteArrayToByteSlice[testutils.Uint8Value](array)
+		require.NoError(t, err)
+		require.Equal(t, arrayCount, len(data))
+		require.Equal(t, expectedByteSlice, data)
+
+		// Convert []byte to atree array.
+		convertedArray, err := atree.ByteSliceToByteArray[testutils.Uint8Value](storage, address, typeInfo, data, estimatedElementSize)
+		require.NoError(t, err)
+		require.Equal(t, uint64(arrayCount), convertedArray.Count())
+
+		for i := range arrayCount {
+			originalElement, err := array.Get(uint64(i))
+			require.NoError(t, err)
+
+			convertedElement, err := convertedArray.Get(uint64(i))
+			require.NoError(t, err)
+
+			require.Equal(t, originalElement, convertedElement)
+		}
+
+		testArray(t, storage, typeInfo, address, convertedArray, expectedValues, false, 2)
+	})
+
+	t.Run("multi-slab byte array", func(t *testing.T) {
+		const arrayCount = 4096
+
+		storage := newTestPersistentStorage(t)
+
+		array, err := atree.NewArray(storage, address, typeInfo)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), array.Count())
+
+		expectedByteSlice := make([]byte, arrayCount)
+		expectedValues := make(testutils.ExpectedArrayValue, arrayCount)
+		for i := range arrayCount {
+			b := uint8(i % 256)
+			expectedByteSlice[i] = b
+
+			v := testutils.Uint8Value(b)
+			expectedValues[i] = testutils.Uint8Value(b)
+
+			err = array.Append(v)
+			require.NoError(t, err)
+		}
+		require.Equal(t, uint64(arrayCount), array.Count())
+		require.False(t, atree.GetArrayRootSlab(array).IsData())
+
+		// Convert atree array to []byte.
+		data, err := atree.ByteArrayToByteSlice[testutils.Uint8Value](array)
+		require.NoError(t, err)
+		require.Equal(t, arrayCount, len(data))
+		require.Equal(t, expectedByteSlice, data)
+
+		// Convert []byte to atree array.
+		convertedArray, err := atree.ByteSliceToByteArray[testutils.Uint8Value](storage, address, typeInfo, data, estimatedElementSize)
+		require.NoError(t, err)
+		require.Equal(t, uint64(arrayCount), convertedArray.Count())
+
+		for i := range arrayCount {
+			originalElement, err := array.Get(uint64(i))
+			require.NoError(t, err)
+
+			convertedElement, err := convertedArray.Get(uint64(i))
+			require.NoError(t, err)
+
+			require.Equal(t, originalElement, convertedElement)
+		}
+
+		testArray(t, storage, typeInfo, address, convertedArray, expectedValues, false, 2)
+	})
+
+	t.Run("array with non byte elements", func(t *testing.T) {
+		const arrayCount = 10
+
+		storage := newTestPersistentStorage(t)
+
+		array, err := atree.NewArray(storage, address, typeInfo)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0), array.Count())
+
+		for i := range arrayCount {
+			b := byte(i)
+			v := testutils.Uint64Value(b)
+
+			err = array.Append(v)
+			require.NoError(t, err)
+		}
+		require.Equal(t, uint64(arrayCount), array.Count())
+		require.True(t, atree.GetArrayRootSlab(array).IsData())
+
+		_, err = atree.ByteArrayToByteSlice[testutils.Uint8Value](array)
+		require.Error(t, err)
+		var unexpectedElementTypeError *atree.UnexpectedElementTypeError
+		require.ErrorAs(t, err, &unexpectedElementTypeError)
+		require.ErrorContains(t, err, "invalid element type: expected testutils.Uint8Value, got testutils.Uint64Value")
+	})
+}

--- a/array_test.go
+++ b/array_test.go
@@ -53,7 +53,7 @@ func testEmptyArray(
 	address atree.Address,
 	array *atree.Array,
 ) {
-	testArray(t, storage, typeInfo, address, array, nil, false)
+	testArray(t, storage, typeInfo, address, array, nil, false, 1)
 }
 
 func testArrayV0(
@@ -65,7 +65,7 @@ func testArrayV0(
 	expectedValues testutils.ExpectedArrayValue,
 	hasNestedArrayMapElement bool,
 ) {
-	_testArray(t, storage, typeInfo, address, array, expectedValues, hasNestedArrayMapElement, false)
+	_testArray(t, storage, typeInfo, address, array, expectedValues, hasNestedArrayMapElement, false, 1)
 }
 
 func testArray(
@@ -76,8 +76,9 @@ func testArray(
 	array *atree.Array,
 	expectedValues testutils.ExpectedArrayValue,
 	hasNestedArrayMapElement bool,
+	numberOfRootSlabsInStorage int,
 ) {
-	_testArray(t, storage, typeInfo, address, array, expectedValues, hasNestedArrayMapElement, true)
+	_testArray(t, storage, typeInfo, address, array, expectedValues, hasNestedArrayMapElement, true, numberOfRootSlabsInStorage)
 }
 
 // _testArray tests array elements, serialization, and in-memory slab tree.
@@ -90,6 +91,7 @@ func _testArray(
 	expectedValues testutils.ExpectedArrayValue,
 	hasNestedArrayMapElement bool,
 	inlineEnabled bool,
+	numberOfRootSlabsInStorage int,
 ) {
 	require.True(t, testutils.CompareTypeInfo(typeInfo, array.Type()))
 	require.Equal(t, address, array.Address())
@@ -139,15 +141,15 @@ func _testArray(
 	require.NoError(t, err)
 
 	// Check storage slab tree
-	rootIDSet, err := atree.CheckStorageHealth(storage, 1)
+	rootIDSet, err := atree.CheckStorageHealth(storage, numberOfRootSlabsInStorage)
 	require.NoError(t, err)
 
 	rootIDs := make([]atree.SlabID, 0, len(rootIDSet))
 	for id := range rootIDSet {
 		rootIDs = append(rootIDs, id)
 	}
-	require.Equal(t, 1, len(rootIDs))
-	require.Equal(t, array.SlabID(), rootIDs[0])
+	require.Equal(t, numberOfRootSlabsInStorage, len(rootIDs))
+	require.Contains(t, rootIDs, array.SlabID())
 
 	// Encode all non-nil slab
 	deltas := atree.GetDeltas(storage)
@@ -181,7 +183,9 @@ func _testArray(
 
 		stats, err := atree.GetArrayStats(array)
 		require.NoError(t, err)
-		require.Equal(t, stats.SlabCount(), uint64(storage.Count()))
+		if numberOfRootSlabsInStorage == 1 {
+			require.Equal(t, stats.SlabCount(), uint64(storage.Count()))
+		}
 
 		if len(expectedValues) == 0 {
 			// Verify slab count for empty array
@@ -227,7 +231,7 @@ func TestArrayAppendAndGet(t *testing.T) {
 	require.ErrorAs(t, err, &indexOutOfBoundsError)
 	require.ErrorAs(t, userError, &indexOutOfBoundsError)
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, false)
+	testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 }
 
 func TestArraySetAndGet(t *testing.T) {
@@ -252,7 +256,7 @@ func TestArraySetAndGet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
@@ -267,7 +271,7 @@ func TestArraySetAndGet(t *testing.T) {
 			testValueEqual(t, oldValue, existingValue)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	// This tests slabs splitting and root slab reassignment caused by Set operation.
@@ -298,7 +302,7 @@ func TestArraySetAndGet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
@@ -313,7 +317,7 @@ func TestArraySetAndGet(t *testing.T) {
 			testValueEqual(t, oldValue, existingValue)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	// This tests slabs merging and root slab reassignment caused by Set operation.
@@ -345,7 +349,7 @@ func TestArraySetAndGet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 		for i := range expectedValues {
 			oldValue := expectedValues[i]
@@ -360,7 +364,7 @@ func TestArraySetAndGet(t *testing.T) {
 			testValueEqual(t, oldValue, existingValue)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("index out of bounds", func(t *testing.T) {
@@ -396,7 +400,7 @@ func TestArraySetAndGet(t *testing.T) {
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
 		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 }
 
@@ -427,7 +431,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("insert-last", func(t *testing.T) {
@@ -450,7 +454,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("insert", func(t *testing.T) {
@@ -482,7 +486,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("index out of bounds", func(t *testing.T) {
@@ -517,7 +521,7 @@ func TestArrayInsertAndGet(t *testing.T) {
 		require.ErrorAs(t, err, &indexOutOfBoundsError)
 		require.ErrorAs(t, userError, &indexOutOfBoundsError)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 }
 
@@ -572,7 +576,7 @@ func TestArrayRemove(t *testing.T) {
 			require.Equal(t, remainingArrayCount, array.Count())
 
 			if i%256 == 0 {
-				testArray(t, storage, typeInfo, address, array, expectedValues[i+1:], false)
+				testArray(t, storage, typeInfo, address, array, expectedValues[i+1:], false, 1)
 			}
 		}
 
@@ -620,7 +624,7 @@ func TestArrayRemove(t *testing.T) {
 			require.Equal(t, uint64(i), array.Count())
 
 			if i%256 == 0 {
-				testArray(t, storage, typeInfo, address, array, expectedValues[:i], false)
+				testArray(t, storage, typeInfo, address, array, expectedValues[:i], false, 1)
 			}
 		}
 
@@ -673,13 +677,13 @@ func TestArrayRemove(t *testing.T) {
 			require.Equal(t, uint64(len(expectedValues)), array.Count())
 
 			if i%256 == 0 {
-				testArray(t, storage, typeInfo, address, array, expectedValues, false)
+				testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 			}
 		}
 
 		require.Equal(t, arrayCount/2, uint64(len(expectedValues)))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("index out of bounds", func(t *testing.T) {
@@ -712,7 +716,7 @@ func TestArrayRemove(t *testing.T) {
 		require.ErrorAs(t, err, &indexOutOfBounds)
 		require.ErrorAs(t, userError, &indexOutOfBounds)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 }
 
@@ -1197,7 +1201,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate primitive values, root is metadata slab, no slab operation", func(t *testing.T) {
@@ -1245,7 +1249,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate primitive values, root is data slab, split slab", func(t *testing.T) {
@@ -1298,7 +1302,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate primitive values, root is metadata slab, split slab", func(t *testing.T) {
@@ -1351,7 +1355,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate primitive values, root is metadata slab, merge slabs", func(t *testing.T) {
@@ -1404,7 +1408,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate inlined container, root is data slab, no slab operation", func(t *testing.T) {
@@ -1463,7 +1467,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate inlined container, root is metadata slab, no slab operation", func(t *testing.T) {
@@ -1522,7 +1526,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate inlined container, root is data slab, split slab", func(t *testing.T) {
@@ -1595,7 +1599,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate inlined container, root is metadata slab, split slab", func(t *testing.T) {
@@ -1668,7 +1672,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("mutate inlined container, root is metadata slab, merge slab", func(t *testing.T) {
@@ -1741,7 +1745,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("uninline inlined container, root is data slab, no slab operation", func(t *testing.T) {
@@ -1815,7 +1819,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("uninline inlined container, root is metadata slab, merge slab", func(t *testing.T) {
@@ -1889,7 +1893,7 @@ func TestMutableArrayIterate(t *testing.T) {
 		require.Equal(t, arrayCount, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("inline uninlined container, root is data slab, no slab operation", func(t *testing.T) {
@@ -1964,7 +1968,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("inline uninlined container, root is data slab, split slab", func(t *testing.T) {
@@ -2039,7 +2043,7 @@ func TestMutableArrayIterate(t *testing.T) {
 
 		require.False(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("stop", func(t *testing.T) {
@@ -2429,7 +2433,7 @@ func TestMutableArrayIterateRange(t *testing.T) {
 		require.Equal(t, endIndex-startIndex, i)
 		require.True(t, IsArrayRootDataSlab(array))
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("stop", func(t *testing.T) {
@@ -2576,7 +2580,7 @@ func TestArraySetRandomValues(t *testing.T) {
 		testValueEqual(t, oldValue, existingValue)
 	}
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, false)
+	testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 }
 
 func TestArrayInsertRandomValues(t *testing.T) {
@@ -2609,7 +2613,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("insert-last", func(t *testing.T) {
@@ -2635,7 +2639,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("insert-random", func(t *testing.T) {
@@ -2663,7 +2667,7 @@ func TestArrayInsertRandomValues(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 }
 
@@ -2693,7 +2697,7 @@ func TestArrayRemoveRandomValues(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, false)
+	testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 	// Remove n elements at random index
 	for range arrayCount {
@@ -2827,7 +2831,7 @@ func TestArrayAppendSetInsertRemoveRandomValues(t *testing.T) {
 	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
 
 	array, expectedValues := testArrayAppendSetInsertRemoveRandomValues(t, r, storage, typeInfo, address, opCount)
-	testArray(t, storage, typeInfo, address, array, expectedValues, false)
+	testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 }
 
 func TestArrayWithChildArrayMap(t *testing.T) {
@@ -2871,7 +2875,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			expectedValues[i] = testutils.ExpectedArrayValue{v}
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("big array", func(t *testing.T) {
@@ -2913,7 +2917,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			expectedValues[i] = testutils.ExpectedArrayValue(expectedChildArrayValues)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("small map", func(t *testing.T) {
@@ -2948,7 +2952,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			expectedValues[i] = testutils.ExpectedMapValue{k: v}
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 	})
 
 	t.Run("big map", func(t *testing.T) {
@@ -2991,7 +2995,7 @@ func TestArrayWithChildArrayMap(t *testing.T) {
 			expectedValues[i] = expectedChildMapValues
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 }
 
@@ -3318,7 +3322,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	t.Run("root metadata slab", func(t *testing.T) {
@@ -3432,7 +3436,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	// Same type info is reused.
@@ -3513,7 +3517,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, parentArray.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	// Different type info are encoded.
@@ -3604,7 +3608,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, parentArray.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	// Same type info is reused.
@@ -3698,7 +3702,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, parentArray.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	t.Run("root data slab, multiple levels of inlined array of different type", func(t *testing.T) {
@@ -3813,7 +3817,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, parentArray.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	t.Run("root metadata slab, inlined array of same type", func(t *testing.T) {
@@ -3957,7 +3961,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	t.Run("root metadata slab, inlined array of different type", func(t *testing.T) {
@@ -4113,7 +4117,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	t.Run("has pointers", func(t *testing.T) {
@@ -4277,7 +4281,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 
 	t.Run("has pointers in inlined slab", func(t *testing.T) {
@@ -4466,7 +4470,7 @@ func TestArrayEncodeDecode(t *testing.T) {
 		array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 		require.NoError(t, err)
 
-		testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+		testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 	})
 }
 
@@ -4485,7 +4489,7 @@ func TestArrayEncodeDecodeRandomValues(t *testing.T) {
 
 	array, expectedValues := testArrayAppendSetInsertRemoveRandomValues(t, r, storage, typeInfo, address, opCount)
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, false)
+	testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 	// Decode data to new storage
 	storage2 := newTestPersistentStorageWithBaseStorage(t, atree.GetBaseStorage(storage))
@@ -4494,7 +4498,7 @@ func TestArrayEncodeDecodeRandomValues(t *testing.T) {
 	array2, err := atree.NewArrayWithRootID(storage2, array.SlabID())
 	require.NoError(t, err)
 
-	testArray(t, storage2, typeInfo, address, array2, expectedValues, false)
+	testArray(t, storage2, typeInfo, address, array2, expectedValues, false, 1)
 }
 
 func TestEmptyArray(t *testing.T) {
@@ -4613,7 +4617,7 @@ func TestArrayStringElement(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 		stats, err := atree.GetArrayStats(array)
 		require.NoError(t, err)
@@ -4646,7 +4650,7 @@ func TestArrayStringElement(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, false)
+		testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 
 		stats, err := atree.GetArrayStats(array)
 		require.NoError(t, err)
@@ -4694,7 +4698,7 @@ func TestArrayStoredValue(t *testing.T) {
 			array2, ok := value.(*atree.Array)
 			require.True(t, ok)
 
-			testArray(t, storage, typeInfo, address, array2, expectedValues, false)
+			testArray(t, storage, typeInfo, address, array2, expectedValues, false, 1)
 		} else {
 			require.Equal(t, 1, errorCategorizationCount(err))
 			var fatalError *atree.FatalError
@@ -4874,7 +4878,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, copied.SlabID(), array.SlabID())
 
-		testArray(t, storage, typeInfo, address, copied, expectedValues, false)
+		testArray(t, storage, typeInfo, address, copied, expectedValues, false, 1)
 	})
 
 	t.Run("root-metaslab", func(t *testing.T) {
@@ -4916,7 +4920,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
-		testArray(t, storage, typeInfo, address, copied, expectedValues, false)
+		testArray(t, storage, typeInfo, address, copied, expectedValues, false, 1)
 	})
 
 	t.Run("rebalance two data slabs", func(t *testing.T) {
@@ -4967,7 +4971,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
-		testArray(t, storage, typeInfo, address, copied, expectedValues, false)
+		testArray(t, storage, typeInfo, address, copied, expectedValues, false, 1)
 	})
 
 	t.Run("merge two data slabs", func(t *testing.T) {
@@ -5017,7 +5021,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
-		testArray(t, storage, typeInfo, address, copied, expectedValues, false)
+		testArray(t, storage, typeInfo, address, copied, expectedValues, false, 1)
 	})
 
 	t.Run("random", func(t *testing.T) {
@@ -5063,7 +5067,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
-		testArray(t, storage, typeInfo, address, copied, expectedValues, false)
+		testArray(t, storage, typeInfo, address, copied, expectedValues, false, 1)
 	})
 
 	t.Run("data slab too large", func(t *testing.T) {
@@ -5116,7 +5120,7 @@ func TestArrayFromBatchData(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, array.SlabID(), copied.SlabID())
 
-		testArray(t, storage, typeInfo, address, copied, expectedValues, false)
+		testArray(t, storage, typeInfo, address, copied, expectedValues, false, 1)
 	})
 }
 
@@ -5144,7 +5148,7 @@ func TestArrayNestedStorables(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, true)
+	testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 }
 
 func TestArrayMaxInlineElement(t *testing.T) {
@@ -5178,7 +5182,7 @@ func TestArrayMaxInlineElement(t *testing.T) {
 	// (for rounding when computing max inline array element size).
 	require.Equal(t, atree.TargetSlabSize()-atree.SlabIDLength-1, GetArrayRootSlabByteSize(array))
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, false)
+	testArray(t, storage, typeInfo, address, array, expectedValues, false, 1)
 }
 
 func TestArrayString(t *testing.T) {
@@ -6441,7 +6445,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		expectedParentSize := atree.ComputeArrayRootDataSlabByteSizeWithFixSizedElement(childArraySize, arrayCount)
 		require.Equal(t, expectedParentSize, GetArrayRootSlabByteSize(parentArray))
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Get inlined child array
 		e, err := parentArray.Get(0)
@@ -6488,7 +6492,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			// Test parent array's mutableElementIndex
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Add one more element to child array which triggers inlined child array slab becomes standalone slab
@@ -6514,7 +6518,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove elements from child array which triggers standalone array slab becomes inlined slab again.
 		for childArray.Count() > 0 {
@@ -6539,7 +6543,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			// Test parent array's mutableElementIndex
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		require.Equal(t, uint64(0), childArray.Count())
@@ -6573,7 +6577,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		children := make([]struct {
 			array   *atree.Array
@@ -6633,7 +6637,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				// Test parent array's mutableElementIndex
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -6670,7 +6674,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			// Test parent array's mutableElementIndex
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Remove one element from child array which triggers standalone array slab becomes inlined slab again.
@@ -6705,7 +6709,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			// Test parent array's mutableElementIndex
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Remove remaining elements from inlined child array
@@ -6739,7 +6743,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				// Test parent array's mutableElementIndex
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -6773,7 +6777,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		children := make([]struct {
 			array   *atree.Array
@@ -6828,7 +6832,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				// Test parent array's mutableElementIndex
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -6862,7 +6866,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			// Test parent array's mutableElementIndex
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Parent array has one data slab and all child arrays are not inlined.
@@ -6894,7 +6898,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 			// Test parent array's mutableElementIndex
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Parent array has 1 meta data slab and 2 data slabs.
@@ -6929,7 +6933,7 @@ func TestChildArrayInlinabilityInParentArray(t *testing.T) {
 				// Test parent array's mutableElementIndex
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -6977,7 +6981,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Get inlined child array
 		e, err := parentArray.Get(0)
@@ -7056,7 +7060,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Add one more element to grand child array which triggers inlined child array slab (NOT grand child array slab) becomes standalone slab
@@ -7099,7 +7103,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove elements from grand child array which triggers standalone child array slab becomes inlined slab again.
 		for gchildArray.Count() > 0 {
@@ -7144,7 +7148,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		require.Equal(t, uint64(0), gchildArray.Count())
@@ -7177,7 +7181,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Get inlined child array
 		e, err := parentArray.Get(0)
@@ -7255,7 +7259,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Add one more element to grand child array which triggers inlined grand child array slab (NOT child array slab) becomes standalone slab
@@ -7305,7 +7309,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove elements from grand child array which triggers standalone child array slab becomes inlined slab again.
 		for gchildArray.Count() > 0 {
@@ -7349,7 +7353,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		require.Equal(t, uint64(0), gchildArray.Count())
@@ -7411,7 +7415,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		type arrayInfo struct {
 			array   *atree.Array
@@ -7513,7 +7517,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -7562,7 +7566,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because child array is no longer inlined.
@@ -7620,7 +7624,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		expectedParentSize = atree.ComputeArrayRootDataSlabByteSize(storableByteSizes)
@@ -7679,7 +7683,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -7739,7 +7743,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 		// Test parent array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		type arrayInfo struct {
 			array   *atree.Array
@@ -7830,7 +7834,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -7877,7 +7881,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		require.Equal(t, 3, getStoredDeltas(storage)) // There are 3 stored slab because child array is no longer inlined.
@@ -7930,7 +7934,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Parent array has one root data slab, 4 grand child array with standalone root data slab.
@@ -7982,7 +7986,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Parent array has 1 metadata slab, and two data slab, all child and grand child arrays are inlined.
@@ -8036,7 +8040,7 @@ func TestNestedThreeLevelChildArrayInlinabilityInParentArray(t *testing.T) {
 				require.True(t, atree.GetArrayMutableElementIndexCount(gchildArray) <= gchildArray.Count())
 				require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+				testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 			}
 		}
 
@@ -8078,7 +8082,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 	// Test array's mutableElementIndex
 	require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-	testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+	testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 	children := make([]*struct {
 		array       *atree.Array
@@ -8148,7 +8152,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// insert value at index 2, so only second child array index is moved by +1
@@ -8191,7 +8195,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// insert value at index 4, so none of child array indexes are affected.
@@ -8231,7 +8235,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 	})
 
@@ -8274,7 +8278,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Remove value at index 1, so only second child array index is moved by -1
@@ -8317,7 +8321,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 
 		// Remove value at index 2 (last element), so none of child array indexes are affected.
@@ -8357,7 +8361,7 @@ func TestChildArrayWhenParentArrayIsModified(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(childArray) <= childArray.Count())
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+			testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 		}
 	})
 }
@@ -8482,7 +8486,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Overwrite existing child array value
 		for i := range expectedValues {
@@ -8507,7 +8511,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 			require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 		}
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 	})
 
 	t.Run("child array is inlined", func(t *testing.T) {
@@ -8542,7 +8546,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Overwrite existing child array value
 		for i := range expectedValues {
@@ -8567,7 +8571,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 	})
 
 	t.Run("child map is not inlined", func(t *testing.T) {
@@ -8612,7 +8616,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Overwrite existing child map value
 		for i := range expectedValues {
@@ -8637,7 +8641,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 	})
 
 	t.Run("child map is inlined", func(t *testing.T) {
@@ -8677,7 +8681,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Overwrite existing child map value
 		for i := range expectedValues {
@@ -8702,7 +8706,7 @@ func TestArraySetReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 	})
 }
 
@@ -8751,7 +8755,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove child array value
 		for i := range expectedValues {
@@ -8808,7 +8812,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove child array value
 		for i := range expectedValues {
@@ -8876,7 +8880,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove child map value
 		for i := range expectedValues {
@@ -8938,7 +8942,7 @@ func TestArrayRemoveReturnedValue(t *testing.T) {
 		// Test array's mutableElementIndex
 		require.True(t, atree.GetArrayMutableElementIndexCount(parentArray) <= parentArray.Count())
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove child map value
 		for i := range expectedValues {
@@ -8995,7 +8999,7 @@ func TestArrayWithOutdatedCallback(t *testing.T) {
 
 		expectedValues = append(expectedValues, testutils.ExpectedArrayValue{v})
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Overwrite child array value from parent
 		valueStorable, err := parentArray.Set(0, testutils.Uint64Value(0))
@@ -9050,7 +9054,7 @@ func TestArrayWithOutdatedCallback(t *testing.T) {
 
 		expectedValues = append(expectedValues, testutils.ExpectedArrayValue{v})
 
-		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true)
+		testArray(t, storage, typeInfo, address, parentArray, expectedValues, true, 1)
 
 		// Remove child array value from parent
 		valueStorable, err := parentArray.Remove(0)

--- a/array_wrappervalue_test.go
+++ b/array_wrappervalue_test.go
@@ -535,7 +535,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
@@ -563,7 +563,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Commit storage
 				err = storage.FastCommit(runtime.NumCPU())
@@ -577,7 +577,7 @@ func TestArrayWrapperValueAppendAndModify(t *testing.T) {
 				require.Equal(t, arrayCount, array2.Count())
 
 				// Test loaded array
-				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
+				testArray(t, storage2, typeInfo, address, array2, expectedValues, true, 1)
 			})
 		}
 	}
@@ -650,7 +650,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
@@ -678,7 +678,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Commit storage
 				err = storage.FastCommit(runtime.NumCPU())
@@ -692,7 +692,7 @@ func TestArrayWrapperValueInsertAndModify(t *testing.T) {
 				require.Equal(t, arrayCount, array2.Count())
 
 				// Test loaded array
-				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
+				testArray(t, storage2, typeInfo, address, array2, expectedValues, true, 1)
 			})
 		}
 	}
@@ -765,7 +765,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Set new WrapperValue in array
 				for i := range expectedValues {
@@ -780,7 +780,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Retrieve and modify WrapperValue from array
 				for i := range expectedValues {
@@ -808,7 +808,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 
 				testArrayMutableElementIndex(t, array)
 
-				testArray(t, storage, typeInfo, address, array, expectedValues, true)
+				testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 				// Commit storage
 				err = storage.FastCommit(runtime.NumCPU())
@@ -822,7 +822,7 @@ func TestArrayWrapperValueSetAndModify(t *testing.T) {
 				require.Equal(t, arrayCount, array2.Count())
 
 				// Test loaded array
-				testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
+				testArray(t, storage2, typeInfo, address, array2, expectedValues, true, 1)
 			})
 		}
 	}
@@ -926,7 +926,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 
 						testArrayMutableElementIndex(t, array)
 
-						testArray(t, storage, typeInfo, address, array, expectedValues, true)
+						testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 						// Retrieve and modify WrapperValue from array
 						if needToModifyElement {
@@ -955,7 +955,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 
 							testArrayMutableElementIndex(t, array)
 
-							testArray(t, storage, typeInfo, address, array, expectedValues, true)
+							testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 						}
 
 						// Remove random elements
@@ -973,7 +973,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 
 						testArrayMutableElementIndex(t, array)
 
-						testArray(t, storage, typeInfo, address, array, expectedValues, true)
+						testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 						// Commit storage
 						err = storage.FastCommit(runtime.NumCPU())
@@ -987,7 +987,7 @@ func TestArrayWrapperValueInsertAndRemove(t *testing.T) {
 						require.Equal(t, arrayCount-removeCount, array2.Count())
 
 						// Test loaded array
-						testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
+						testArray(t, storage2, typeInfo, address, array2, expectedValues, true, 1)
 					})
 				}
 			}
@@ -1094,7 +1094,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 						testArrayMutableElementIndex(t, array)
 
-						testArray(t, storage, typeInfo, address, array, expectedValues, true)
+						testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 						// Set WrapperValue in array
 						for i := range expectedValues {
@@ -1109,7 +1109,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 						testArrayMutableElementIndex(t, array)
 
-						testArray(t, storage, typeInfo, address, array, expectedValues, true)
+						testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 						// Retrieve and modify WrapperValue from array
 						if needToModifyElement {
@@ -1138,7 +1138,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 							testArrayMutableElementIndex(t, array)
 
-							testArray(t, storage, typeInfo, address, array, expectedValues, true)
+							testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 						}
 
 						// Remove random elements
@@ -1156,7 +1156,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 
 						testArrayMutableElementIndex(t, array)
 
-						testArray(t, storage, typeInfo, address, array, expectedValues, true)
+						testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 						// Commit storage
 						err = storage.FastCommit(runtime.NumCPU())
@@ -1170,7 +1170,7 @@ func TestArrayWrapperValueSetAndRemove(t *testing.T) {
 						require.Equal(t, arrayCount-removeCount, array2.Count())
 
 						// Test loaded array
-						testArray(t, storage2, typeInfo, address, array2, expectedValues, true)
+						testArray(t, storage2, typeInfo, address, array2, expectedValues, true, 1)
 					})
 				}
 			}
@@ -1256,7 +1256,7 @@ func TestArrayWrapperValueReadOnlyIterate(t *testing.T) {
 
 					testArrayMutableElementIndex(t, array)
 
-					testArray(t, storage, typeInfo, address, array, expectedValues, true)
+					testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 					iterator, err := array.ReadOnlyIterator()
 					require.NoError(t, err)
@@ -1373,7 +1373,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 
 					testArrayMutableElementIndex(t, array)
 
-					testArray(t, storage, typeInfo, address, array, expectedValues, true)
+					testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 					iterator, err := array.Iterator()
 					require.NoError(t, err)
@@ -1408,7 +1408,7 @@ func TestArrayWrapperValueIterate(t *testing.T) {
 
 					testArrayMutableElementIndex(t, array)
 
-					testArray(t, storage, typeInfo, address, array, expectedValues, true)
+					testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 				})
 			}
 		}
@@ -1480,7 +1480,7 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		testLevel1WrappedChildArrayInlined(t, array, true)
 	}
@@ -1523,7 +1523,7 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	}
 
 	testLevel1WrappedChildArrayInlined(t, array, false)
@@ -1570,14 +1570,14 @@ func TestArrayWrapperValueInlineArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	}
 
 	testLevel1WrappedChildArrayInlined(t, array, true)
 
 	testArrayMutableElementIndex(t, array)
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, true)
+	testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 }
 
 func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
@@ -1675,7 +1675,7 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		testLevel2WrappedChildArrayInlined(t, array, true)
 	}
@@ -1739,7 +1739,7 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	}
 
 	testLevel2WrappedChildArrayInlined(t, array, false)
@@ -1806,14 +1806,14 @@ func TestArrayWrapperValueInlineArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	}
 
 	testLevel2WrappedChildArrayInlined(t, array, true)
 
 	testArrayMutableElementIndex(t, array)
 
-	testArray(t, storage, typeInfo, address, array, expectedValues, true)
+	testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 }
 
 func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
@@ -1898,7 +1898,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove at least half of elements
 
@@ -1922,7 +1922,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("insert and remove", func(t *testing.T) {
@@ -1954,7 +1954,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements (including one previously inserted element)
 
@@ -1988,7 +1988,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("set and remove", func(t *testing.T) {
@@ -2018,7 +2018,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements (including some previously set elements)
 
@@ -2065,7 +2065,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("remove all", func(t *testing.T) {
@@ -2084,7 +2084,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel1(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 }
 
@@ -2159,7 +2159,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements
 
@@ -2183,7 +2183,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("insert and remove", func(t *testing.T) {
@@ -2214,7 +2214,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements (including one previously inserted element)
 
@@ -2248,7 +2248,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("modify retrieved nested container and remove", func(t *testing.T) {
@@ -2286,7 +2286,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements (including some previously set elements)
 
@@ -2333,7 +2333,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("remove all", func(t *testing.T) {
@@ -2352,7 +2352,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel2(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 }
 
@@ -2440,7 +2440,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements
 
@@ -2464,7 +2464,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("insert and remove", func(t *testing.T) {
@@ -2495,7 +2495,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements (including one previously inserted element)
 
@@ -2529,7 +2529,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("modify retrieved nested container and remove", func(t *testing.T) {
@@ -2567,7 +2567,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 		// Remove some elements (including some previously set elements)
 
@@ -2614,7 +2614,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 
 	t.Run("remove all", func(t *testing.T) {
@@ -2633,7 +2633,7 @@ func TestArrayWrapperValueModifyNewArrayAtLevel3(t *testing.T) {
 
 		testArrayMutableElementIndex(t, array)
 
-		testArray(t, storage, typeInfo, address, array, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 	})
 }
 
@@ -2681,7 +2681,7 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 			array := v.(*atree.Array)
 			expectedValues = expected.(testutils.ExpectedArrayValue)
 
-			testArray(t, storage, typeInfo, address, array, expectedValues, true)
+			testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 			err := storage.FastCommit(runtime.NumCPU())
 			require.NoError(t, err)
@@ -2749,7 +2749,7 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(len(expectedValues)), array2.Count())
 
-		testArray(t, storage, typeInfo, address, array2, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array2, expectedValues, true, 1)
 	})
 
 	t.Run("modify 2-level wrapper array in [testutils.SomeValue([testutils.SomeValue([testutils.SomeValue(uint64)])])]", func(t *testing.T) {
@@ -2799,7 +2799,7 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 			array := v.(*atree.Array)
 			expectedValues = expected.(testutils.ExpectedArrayValue)
 
-			testArray(t, storage, typeInfo, address, array, expectedValues, true)
+			testArray(t, storage, typeInfo, address, array, expectedValues, true, 1)
 
 			err := storage.FastCommit(runtime.NumCPU())
 			require.NoError(t, err)
@@ -2883,7 +2883,7 @@ func TestArrayWrapperValueModifyExistingArray(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, uint64(len(expectedValues)), array2.Count())
 
-		testArray(t, storage, typeInfo, address, array2, expectedValues, true)
+		testArray(t, storage, typeInfo, address, array2, expectedValues, true, 1)
 	})
 }
 

--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,7 @@ package atree
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"runtime/debug"
 )
 
@@ -515,4 +516,24 @@ func wrapErrorfAsExternalErrorIfNeeded(err error, msg string) error {
 
 	// Create new external error wrapping err with context.
 	return NewExternalError(err, msg)
+}
+
+// UnexpectedElementTypeError is returned when the array element type is not as expected during array and byte slice conversion.
+type UnexpectedElementTypeError struct {
+	expectedType reflect.Type
+	actualType   reflect.Type
+}
+
+// NewUnexpectedElementTypeError returns UnexpectedElementTypeError.
+func NewUnexpectedElementTypeError(expectedType, actualType reflect.Type) error {
+	return NewUserError(
+		&UnexpectedElementTypeError{
+			expectedType: expectedType,
+			actualType:   actualType,
+		},
+	)
+}
+
+func (e *UnexpectedElementTypeError) Error() string {
+	return fmt.Sprintf("invalid element type: expected %s, got %s", e.expectedType.String(), e.actualType.String())
 }


### PR DESCRIPTION
Updates https://github.com/onflow/flow-go/issues/8447 https://github.com/onflow/flow-go/issues/8401

Currently, byte slice conversions are done in onflow/cadence repo but we can improve speed and reduce memory use by doing the conversions here in onflow/atree.

This PR adds two functions to support atree array and Go []byte conversions, which can be used by Cadence:
- `ByteArrayToByteSlice()`
- `ByteSliceToByteArray()`

These new functions provide optimized atree array and Go []byte conversion if atree array elements satisfy `ByteStorable` type constraint (any type that implements `atree.Storable` and has `byte` underlying type).

## Benchmarks

Notably, `cadence.ByteArrayValueToByteSlice()` using `atree.ByteArrayToByteSlice()` is:
- 13.7 times faster :rocket: 
- 8 times less memory use (bytes/op)
- 8 times fewer memory allocations (allocs/op)

Cadence `ByteArrayValueToByteSlice` benchmark using the optimized function:

```
                             │  before.txt   │              after.txt              │
                             │    sec/op     │   sec/op     vs base                │
ByteArrayValueToByteSlice-12   1049.50n ± 2%   76.52n ± 4%  -92.71% (p=0.000 n=20)

                             │ before.txt  │             after.txt              │
                             │    B/op     │    B/op     vs base                │
ByteArrayValueToByteSlice-12   256.00 ± 0%   32.00 ± 0%  -87.50% (p=0.000 n=20)

                             │ before.txt │             after.txt              │
                             │ allocs/op  │ allocs/op   vs base                │
ByteArrayValueToByteSlice-12   8.000 ± 0%   1.000 ± 0%  -87.50% (p=0.000 n=20)
```

Cadence `ByteSliceToByteArrayValue` benchmark using the optimized function:

```
                             │  before.txt  │              after.txt              │
                             │    sec/op    │   sec/op     vs base                │
ByteSliceToByteArrayValue-12   1038.0n ± 2%   669.7n ± 1%  -35.48% (p=0.000 n=20)

                             │ before.txt  │             after.txt              │
                             │    B/op     │    B/op     vs base                │
ByteSliceToByteArrayValue-12   1399.0 ± 0%   869.5 ± 0%  -37.85% (p=0.000 n=20)

                             │ before.txt  │             after.txt              │
                             │  allocs/op  │ allocs/op   vs base                │
ByteSliceToByteArrayValue-12   11.000 ± 0%   5.000 ± 0%  -54.55% (p=0.000 n=20)
```
______

<!-- Complete: -->

- [x] Targeted PR against `main` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
