### PR TITLE
Add maxThreshold to enforce size invariants

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -28,8 +28,10 @@ import (
 // - data slab must have at least 2 elements when slab size > maxThreshold
 
 const (
-	defaultSlabSize       = uint32(1024)
-	minSlabSize           = uint32(256)
+	defaultSlabSize = uint32(1024)
+	minSlabSize     = uint32(256)
+	maxSlabSize     = uint32(32 * 1024)
+
 	minElementCountInSlab = 2
 )
 
@@ -49,6 +51,10 @@ func init() {
 func setThreshold(threshold uint32) (uint32, uint32, uint32, uint32) {
 	if threshold < minSlabSize {
 		panic(fmt.Sprintf("Slab size %d is smaller than minSlabSize %d", threshold, minSlabSize))
+	}
+
+	if threshold > maxSlabSize {
+		panic(fmt.Sprintf("Slab size %d is larger than maxSlabSize %d", threshold, maxSlabSize))
 	}
 
 	targetThreshold = threshold


### PR DESCRIPTION
This PR doesn't change actual behavior because current threshold used is 1024 bytes, which is always under maxThreshold (32*1024 bytes).

This PR adds max threshold, to make the code self-documenting and any slab size in the range of `[minThreshold, maxThreshold]` would conform to the invariants used in the code.

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
