### PR TITLE
Document encoding code that is truncation safe to prevent security bug reports

### DIFF
--- a/array_data_slab_encode.go
+++ b/array_data_slab_encode.go
@@ -219,6 +219,9 @@ func (a *ArrayDataSlab) encodeElements(enc *Encoder) error {
 
 	countOffset := 1
 	const countSize = 2
+	// Cast len(a.elements) to uint16 is safe because the number of elements
+	// per data slab is limited by slab size, which is at most maxThreshold
+	// (48KiB with maxSlabSize of 32KiB), well below math.MaxUint16 (65535).
 	binary.BigEndian.PutUint16(
 		enc.Scratch[countOffset:],
 		uint16(len(a.elements)),

--- a/array_metadata_slab_encode.go
+++ b/array_metadata_slab_encode.go
@@ -73,7 +73,12 @@ func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 	// Encode shared address to scratch
 	copy(enc.Scratch[:], a.header.slabID.address[:])
 
-	// Encode child header count to scratch
+	// Encode child header count to scratch.
+	// Cast len(a.childrenHeaders) to uint16 is safe because
+	// the number of children per metadata slab is limited by
+	// slab size, which is at most maxThreshold (48KiB with maxSlabSize
+	// of 32KiB).  Each child header is arraySlabHeaderSize (14) bytes,
+	// so the maximum number of children is well below math.MaxUint16 (65535).
 	const childHeaderCountOffset = SlabAddressLength
 	binary.BigEndian.PutUint16(
 		enc.Scratch[childHeaderCountOffset:],
@@ -96,7 +101,9 @@ func (a *ArrayMetaDataSlab) Encode(enc *Encoder) error {
 		const countOffset = SlabIndexLength
 		binary.BigEndian.PutUint32(enc.Scratch[countOffset:], h.count)
 
-		// Encode size
+		// Encode size.
+		// Cast h.size to uint16 is safe because child slab size is limited by
+		// maxThreshold (48KiB with maxSlabSize of 32KiB), which fits in uint16.
 		const sizeOffset = countOffset + 4
 		binary.BigEndian.PutUint16(enc.Scratch[sizeOffset:], uint16(h.size))
 

--- a/map_elements_encode.go
+++ b/map_elements_encode.go
@@ -51,6 +51,10 @@ func (e *hkeyElements) Encode(enc *Encoder) error {
 	const cborByteStringHead = 0x59
 	enc.Scratch[2] = cborByteStringHead
 
+	// Cast len(e.hkeys)*8 to uint16 is safe because the number of
+	// hkeys per data slab is limited by slab size, which is at most
+	// maxThreshold (48KiB with maxSlabSize of 32KiB).  Even in the
+	// worst case, len(e.hkeys)*8 is well below math.MaxUint16 (65535).
 	binary.BigEndian.PutUint16(enc.Scratch[3:], uint16(len(e.hkeys)*8))
 
 	// Write scratch content to encoder
@@ -75,6 +79,10 @@ func (e *hkeyElements) Encode(enc *Encoder) error {
 	// TODO: maybe make this header dynamic to reduce size
 	// CBOR array head 0x99 indicating that the number of array elements are encoded in the next 2 bytes.
 	const cborArrayHead = 0x99
+	// Cast len(e.elems) to uint16 is safe because the number of
+	// elements per data slab is limited by slab size, which is at
+	// most maxThreshold (48KiB with maxSlabSize of 32KiB), well
+	// below math.MaxUint16 (65535).
 	enc.Scratch[0] = cborArrayHead
 	binary.BigEndian.PutUint16(enc.Scratch[1:], uint16(len(e.elems)))
 	err = enc.CBOR.EncodeRawBytes(enc.Scratch[:3])
@@ -126,6 +134,10 @@ func (e *singleElements) Encode(enc *Encoder) error {
 
 	// Encode elements array header manually for fix-sized encoding
 	// TODO: maybe make this header dynamic to reduce size
+	// Cast len(e.elems) to uint16 is safe because the number of
+	// elements per data slab is limited by slab size, which is at
+	// most maxThreshold (48KiB with maxSlabSize of 32KiB), well
+	// below math.MaxUint16 (65535).
 	enc.Scratch[3] = 0x99
 	binary.BigEndian.PutUint16(enc.Scratch[4:], uint16(len(e.elems)))
 

--- a/map_metadata_slab_encode.go
+++ b/map_metadata_slab_encode.go
@@ -71,7 +71,12 @@ func (m *MapMetaDataSlab) Encode(enc *Encoder) error {
 	// Encode shared address to scratch
 	copy(enc.Scratch[:], m.header.slabID.address[:])
 
-	// Encode child header count to scratch
+	// Encode child header count to scratch.
+	// Cast len(m.childrenHeaders) to uint16 is safe because the number of
+	// children per metadata slab is limited by slab size, which is at most
+	// maxThreshold (48KiB with maxSlabSize of 32KiB).  Each child header
+	// is mapSlabHeaderSize (18) bytes, so the maximum number of children
+	// is well below math.MaxUint16 (65535).
 	const childHeaderCountOffset = SlabAddressLength
 	binary.BigEndian.PutUint16(
 		enc.Scratch[childHeaderCountOffset:],
@@ -93,6 +98,8 @@ func (m *MapMetaDataSlab) Encode(enc *Encoder) error {
 		const firstKeyOffset = SlabIndexLength
 		binary.BigEndian.PutUint64(enc.Scratch[firstKeyOffset:], uint64(h.firstKey))
 
+		// Cast h.size to uint16 is safe because child slab size is limited by
+		// maxThreshold (48KiB with maxSlabSize of 32KiB), which fits in uint16.
 		const sizeOffset = firstKeyOffset + digestSize
 		binary.BigEndian.PutUint16(enc.Scratch[sizeOffset:], uint16(h.size))
 


### PR DESCRIPTION
These comments should help reduce future security bug reports (false positives).

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
