### PR TITLE
Limit storable size in NewStorableSlab()

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -33,6 +33,10 @@ const (
 	maxSlabSize     = uint32(32 * 1024)
 
 	minElementCountInSlab = 2
+
+	// maxStorableSizeInStorableSlab is the maximum storable byte size
+	// that can fit into a StorableSlab.
+	maxStorableSizeInStorableSlab = math.MaxUint32 - versionAndFlagSize
 )
 
 var (
@@ -107,4 +111,10 @@ func maxInlineMapValueSize(keySize uint32) uint32 {
 
 func targetSlabSize() uint32 {
 	return targetThreshold
+}
+
+// MaxStorableSizeInStorableSlab() returns the maximum storable byte size
+// that can fit into a StorableSlab.
+func MaxStorableSizeInStorableSlab() uint32 {
+	return maxStorableSizeInStorableSlab
 }

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -33,6 +33,13 @@ type StorableSlab struct {
 var _ Slab = &StorableSlab{}
 
 func NewStorableSlab(storage SlabStorage, address Address, storable Storable) (Storable, error) {
+	if storable.ByteSize() > maxStorableSizeInStorableSlab {
+		return nil, NewUserError(fmt.Errorf(
+			"failed to create StorableSlab due to size limit: got %d bytes, max %d bytes",
+			storable.ByteSize(),
+			maxStorableSizeInStorableSlab))
+	}
+
 	id, err := storage.GenerateSlabID(address)
 	if err != nil {
 		// Wrap err as external error (if needed) because err is returned by SlabStorage interface.
@@ -108,6 +115,8 @@ func (s *StorableSlab) Encode(enc *Encoder) error {
 }
 
 func (s *StorableSlab) ByteSize() uint32 {
+	// Note: maxStorableSizeInStorableSlab needs to be updated
+	// when this function is updated.
 	return versionAndFlagSize + s.storable.ByteSize()
 }
 

--- a/storable_slab.go
+++ b/storable_slab.go
@@ -32,11 +32,16 @@ type StorableSlab struct {
 
 var _ Slab = &StorableSlab{}
 
-func NewStorableSlab(storage SlabStorage, address Address, storable Storable) (Storable, error) {
-	if storable.ByteSize() > maxStorableSizeInStorableSlab {
+func NewStorableSlab(
+	storage SlabStorage,
+	address Address,
+	storable Storable,
+	storableSize uint32,
+) (Storable, error) {
+	if storableSize > maxStorableSizeInStorableSlab {
 		return nil, NewUserError(fmt.Errorf(
 			"failed to create StorableSlab due to size limit: got %d bytes, max %d bytes",
-			storable.ByteSize(),
+			storableSize,
 			maxStorableSizeInStorableSlab))
 	}
 

--- a/storable_slab_test.go
+++ b/storable_slab_test.go
@@ -37,7 +37,7 @@ func TestNewStorableSlab(t *testing.T) {
 		v := testutils.NewStringValue(strings.Repeat("a", 1_000))
 
 		// Create StorableSlab for a large string value.
-		s, err := atree.NewStorableSlab(storage, address, v)
+		s, err := atree.NewStorableSlab(storage, address, v, v.ByteSize())
 		require.NoError(t, err)
 
 		slabIDStorable, ok := s.(atree.SlabIDStorable)

--- a/storable_slab_test.go
+++ b/storable_slab_test.go
@@ -1,0 +1,56 @@
+/*
+ * Atree - Scalable Arrays and Ordered Maps
+ *
+ * Copyright Flow Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package atree_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onflow/atree"
+	testutils "github.com/onflow/atree/test_utils"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStorableSlab(t *testing.T) {
+	address := atree.Address{1, 2, 3, 4, 5, 6, 7, 8}
+
+	t.Run("large string", func(t *testing.T) {
+		storage := newTestPersistentStorage(t)
+
+		v := testutils.NewStringValue(strings.Repeat("a", 1_000))
+
+		// Create StorableSlab for a large string value.
+		s, err := atree.NewStorableSlab(storage, address, v)
+		require.NoError(t, err)
+
+		slabIDStorable, ok := s.(atree.SlabIDStorable)
+		require.True(t, ok)
+
+		// Retrieve StorableSlab from storage.
+		slab, found, err := storage.Retrieve(atree.SlabID(slabIDStorable))
+		require.NoError(t, err)
+		require.True(t, found)
+
+		// Retrieve large string value from StorableSlab
+		v2, err := slab.(*atree.StorableSlab).StoredValue(storage)
+		require.NoError(t, err)
+		require.Equal(t, v, v2)
+	})
+}

--- a/test_utils/value_utils.go
+++ b/test_utils/value_utils.go
@@ -424,8 +424,9 @@ func (v StringValue) ID() string {
 }
 
 func (v StringValue) Storable(storage atree.SlabStorage, address atree.Address, maxInlineSize uint32) (atree.Storable, error) {
-	if v.ByteSize() > maxInlineSize {
-		return atree.NewStorableSlab(storage, address, v)
+	size := v.ByteSize()
+	if size > maxInlineSize {
+		return atree.NewStorableSlab(storage, address, v, size)
 	}
 
 	return v, nil


### PR DESCRIPTION
I found an issue that can affect metering, but running into this on mainnet would require extremely large data we haven't encountered yet.

Currently, we don’t have guards in both Atree and Cadence to prevent MaxUInt32 overflow when a single Cadence value stored in StorableSlab exceeds ~4.2 GB.

This PR enforces a limit that is far above what we are likely to encounter in practice due to other limits and fees already being enforced.

For perspective, the largest StorableSlab on mainnet is ~7.3 MB and the ~4.2 GB limit this PR enforces is far above that.

Also, StorableSlab is not used to store arrays and maps. Arrays and maps can use separate slabs to store each element.

### Severity

If this overflow ever happens (by a StorableSlab exceeding ~4.2 GB), it can cause metering to undercharge for encoded data during commit.  But the account will still be charged correctly for storage used.
______

<!-- Complete: -->

- [ ] Targeted PR against `main` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/atree/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
