### PR TITLE
Document more code that is underflow/overflow safe to prevent false-positive security reports

### DIFF
--- a/array.go
+++ b/array.go
@@ -191,6 +191,9 @@ func NewArrayFromBatchData(storage SlabStorage, address Address, typeInfo TypeIn
 		// Append new element
 		dataSlab.elements = append(dataSlab.elements, storable)
 		dataSlab.header.count++
+		// This addition is safe from overflow because slab size is
+		// checked against targetThreshold before each batch append,
+		// and a new data slab is created when the threshold is reached.
 		dataSlab.header.size += storable.ByteSize()
 	}
 
@@ -329,6 +332,8 @@ func nextLevelArraySlabs(storage SlabStorage, address Address, slabs []ArraySlab
 			}
 		}
 
+		// These additions are safe from overflow because metadata slab size
+		// is checked against maxThreshold and is split if it exceeds the limit.
 		metaSlab.header.size += arraySlabHeaderSize
 		metaSlab.header.count += slab.Header().count
 
@@ -644,6 +649,8 @@ func (a *Array) splitRoot() error {
 	right := rightSlab.(ArraySlab)
 
 	// Create new ArrayMetaDataSlab with the old root's slab ID
+	// The count and size computations are safe from overflow because the
+	// total count was the root's count before splitting, which already fit in uint32.
 	newRoot := &ArrayMetaDataSlab{
 		header: ArraySlabHeader{
 			slabID: rootID,

--- a/array_conversion.go
+++ b/array_conversion.go
@@ -110,6 +110,8 @@ func ByteSliceToByteArray[T ByteStorableValue](
 		for i, b := range data {
 			e := T(b)
 			elements[i] = e
+			// This addition is safe from overflow because total element size
+			// is checked against targetThreshold before use (see below).
 			elementSize += e.ByteSize()
 		}
 
@@ -153,6 +155,8 @@ func newArrayWithElements(
 	root := array.root.(*ArrayDataSlab)
 	root.elements = elements
 	root.header.count = uint32(len(elements))
+	// This addition is safe from overflow because elementSize was already
+	// checked to be less than targetThreshold - arrayRootDataSlabPrefixSize.
 	root.header.size += elementSize
 
 	// This isn't needed because slab is already stored in the storage by pointer in NewArray(),

--- a/array_data_slab.go
+++ b/array_data_slab.go
@@ -145,6 +145,8 @@ func (a *ArrayDataSlab) Set(storage SlabStorage, address Address, index uint64, 
 	// Given this, size diff of the old and new element can be 0 even when its actual size changed.
 	size := a.getPrefixSize()
 	for _, e := range a.elements {
+		// This addition is safe from overflow because slab size is limited by
+		// maxThreshold (48KiB with maxSlabSize of 32KiB), well within uint32.
 		size += e.ByteSize()
 	}
 
@@ -175,6 +177,8 @@ func (a *ArrayDataSlab) Insert(storage SlabStorage, address Address, index uint6
 	a.elements = slices.Insert(a.elements, int(index), storable)
 
 	a.header.count++
+	// This addition is safe from overflow because slab size is checked
+	// against maxThreshold and the slab is split if needed.
 	a.header.size += storable.ByteSize()
 
 	if !a.inlined {

--- a/array_metadata_slab.go
+++ b/array_metadata_slab.go
@@ -382,7 +382,9 @@ func (a *ArrayMetaDataSlab) SplitChildSlab(storage SlabStorage, child ArraySlab,
 		rightSlabCountSum,
 	)
 
-	// Increase header size
+	// Increase header size.
+	// This addition is safe from overflow because metadata slab size
+	// is checked against maxThreshold and is split if it exceeds the limit.
 	a.header.size += arraySlabHeaderSize
 
 	// Store modified slabs
@@ -650,8 +652,10 @@ func (a *ArrayMetaDataSlab) Merge(slab Slab) error {
 
 	rightSlab := slab.(*ArrayMetaDataSlab)
 	a.childrenHeaders = merge(a.childrenHeaders, rightSlab.childrenHeaders)
-	// The computation is safe because header.size >= arrayMetaDataSlabPrefixSize,
+	// The subtraction is safe because header.size >= arrayMetaDataSlabPrefixSize,
 	// as header.size = arrayMetaDataSlabPrefixSize + len(childrenHeaders) * arraySlabHeaderSize.
+	// The addition is safe from overflow because merge is only called when
+	// both slabs are underflowing, so their combined size fits in uint32.
 	a.header.size += rightSlab.header.size - arrayMetaDataSlabPrefixSize
 	a.header.count += rightSlab.header.count
 
@@ -678,6 +682,8 @@ func (a *ArrayMetaDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 
 	leftCount := uint32(0)
 	for i := range leftChildrenCount {
+		// This addition is safe from overflow because the total count was
+		// already validated when the metadata slab was created or modified.
 		leftCount += a.childrenHeaders[i].count
 	}
 
@@ -706,6 +712,8 @@ func (a *ArrayMetaDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 	rightSlab.childrenCountSum = make([]uint32, len(rightSlab.childrenHeaders))
 	countSum := uint32(0)
 	for i := range rightSlab.childrenCountSum {
+		// These additions are safe from overflow because the total count was
+		// already validated when the metadata slab was created or modified.
 		countSum += rightSlab.childrenHeaders[i].count
 		rightSlab.childrenCountSum[i] = countSum
 	}
@@ -729,10 +737,12 @@ func (a *ArrayMetaDataSlab) LendToRight(slab Slab) error {
 	moveCount := oldLeftChildrenHeaderCount - leftChildrenHeaderCount
 	a.childrenHeaders, rightSlab.childrenHeaders = lendToRight(a.childrenHeaders, rightSlab.childrenHeaders, moveCount)
 
-	// Rebuild right slab childrenCountSum
+	// Rebuild right slab childrenCountSum.
 	rightSlab.childrenCountSum = make([]uint32, len(rightSlab.childrenHeaders))
 	countSum := uint32(0)
 	for i := range rightSlab.childrenCountSum {
+		// These count additions are safe from overflow because the total count was
+		// already validated when the metadata slab was created or modified.
 		countSum += rightSlab.childrenHeaders[i].count
 		rightSlab.childrenCountSum[i] = countSum
 	}
@@ -769,9 +779,11 @@ func (a *ArrayMetaDataSlab) BorrowFromRight(slab Slab) error {
 	moveCount := leftChildrenHeaderCount - oldLeftChildrenHeaderCount
 	a.childrenHeaders, rightSlab.childrenHeaders = borrowFromRight(a.childrenHeaders, rightSlab.childrenHeaders, moveCount)
 
-	// Update left slab (original)
+	// Update left slab (original).
 	countSum := oldLeftSlabCountSum
 	for i := oldLeftChildrenHeaderCount; i < len(a.childrenHeaders); i++ {
+		// These count additions are safe from overflow because the total count was
+		// already validated when the metadata slab was created or modified.
 		countSum += a.childrenHeaders[i].count
 		a.childrenCountSum = append(a.childrenCountSum, countSum)
 	}

--- a/map.go
+++ b/map.go
@@ -244,6 +244,8 @@ func NewMapFromBatchData(
 			}
 
 			elements.elems[lastElementIndex] = elem
+			// This is safe from overflow because elements.size includes
+			// prevElemSize, and slab size is bounded by maxThreshold.
 			elements.size += elem.Size() - prevElemSize
 
 			putDigester(digester)
@@ -304,6 +306,9 @@ func NewMapFromBatchData(
 
 		elements.hkeys = append(elements.hkeys, hkey)
 		elements.elems = append(elements.elems, elem)
+		// This addition is safe from overflow because slab size is checked
+		// against targetThreshold/maxThreshold before each append,
+		// and a new data slab is created when the threshold is reached.
 		elements.size += digestSize + elem.Size()
 
 		prevHkey = hkey
@@ -462,6 +467,8 @@ func nextLevelMapSlabs(storage SlabStorage, address Address, slabs []MapSlab) ([
 			}
 		}
 
+		// This addition is safe from overflow because metadata slab size
+		// is checked against maxThreshold and is split if it exceeds the limit.
 		metaSlab.header.size += mapSlabHeaderSize
 
 		metaSlab.childrenHeaders = append(metaSlab.childrenHeaders, slab.Header())

--- a/map_data_slab.go
+++ b/map_data_slab.go
@@ -198,7 +198,9 @@ func (m *MapDataSlab) Split(storage SlabStorage) (Slab, Slab, error) {
 		return nil, nil, wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to generate slab ID for address 0x%x", m.SlabID().address))
 	}
 
-	// Create new right slab
+	// Create new right slab.
+	// These additions are safe from overflow because each split half's elements
+	// size is less than the original slab size, which is bounded by maxThreshold.
 	rightSlab := &MapDataSlab{
 		header: MapSlabHeader{
 			slabID:   sID,
@@ -252,7 +254,9 @@ func (m *MapDataSlab) LendToRight(slab Slab) error {
 		return err
 	}
 
-	// Update right slab
+	// Update right slab.
+	// These additions are safe from overflow because rebalancing redistributes
+	// elements between two slabs whose combined size fits in uint32.
 	rightSlab.elements = rightElements
 	rightSlab.header.size = mapDataSlabPrefixSize + rightElements.Size()
 	rightSlab.header.firstKey = rightElements.firstKey()
@@ -278,7 +282,9 @@ func (m *MapDataSlab) BorrowFromRight(slab Slab) error {
 		return err
 	}
 
-	// Update right slab
+	// Update right slab.
+	// These additions are safe from overflow because rebalancing redistributes
+	// elements between two slabs whose combined size fits in uint32.
 	rightSlab.elements = rightElements
 	rightSlab.header.size = mapDataSlabPrefixSize + rightElements.Size()
 	rightSlab.header.firstKey = rightElements.firstKey()
@@ -343,6 +349,8 @@ func (m *MapDataSlab) Inlinable(maxInlineSize uint32) bool {
 		return false
 	}
 
+	// This addition is safe from overflow because elements size
+	// is bounded by slab size limits, well within uint32.
 	inlinedSize := inlinedMapDataSlabPrefixSize + m.Size()
 
 	// Inlined byte size must be less than max inline size.
@@ -364,7 +372,9 @@ func (m *MapDataSlab) Inline(storage SlabStorage) error {
 		return wrapErrorfAsExternalErrorIfNeeded(err, fmt.Sprintf("failed to remove slab %s", id))
 	}
 
-	// Update data slab size from not inlined to inlined
+	// Update data slab size from not inlined to inlined.
+	// This addition is safe from overflow because elements size
+	// is bounded by slab size limits, well within uint32.
 	m.header.size = inlinedMapDataSlabPrefixSize + m.Size()
 
 	// Update data slab inlined status.
@@ -380,6 +390,8 @@ func (m *MapDataSlab) Uninline(storage SlabStorage) error {
 	}
 
 	// Update data slab size from inlined to not inlined.
+	// This addition is safe from overflow because elements size
+	// is bounded by slab size limits, well within uint32.
 	m.header.size = mapRootDataSlabPrefixSize + m.Size()
 
 	// Update data slab inlined status.

--- a/map_element.go
+++ b/map_element.go
@@ -122,6 +122,8 @@ func newSingleElement(storage SlabStorage, address Address, key Value, value Val
 		return nil, wrapErrorfAsExternalErrorIfNeeded(err, "failed to get value's storable")
 	}
 
+	// This addition is safe from overflow because key and value sizes
+	// are bounded by max inline size limits, well within uint32.
 	return &singleElement{
 		key:   ks,
 		value: vs,
@@ -212,6 +214,8 @@ func (e *singleElement) Set(
 		}
 
 		e.value = valueStorable
+		// This addition is safe from overflow because key and value sizes
+		// are bounded by max inline size limits, well within uint32.
 		e.size = singleElementPrefixSize + e.key.ByteSize() + e.value.ByteSize()
 		return e, e.key, existingMapValueStorable, nil
 	}
@@ -405,7 +409,9 @@ func (e *inlineCollisionGroup) Set(
 					fmt.Sprintf("failed to generate slab ID for address 0x%x", address))
 			}
 
-			// Create MapDataSlab
+			// Create MapDataSlab.
+			// This addition is safe from overflow because elements size
+			// is bounded by slab size limits, well within uint32.
 			slab := &MapDataSlab{
 				header: MapSlabHeader{
 					slabID:   id,
@@ -422,7 +428,8 @@ func (e *inlineCollisionGroup) Set(
 				return nil, nil, nil, err
 			}
 
-			// Create and return externalCollisionGroup (wrapper of newly created MapDataSlab)
+			// Create and return externalCollisionGroup (wrapper of newly created MapDataSlab).
+			// This addition is safe from overflow because both operands are small constants.
 			return &externalCollisionGroup{
 				slabID: id,
 				size:   externalCollisionGroupPrefixSize + SlabIDStorable(id).ByteSize(),
@@ -469,7 +476,10 @@ func (e *inlineCollisionGroup) hasPointer() bool {
 	return e.elements.hasPointer()
 }
 
+// Size returns the encoded size of the inline collision group.
 func (e *inlineCollisionGroup) Size() uint32 {
+	// This addition is safe from overflow because elements size
+	// is bounded by slab size limits, well within uint32.
 	return inlineCollisionGroupPrefixSize + e.elements.Size()
 }
 

--- a/map_elements_hashkey.go
+++ b/map_elements_hashkey.go
@@ -50,6 +50,8 @@ func newHkeyElements(level uint) *hkeyElements {
 }
 
 func newHkeyElementsWithElement(level uint, hkey Digest, elem element) *hkeyElements {
+	// This addition is safe from overflow because element size
+	// is bounded by max inline size limits and prefix/digest are small constants.
 	return &hkeyElements{
 		hkeys: []Digest{hkey},
 		elems: []element{elem},
@@ -218,6 +220,8 @@ func (e *hkeyElements) Set(
 
 		e.elems = []element{newElem}
 
+		// This addition is safe from overflow because slab size is checked
+		// against maxThreshold and the slab is split if needed.
 		e.size += digestSize + newElem.Size()
 
 		return newElem.key, nil, nil
@@ -236,6 +240,8 @@ func (e *hkeyElements) Set(
 
 		e.elems = slices.Insert(e.elems, 0, element(newElem))
 
+		// This addition is safe from overflow because slab size is checked
+		// against maxThreshold and the slab is split if needed.
 		e.size += digestSize + newElem.Size()
 
 		return newElem.key, nil, nil
@@ -254,6 +260,8 @@ func (e *hkeyElements) Set(
 
 		e.elems = append(e.elems, newElem)
 
+		// This addition is safe from overflow because slab size is checked
+		// against maxThreshold and the slab is split if needed.
 		e.size += digestSize + newElem.Size()
 
 		return newElem.key, nil, nil
@@ -331,6 +339,8 @@ func (e *hkeyElements) Set(
 		// Given this, size diff of the old and new element can be 0 even when its actual size changed.
 		size := uint32(hkeyElementsPrefixSize)
 		for _, element := range e.elems {
+			// This addition is safe from overflow because slab size is limited by
+			// maxThreshold (48KiB with maxSlabSize of 32KiB), well within uint32.
 			size += element.Size() + digestSize
 		}
 		e.size = size
@@ -352,6 +362,8 @@ func (e *hkeyElements) Set(
 	// insert into sorted elements
 	e.elems = slices.Insert(e.elems, lessThanIndex, element(newElem))
 
+	// This addition is safe from overflow because slab size is checked
+	// against maxThreshold and the slab is split if needed.
 	e.size += digestSize + newElem.Size()
 
 	return newElem.key, nil, nil
@@ -470,6 +482,10 @@ func (e *hkeyElements) Merge(elems elements) error {
 
 	e.hkeys = merge(e.hkeys, rElems.hkeys)
 	e.elems = merge(e.elems, rElems.elems)
+	// The subtraction is safe because rElems.Size() >= hkeyElementsPrefixSize,
+	// as Size() = hkeyElementsPrefixSize + size of elements.
+	// The addition is safe from overflow because merge is only called when
+	// both slabs are underflowing, so their combined size fits in uint32.
 	e.size += rElems.Size() - hkeyElementsPrefixSize
 
 	return nil

--- a/map_elements_nokey.go
+++ b/map_elements_nokey.go
@@ -35,6 +35,8 @@ type singleElements struct {
 var _ elements = &singleElements{}
 
 func newSingleElementsWithElement(level uint, elem *singleElement) *singleElements {
+	// This addition is safe from overflow because element size
+	// is bounded by max inline size limits and prefix is a small constant.
 	return &singleElements{
 		level: level,
 		size:  singleElementsPrefixSize + elem.size,
@@ -168,6 +170,8 @@ func (e *singleElements) Set(
 			}
 
 			elem.value = vs
+			// This addition is safe from overflow because key and value sizes
+			// are bounded by max inline size limits, well within uint32.
 			elem.size = singleElementPrefixSize + elem.key.ByteSize() + elem.value.ByteSize()
 
 			// Recompute slab size by adding all element sizes instead of using the size diff of old and new element because
@@ -175,6 +179,8 @@ func (e *singleElements) Set(
 			// Given this, size diff of the old and new element can be 0 even when its actual size changed.
 			size := uint32(singleElementsPrefixSize)
 			for _, element := range e.elems {
+				// This addition is safe from overflow because slab size is limited by
+				// maxThreshold (48KiB with maxSlabSize of 32KiB), well within uint32.
 				size += element.Size()
 			}
 			e.size = size
@@ -190,6 +196,8 @@ func (e *singleElements) Set(
 		return nil, nil, err
 	}
 	e.elems = append(e.elems, newElem)
+	// This addition is safe from overflow because slab size is checked
+	// against maxThreshold and the slab is split if needed.
 	e.size += newElem.size
 
 	return newElem.key, nil, nil

--- a/map_metadata_slab.go
+++ b/map_metadata_slab.go
@@ -350,7 +350,9 @@ func (m *MapMetaDataSlab) SplitChildSlab(storage SlabStorage, child MapSlab, chi
 		right.Header(),
 	)
 
-	// Increase header size
+	// Increase header size.
+	// This addition is safe from overflow because metadata slab size
+	// is checked against maxThreshold and is split if it exceeds the limit.
 	m.header.size += mapSlabHeaderSize
 
 	// Store modified slabs
@@ -609,8 +611,10 @@ func (m *MapMetaDataSlab) Merge(slab Slab) error {
 	rightSlab := slab.(*MapMetaDataSlab)
 
 	m.childrenHeaders = merge(m.childrenHeaders, rightSlab.childrenHeaders)
-	// This computation is safe because header.size >= mapMetaDataSlabPrefixSize,
+	// The subtraction is safe because header.size >= mapMetaDataSlabPrefixSize,
 	// as header.size = mapMetaDataSlabPrefixSize + len(childrenHeaders) * mapSlabHeaderSize.
+	// The addition is safe from overflow because merge is only called when
+	// both slabs are underflowing, so their combined size fits in uint32.
 	m.header.size += rightSlab.header.size - mapMetaDataSlabPrefixSize
 
 	return nil


### PR DESCRIPTION
This PR adds comments to help reduce future security bug reports (false positives).

______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels 
